### PR TITLE
Tweaks logging colors to be less surprising

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -101,13 +101,13 @@ func (g *GitVCS) Version(dep *Dependency) error {
 			switch len(count) {
 			// 0-9, not that bad
 			case 1:
-				c = Yellow
+				c = Green
 			// 10-99, we're getting behind
 			case 2:
-				c = Red
+				c = Yellow
 			// Whoa! We're falling way behind!
 			default:
-				c = BoldRed
+				c = Red
 			}
 			Info(Color(c, fmt.Sprintf("Git: %s is %s behind origin.\n", dep.Name, count)))
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -13,12 +13,12 @@ var Quiet = false
 // These contanstants map to color codes for shell scripts making them
 // human readable.
 const (
-	Blue    = "0;34"
-	Red     = "0;31"
-	BoldRed = "1;31"
-	Yellow  = "0;33"
-	Cyan    = "0;36"
-	Pink    = "1;35"
+	Blue   = "0;34"
+	Red    = "0;31"
+	Green  = "0;32"
+	Yellow = "0;33"
+	Cyan   = "0;36"
+	Pink   = "1;35"
 )
 
 // Color returns a string in a certain color. The first argument is a string
@@ -41,7 +41,7 @@ func Info(msg string, args ...interface{}) {
 	if Quiet {
 		return
 	}
-	fmt.Print(Color(Yellow, "[INFO] "))
+	fmt.Print(Color(Green, "[INFO] "))
 	Msg(msg, args...)
 }
 
@@ -56,13 +56,13 @@ func Debug(msg string, args ...interface{}) {
 
 // Warn logs a warning
 func Warn(msg string, args ...interface{}) {
-	fmt.Fprint(os.Stderr, Color(Red, "[WARN] "))
+	fmt.Fprint(os.Stderr, Color(Yellow, "[WARN] "))
 	ErrMsg(msg, args...)
 }
 
 // Error logs and error.
 func Error(msg string, args ...interface{}) {
-	fmt.Fprint(os.Stderr, Color(BoldRed, "[ERROR] "))
+	fmt.Fprint(os.Stderr, Color(Red, "[ERROR] "))
 	ErrMsg(msg, args...)
 }
 


### PR DESCRIPTION
Tweaks the log message colors to be more consistent with the expected
green=good, yellow=warning, red=bad standard.  Also updates the git
'behind' logging to show green/yellow/red for how far behind the repo
is.
