### PR TITLE
Add github.com/codegangsta/cli to bootstrapped packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ bootstrap:
 	mkdir ./_vendor
 	GOPATH=${PWD}/_vendor go get github.com/Masterminds/cookoo
 	GOPATH=${PWD}/_vendor go get github.com/kylelemons/go-gypsy/yaml
+	GOPATH=${PWD}/_vendor go get github.com/codegangsta/cli
 	ln -s ${PWD} _vendor/src/github.com/Masterminds/glide
 	GOPATH=${PWD}/_vendor go build -o glide -ldflags "-X main.version ${VERSION}" glide.go
 


### PR DESCRIPTION
This is missing in `Makefile` vs. `glide.yaml`.
