### PR TITLE
Fix `import godep` subcommand reference

### DIFF
--- a/glide.go
+++ b/glide.go
@@ -181,7 +181,7 @@ func commands(cxt cookoo.Context, router *cookoo.Router) []cli.Command {
 			Usage: "Import files from other dependency management systems.",
 			Subcommands: []cli.Command{
 				{
-					Name:  "godeps",
+					Name:  "godep",
 					Usage: "Import Godep's Godeps.json files and display the would-be yaml file",
 					Action: func(c *cli.Context) {
 						setupHandler(c, "import godep", cxt, router)


### PR DESCRIPTION
The README lists the command as `import godep`, but that was resulting
in:

	Oops! Command glide-godep does not exist.

I think this is the right solution, but don't quite grok the cookoo
rabbit hole yet, so might be off base - there are a lot of godep/godeps
references around. This makes it work as promised at least :-).