### PR TITLE
Fail early when unable to update or build dependencies.

### DIFF
--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -45,7 +45,7 @@ func UpdateImports(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Inte
 
 	for _, dep := range cfg.Imports {
 		if err := VcsUpdate(dep); err != nil {
-			Warn("Update failed for %s: %s\n", dep.Name, err)
+			Error("Update failed for %s: %s\n", dep.Name, err)
 		}
 	}
 
@@ -81,7 +81,7 @@ func SetReference(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Inter
 
 	for _, dep := range cfg.Imports {
 		if err := VcsVersion(dep); err != nil {
-			Warn("Failed to set version on %s to %s: %s\n", dep.Name, dep.Reference, err)
+			Error("Failed to set version on %s to %s: %s\n", dep.Name, dep.Reference, err)
 		}
 	}
 

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -27,7 +27,7 @@ func Rebuild(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt)
 
 	for _, dep := range cfg.Imports {
 		if err := buildDep(c, dep, gopath); err != nil {
-			Warn("Failed to build %s: %s\n", dep.Name, err)
+			Error("Failed to build %s: %s\n", dep.Name, err)
 		}
 	}
 
@@ -46,7 +46,7 @@ func buildDep(c cookoo.Context, dep *Dependency, gopath string) error {
 		} else {
 			paths, err := resolvePackages(gopath, dep.Name, pkg)
 			if err != nil {
-				Warn("Error resolving packages: %s", err)
+				Error("Error resolving packages: %s", err)
 			}
 			//buildPath(c, path.Join(dep.Name, pkg))
 			buildPaths(c, paths)
@@ -80,7 +80,7 @@ func buildPath(c cookoo.Context, path string) error {
 	Info("Running go build %s\n", path)
 	out, err := exec.Command("go", "install", path).CombinedOutput()
 	if err != nil {
-		Warn("Failed to run 'go install' for %s: %s", path, string(out))
+		Error("Failed to run 'go install' for %s: %s", path, string(out))
 	}
 	return err
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -64,6 +64,7 @@ func Warn(msg string, args ...interface{}) {
 func Error(msg string, args ...interface{}) {
 	fmt.Fprint(os.Stderr, Color(Red, "[ERROR] "))
 	ErrMsg(msg, args...)
+	os.Exit(1)
 }
 
 // ErrMsg sends a message to Stderr


### PR DESCRIPTION
This patch implements a "fail early" strategy in some crucial places.

Please see issue #40 for more information.