### PR TITLE
Fix 'glide update' for new dependencies, if no repo configured for git/hg.

### DIFF
--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -205,6 +205,10 @@ func VcsUpdate(dep *Dependency) error {
 		return goGet.Update(dep)
 	}
 
+	if dep.Repository == "" && (dep.VcsType == Git || dep.VcsType == Hg) {
+		dep.Repository = "https://" + dep.Name
+	}
+
 	if dep.VcsType == NoVCS {
 		guess, err := GuessVCS(dep)
 		if err != nil {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -26,7 +26,7 @@ func (g *GitVCS) Update(dep *Dependency) error {
 	if _, err := os.Stat(dest); err != nil {
 		// Assume a new package?
 		Info("Looks like %s is a new package. Cloning.\n", dep.Name)
-		return exec.Command("git", "clone", dep.Repository, dest).Run()
+		return g.Get(dep)
 	}
 
 	oldDir, err := os.Getwd()


### PR DESCRIPTION
For simple dependency configurations like:

```
  - package: github.com/spf13/viper
    vcs: git
    ref: 90734830d1ec30c19cb03e3ecd76a43dc1618b01
```

(package/vcs specified, but no repo) `glide update` did not work as expected. This patch brings the update feature up on par with `glide install` for these cases.

Please also see issue #40.