### PR TITLE
Add support for changed VCS type or repository for Git. Issue #30.

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -69,6 +69,7 @@ func (g *GitVCS) Update(dep *Dependency) error {
 		default:
 			Info("Unable to determine currently checkout out repository ('%s'). I'm doing a fresh clone.\n", err)
 		}
+		os.Chdir(oldDir)
 		if err := os.RemoveAll(dest); err != nil {
 			return err
 		}


### PR DESCRIPTION
This patch adds the much-needed functionality of checking the repository type and remote of the current checkout of a git dependency against the configuration.

If the remote `origin` does not match whatever is configured as repo, a fresh clone is initiated after wiping the dependencies source directory.

As discussed in #30, this allows switching to a fork, or different remote location for any git dependency, by merely changing `glide.yaml` (and running `glide update` for example as part of the CI process).