### PR TITLE
Add flatten open to imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,10 @@ Darwin/OSX systems:
 
 The package will not be fetched for other architectures or OSes.
 
+**Q: How do I prevent vendored packages from importing the same package**
+
+You can use the `flatten: true` config option on the entire project or just one specific dependency.
+
 ## LICENSE
 
 This package is made available under an MIT-style license. See

--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -193,7 +193,7 @@ func VcsExists(dep *Dependency, dest string) bool {
 	if err != nil {
 		return false
 	}
-	Info("Repo not found %s, checking local\n", dep.Name)
+
 	return repo.CheckLocal()
 }
 
@@ -239,7 +239,6 @@ func VcsUpdate(dep *Dependency, vend string, force bool) error {
 		if empty == false && err == v.ErrCannotDetectVCS {
 			Warn("%s appears to be a vendored package. Unable to update. Consider the '--update-vendored' flag.\n", dep.Name)
 		} else {
-			Info("About to GetRepo %s\n", dest)
 			repo, err := dep.GetRepo(dest)
 
 			// Tried to checkout a repo to a path that does not work. Either the

--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -193,7 +193,7 @@ func VcsExists(dep *Dependency, dest string) bool {
 	if err != nil {
 		return false
 	}
-
+	Info("Repo not found %s, checking local\n", dep.Name)
 	return repo.CheckLocal()
 }
 
@@ -239,7 +239,7 @@ func VcsUpdate(dep *Dependency, vend string, force bool) error {
 		if empty == false && err == v.ErrCannotDetectVCS {
 			Warn("%s appears to be a vendored package. Unable to update. Consider the '--update-vendored' flag.\n", dep.Name)
 		} else {
-
+			Info("About to GetRepo %s\n", dest)
 			repo, err := dep.GetRepo(dest)
 
 			// Tried to checkout a repo to a path that does not work. Either the

--- a/cmd/recursive_glide.go
+++ b/cmd/recursive_glide.go
@@ -96,17 +96,18 @@ func dependencyGlideUp(parentConf *Config, base string, godep, gpm, force, delet
 		wd := path.Join(vdir, imp.Name)
 		// if our root glide.yaml says to flatten this, we skip it
 		if dep := conf.GetRoot().Imports.Get(imp.Name); dep != nil {
-			if dep.Flatten == true {
+			flatten := conf.GetRoot().Flatten
+			if flatten == true && dep.Flatten == false ||
+				flatten == false && dep.Flatten == true {
+				flatten = dep.Flatten
+			}
+			if flatten == true {
 				Info("Skipping importing %s due to flatten being set in root import glide.yaml\n", imp.Name)
-				imp.Flattened = true
-
-			} else if conf.GetRoot().Flatten == true {
-				Info("Skipping importing %s due to flatten being set in root config glide.yaml\n", imp.Name)
 				imp.Flattened = true
 			}
 
-			if imp.Reference != dep.Reference {
-				Warn("Main vendored package %s ref (%s) is diferent from sub vendored package ref (%s)\n", imp.Name, imp.Reference, dep.Reference)
+			if flatten == true && imp.Reference != dep.Reference {
+				Warn("Flattened package %s ref (%s) is diferent from sub vendored package ref (%s)\n", imp.Name, imp.Reference, dep.Reference)
 			}
 
 			if imp.Flattened == true && deleteFlatten == true {

--- a/cmd/recursive_glide.go
+++ b/cmd/recursive_glide.go
@@ -105,6 +105,10 @@ func dependencyGlideUp(parentConf *Config, base string, godep, gpm, force, delet
 				imp.Flattened = true
 			}
 
+			if imp.Reference != dep.Reference {
+				Warn("Main vendored package %s ref (%s) is diferent from sub vendored package ref (%s)\n", imp.Name, imp.Reference, dep.Reference)
+			}
+
 			if imp.Flattened == true && deleteFlatten == true {
 				if exists, _ := fileExist(wd); exists == true || true {
 					remove := wd + string(os.PathSeparator)

--- a/cmd/recursive_glide.go
+++ b/cmd/recursive_glide.go
@@ -32,7 +32,7 @@ func Recurse(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt)
 
 	Info("Checking dependencies for updates. Godeps: %v, GPM: %v\n", godeps, gpm)
 	if deleteFlatten == true {
-		Info("Deleting flattened dependencies enabled")
+		Info("Deleting flattened dependencies enabled\n")
 	}
 	conf := p.Get("conf", &Config{}).(*Config)
 	vend, _ := VendorPath(c)

--- a/cmd/recursive_glide.go
+++ b/cmd/recursive_glide.go
@@ -40,12 +40,13 @@ func recDepResolve(conf *Config, vend string, godeps, gpm, force bool) (interfac
 	if len(conf.Imports) == 0 {
 		Info("No imports.\n")
 	}
+	Info("Config: %+v\n", conf.Imports[0].Name)
 
 	// Look in each package to see whether it has a glide.yaml, and no vendor/
 	for _, imp := range conf.Imports {
 		base := path.Join(vend, imp.Name)
 		Info("Looking in %s for a glide.yaml file.\n", base)
-
+		Info("\tFlatten: %b", imp.Flatten)
 		if !needsGlideUp(base) {
 			if godeps {
 				importGodep(base, imp.Name)
@@ -58,7 +59,7 @@ func recDepResolve(conf *Config, vend string, godeps, gpm, force bool) (interfac
 				continue
 			}
 		}
-		if err := dependencyGlideUp(base, godeps, gpm, force); err != nil {
+		if err := dependencyGlideUp(base, godeps, gpm, force, imp.Flatten); err != nil {
 			Warn("Failed to update dependency %s: %s", imp.Name, err)
 		}
 	}
@@ -67,7 +68,7 @@ func recDepResolve(conf *Config, vend string, godeps, gpm, force bool) (interfac
 	return nil, nil
 }
 
-func dependencyGlideUp(base string, godep, gpm, force bool) error {
+func dependencyGlideUp(base string, godep, gpm, force bool, flatten bool) error {
 	//conf := new(Config)
 	fname := path.Join(base, "glide.yaml")
 	f, err := yaml.ReadFile(fname)

--- a/cmd/recursive_glide.go
+++ b/cmd/recursive_glide.go
@@ -96,14 +96,13 @@ func dependencyGlideUp(parentConf *Config, base string, godep, gpm, force bool) 
 		// We don't use the global var to find vendor dir name because the
 		// user may mis-use that var to modify the local vendor dir, and
 		// we don't want that to break the embedded vendor dirs.
-		Info("Found something to import: %s\n", imp.Name)
 		wd := path.Join(base, "vendor", imp.Name)
 		vdir := path.Join(base, "vendor")
 		if err := ensureDir(wd); err != nil {
 			Warn("Skipped getting %s (vendor/ error): %s\n", imp.Name, err)
 			continue
 		}
-		Info("\n\nBefore Vcs Exists\n\n")
+
 		if VcsExists(imp, wd) {
 			Info("Updating project %s (%s)\n", imp.Name, wd)
 			if err := VcsUpdate(imp, vdir, force); err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -100,7 +100,7 @@ func isDirectoryEmpty(dir string) (bool, error) {
 	return false, err
 }
 
-// Get GOPATH from environment and return the most relevant path.
+// GoPath Get GOPATH from environment and return the most relevant path.
 //
 // A GOPATH can contain a colon-separated list of paths. This retrieves the
 // GOPATH and returns only the FIRST ("most relevant") path.
@@ -119,4 +119,15 @@ func Gopaths() []string {
 		ps[0] = "."
 	}
 	return ps
+}
+
+func fileExist(name string) (bool, error) {
+	_, err := os.Stat(name)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
 }

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -180,6 +180,21 @@ func valOrEmpty(key string, store map[string]yaml.Node) string {
 	return strings.TrimSpace(val.(yaml.Scalar).String())
 }
 
+func boolOrDefault(key string, store map[string]yaml.Node, dft bool) bool {
+	val, ok := store[key]
+	if !ok {
+		return dft
+	}
+	switch val.(yaml.Scalar).String() {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		return false
+	}
+}
+
 // valOrList gets a single value or a list of values.
 //
 // Supports syntaxes like:
@@ -258,6 +273,7 @@ func NormalizeName(name string) (string, string) {
 
 // Config is the top-level configuration object.
 type Config struct {
+	Parent     *Config
 	Name       string
 	Imports    []*Dependency
 	DevImports []*Dependency
@@ -372,6 +388,7 @@ type Dependency struct {
 	VcsType                     string
 	Subpackages, Arch, Os       []string
 	UpdateAsVendored            bool
+	Flatten                     bool
 }
 
 // DependencyFromYaml creates a dependency from a yaml.Node.
@@ -388,6 +405,7 @@ func DependencyFromYaml(node yaml.Node) (*Dependency, error) {
 		Subpackages: valOrList("subpackages", pkg),
 		Arch:        valOrList("arch", pkg),
 		Os:          valOrList("os", pkg),
+		Flatten:     boolOrDefault("flatten", pkg, false),
 	}
 
 	return dep, nil

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -281,6 +281,7 @@ type Config struct {
 	// InCommand is the default shell command run to start a 'glide in'
 	// session.
 	InCommand string
+	Flatten   bool
 }
 
 // HasDependency returns true if the given name is listed as an import or dev import.
@@ -336,6 +337,9 @@ func FromYaml(top yaml.Node) (*Config, error) {
 	if incmd, ok := vals["incmd"]; ok {
 		conf.InCommand = incmd.(yaml.Scalar).String()
 	}
+
+	// Package level Flatten
+	conf.Flatten = boolOrDefault("flatten", vals, false)
 
 	conf.Imports = make(Dependencies, 0, 1)
 	if imp, ok := vals["import"]; ok {
@@ -518,7 +522,6 @@ type Dependencies []*Dependency
 // Get a dependency by name
 func (d Dependencies) Get(name string) *Dependency {
 	for _, dep := range d {
-		Info("Get Dep %s vs %s\n", name, dep.Name)
 		if dep.Name == name {
 			return dep
 		}

--- a/cmd/yaml_test.go
+++ b/cmd/yaml_test.go
@@ -24,6 +24,7 @@ import:
     arch:
       - i386
       - arm
+    flatten: true
 
 devimport:
   - package: github.com/kylelemons/go-gypsy
@@ -46,6 +47,10 @@ func TestFromYaml(t *testing.T) {
 
 	if len(cfg.Imports) != 3 {
 		t.Errorf("Expected 3 imports, got %d", len(cfg.Imports))
+	}
+
+	if cfg.Parent != nil {
+		t.Errorf("Expected root glide Parent to be nil")
 	}
 
 	imp := cfg.Imports[2]
@@ -80,6 +85,10 @@ func TestFromYaml(t *testing.T) {
 	}
 	if imp.Reference != "a9949121a2e2192ca92fa6dddfeaaa4a4412d955" {
 		t.Errorf("Got wrong reference.")
+	}
+
+	if imp.Flatten != true {
+		t.Errorf("Expected Flatten: true")
 	}
 
 	if len(cfg.DevImports) != 1 {

--- a/docs/example-glide.yaml
+++ b/docs/example-glide.yaml
@@ -5,6 +5,11 @@ package: github.com/Masterminds/glide
 # will just spawn a new shell.
 incmd: bash -l
 
+# Any listed import will only be imported once. Effectively preventing vendored
+# packages from importing the same pkg via a glide.yaml file.
+# Defaults to false
+flatten: true
+
 # External dependencies.
 import:
   # Minimal definition
@@ -86,3 +91,8 @@ import:
       - darwin
     arch:
       - amd64
+
+  # If you would like to only include the package once and prevent vendored
+  # packages from including the same package.
+  - package: github.com/awesome/only_once
+    flatten: true

--- a/glide.go
+++ b/glide.go
@@ -61,11 +61,13 @@ look something like this:
 		  subpackages: **
 		- package: github.com/kylelemons/go-gypsy
 		  subpackages: yaml
+			flatten: true
 
 NOTE: As of Glide 0.5, the commands 'in', 'into', 'gopath', 'status', and 'env'
 no longer exist.
 `
 
+// VendorDir default vendor directory name
 var VendorDir = "vendor"
 
 func main() {
@@ -268,10 +270,13 @@ Example:
 	from the Godeps data, and then update. This has no effect if '--no-recursive'
 	is set.
 
-	if the '--update-vendored' flag (aliased to '-u') is present vendored
+	If the '--update-vendored' flag (aliased to '-u') is present vendored
 	dependecies, stored in your projects VCS repository, will be updated. This
 	works by removing the old package, checking out an the repo and setting the
 	version, and removing the VCS directory.
+
+	If the '--delete-flatten' flag is present, Glide will remove any depenedencies
+	markred flatten within dependencies.
 	`,
 			Flags: []cli.Flag{
 				cli.BoolFlag{
@@ -294,11 +299,16 @@ Example:
 					Name:  "update-vendored, u",
 					Usage: "Update vendored packages (without local VCS repo). Warning, changes will be lost.",
 				},
+				cli.BoolFlag{
+					Name:  "delete-flatten",
+					Usage: "Delete flattened vendor packages.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				cxt.Put("deleteOptIn", c.Bool("delete"))
 				cxt.Put("forceUpdate", c.Bool("force"))
 				cxt.Put("recursiveDependencies", !c.Bool("no-recursive"))
+				cxt.Put("deleteFlatten", c.Bool("delete-flatten"))
 				if c.Bool("import") {
 					cxt.Put("importGodeps", true)
 					cxt.Put("importGPM", true)
@@ -399,6 +409,7 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Using("force").From("cxt:forceUpdate").
 		Does(cmd.SetReference, "version").Using("conf").From("cxt:cfg").
 		Does(cmd.Recurse, "recurse").Using("conf").From("cxt:cfg").
+		Using("deleteFlatten").From("cxt:deleteFlatten").
 		Using("importGodeps").From("cxt:importGodeps").
 		Using("importGPM").From("cxt:importGPM").
 		Using("enable").From("cxt:recursiveDependencies").

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ import:
   - package: github.com/kylelemons/go-gypsy
     subpackages:
       - yaml
+    flatten: true
   - package: github.com/Masterminds/cookoo
     ref:     master
     repo:    git@github.com:Masterminds/cookoo.git
@@ -11,3 +12,4 @@ import:
       - .
   - package: github.com/Masterminds/vcs
   - package: github.com/codegangsta/cli
+  - package: github.com/interlock/glide_test

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,4 +12,3 @@ import:
       - .
   - package: github.com/Masterminds/vcs
   - package: github.com/codegangsta/cli
-  - package: github.com/interlock/glide_test


### PR DESCRIPTION
This is a prototype of #55 

It adds a `flatten` option that takes `true` or `false` as an option.

When set to `true`, any sub package vendored in with the same name will be skipped.
When set to `false`, business as usual.

A few other changes of note:
- []*Dependency was made into a type Dependencies so I could put common `Get` by name functionality on it. There may be code elsewhere that can use this.
* Added `boolOrDefault` to work with the yaml and having a default bool set
* Added the concept of a Config.Parent and some funs related to it traversing up the tree.
* Enhanced some of the yaml tests for new and existing functionality.