### PR TITLE
More robust GOPATH retrieval

### DIFF
--- a/cmd/link_package.go
+++ b/cmd/link_package.go
@@ -21,7 +21,7 @@ func LinkPackage(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interr
 	here := "../.." + strings.Repeat("/..", depth)
 
 	gopath := Gopath()
-	if len(gopath) == 0 {
+	if gopath == "" {
 		return nil, fmt.Errorf("$GOPATH appears to be unset")
 	}
 	if len(pname) == 0 {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -115,11 +115,10 @@ func Gopath() string {
 // listed in the Gopath.
 func Gopaths() []string {
 	p := os.Getenv("GOPATH")
+	p = strings.Trim(p, string(filepath.ListSeparator))
 	ps := filepath.SplitList(p)
-
-	// XXX: Is this right? What is an empty path supposed to mean?
-	if ps[0] == "" {
-		ps[0] = "."
+	if len(ps) == 0 {
+		return []string{"."}
 	}
 	return ps
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -65,15 +65,12 @@ directory or move the _vendor/src/ directory to vendor/.` + "\n")
 // CowardMode checks that the environment is setup before continuing on. If not
 // setup and error is returned.
 func CowardMode(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
-	gopath := Gopaths()
-	if len(gopath) == 0 {
+	gopath := Gopath()
+	if gopath == "" {
 		return false, fmt.Errorf("No GOPATH is set.\n")
 	}
-	if len(gopath[0]) == 0 {
-		return false, fmt.Errorf("GOPATH cannot be empty.\n")
-	}
 
-	_, err := os.Stat(path.Join(gopath[0], "src"))
+	_, err := os.Stat(path.Join(gopath, "src"))
 	if err != nil {
 		Error("Could not find %s/src.\n", gopath)
 		Info("As of Glide 0.5/Go 1.5, this is required.\n")
@@ -108,7 +105,11 @@ func isDirectoryEmpty(dir string) (bool, error) {
 // This should be used carefully. If, for example, you are looking for a package,
 // you may be better off using Gopaths.
 func Gopath() string {
-	return Gopaths()[0]
+	gopaths := Gopaths()
+	if len(gopaths) == 0 {
+		return ""
+	}
+	return gopaths[0]
 }
 
 // Gopaths retrieves the Gopath as a list when there is more than one path
@@ -116,11 +117,7 @@ func Gopath() string {
 func Gopaths() []string {
 	p := os.Getenv("GOPATH")
 	p = strings.Trim(p, string(filepath.ListSeparator))
-	ps := filepath.SplitList(p)
-	if len(ps) == 0 {
-		return []string{"."}
-	}
-	return ps
+	return filepath.SplitList(p)
 }
 
 // BuildCtxt is a convenience wrapper for not having to import go/build


### PR DESCRIPTION
This patch keeps glide from breaking if GOPATH is not set.

**EDIT**: With the second commit I essentially made both functions `Gopath()` and `Gopaths()` behave in a more predictable way.