### PR TITLE
Feature/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ distributed with the package.
     - hg
     - svn
 * Support custom local and global plugins (see docs/plugins.md)
+* Repository caching including reuse of packages in the `$GOPATH`
 
 ## How It Works
 

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/cookoo"
+)
+
+// EnsureCacheDir Creates the $HOME/.glide/cache directory (unless home is
+// specified to be different) if it does not exist.
+func EnsureCacheDir(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	home := p.Get("home", "").(string)
+	if home == "" {
+		return nil, errors.New("No home directory set to create")
+	}
+
+	return os.MkdirAll(filepath.Join(home, "cache"), os.ModeDir|os.ModePerm), nil
+}
+
+// Pass in a repo location and get a cache key from it.
+func cacheCreateKey(repo string) (string, error) {
+
+	// A url needs a scheme. A git repo such as
+	// git@github.com:Masterminds/cookoo.git reworked to the url parser.
+	c := strings.Contains(repo, "://")
+	if !c {
+		repo = "ssh://" + repo
+	}
+
+	u, err := url.Parse(repo)
+	if err != nil {
+		return "", err
+	}
+
+	if !c {
+		u.Scheme = ""
+	}
+
+	var key string
+	if u.Scheme != "" {
+		key = u.Scheme + "-"
+	}
+	if u.User != nil && u.User.Username() != "" {
+		key = key + u.User.Username() + "-"
+	}
+	key = key + u.Host
+	if u.Path != "" {
+		key = key + strings.Replace(u.Path, "/", "-", -1)
+	}
+
+	key = strings.Replace(key, ":", "-", -1)
+
+	return key, nil
+}

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "testing"
+
+func TestCacheCreateKey(t *testing.T) {
+	tests := map[string]string{
+		"https://github.com/foo/bar": "https-github.com-foo-bar",
+		"git@github.com:foo/bar":     "git-github.com-foo-bar",
+	}
+
+	for k, v := range tests {
+		key, err := cacheCreateKey(k)
+		if err != nil {
+			t.Errorf("Cache key generation err: %s", err)
+			continue
+		}
+		if key != v {
+			t.Errorf("Expected cache key %s for %s but got %s", v, k, key)
+		}
+	}
+}

--- a/cmd/flatten.go
+++ b/cmd/flatten.go
@@ -27,6 +27,8 @@ import (
 func Flatten(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
 	conf := p.Get("conf", &yaml.Config{}).(*yaml.Config)
 	skip := p.Get("skip", false).(bool)
+	home := p.Get("home", "").(string)
+
 	if skip {
 		return conf, nil
 	}
@@ -50,7 +52,7 @@ func Flatten(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt)
 
 	f := &flattening{conf, vend, vend, deps, packages}
 
-	err := recFlatten(f, force)
+	err := recFlatten(f, force, home)
 	flattenSetRefs(f)
 	Info("Project relies on %d dependencies.", len(deps))
 	exportFlattenedDeps(conf, deps)
@@ -84,7 +86,7 @@ type flattening struct {
 var updateCache = map[string]bool{}
 
 // refFlatten recursively flattens the vendor tree.
-func recFlatten(f *flattening, force bool) error {
+func recFlatten(f *flattening, force bool, home string) error {
 	Debug("---> Inspecting %s for changes (%d packages).\n", f.curr, len(f.scan))
 	for _, imp := range f.scan {
 		Debug("----> Scanning %s", imp)
@@ -104,14 +106,14 @@ func recFlatten(f *flattening, force bool) error {
 
 		if len(mod) > 0 {
 			Debug("----> Updating all dependencies for %q (%d)", imp, len(mod))
-			flattenGlideUp(f, base, force)
+			flattenGlideUp(f, base, home, force)
 			f2 := &flattening{
 				conf: f.conf,
 				top:  f.top,
 				curr: base,
 				deps: f.deps,
 				scan: mod}
-			recFlatten(f2, force)
+			recFlatten(f2, force, home)
 		}
 	}
 
@@ -123,7 +125,7 @@ func recFlatten(f *flattening, force bool) error {
 // While this is expensive, it is also necessary to make sure we have the
 // correct version of all dependencies. We might be able to simplify by
 // marking packages dirty when they are added.
-func flattenGlideUp(f *flattening, base string, force bool) error {
+func flattenGlideUp(f *flattening, base, home string, force bool) error {
 	//vdir := path.Join(base, "vendor")
 	for _, imp := range f.deps {
 		wd := path.Join(f.top, imp.Name)
@@ -133,7 +135,7 @@ func flattenGlideUp(f *flattening, base string, force bool) error {
 				continue
 			}
 			Debug("Updating project %s (%s)\n", imp.Name, wd)
-			if err := VcsUpdate(imp, f.top, force); err != nil {
+			if err := VcsUpdate(imp, f.top, home, force); err != nil {
 				// We can still go on just fine even if this fails.
 				Warn("Skipped update %s: %s\n", imp.Name, err)
 				continue
@@ -141,7 +143,7 @@ func flattenGlideUp(f *flattening, base string, force bool) error {
 			updateCache[imp.Name] = true
 		} else {
 			Debug("Importing %s to project %s\n", imp.Name, wd)
-			if err := VcsGet(imp, wd); err != nil {
+			if err := VcsGet(imp, wd, home); err != nil {
 				Warn("Skipped getting %s: %v\n", imp.Name, err)
 				continue
 			}

--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -99,29 +99,6 @@ func GetAll(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) 
 	return deps, nil
 }
 
-// GetImports iterates over the imported packages and gets them.
-func GetImports(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
-	cfg := p.Get("conf", nil).(*yaml.Config)
-	cwd, err := VendorPath(c)
-	if err != nil {
-		Error("Failed to prepare vendor directory: %s", err)
-		return false, err
-	}
-
-	if len(cfg.Imports) == 0 {
-		Info("No dependencies found. Nothing downloaded.\n")
-		return false, nil
-	}
-
-	for _, dep := range cfg.Imports {
-		if err := VcsGet(dep, cwd); err != nil {
-			Warn("Skipped getting %s: %v\n", dep.Name, err)
-		}
-	}
-
-	return true, nil
-}
-
 // UpdateImports iterates over the imported packages and updates them.
 //
 // Params:

--- a/cmd/get_imports.go
+++ b/cmd/get_imports.go
@@ -216,7 +216,7 @@ func VcsGet(dep *yaml.Dependency, dest, home string) error {
 	for _, p := range gps {
 		d := filepath.Join(p, "src", dep.Name)
 		if _, err := os.Stat(d); err == nil {
-			empty, err := isDirectoryEmpty(dest)
+			empty, err := isDirectoryEmpty(d)
 			if empty || err != nil {
 				continue
 			}

--- a/cmd/get_imports_test.go
+++ b/cmd/get_imports_test.go
@@ -1,26 +1,6 @@
 package cmd
 
-import (
-	"testing"
-
-	"github.com/Masterminds/cookoo"
-	"github.com/Masterminds/glide/yaml"
-)
-
-func TestGetImportsEmptyConfig(t *testing.T) {
-	_, _, c := cookoo.Cookoo()
-	SilenceLogs(c)
-	cfg := new(yaml.Config)
-	p := cookoo.NewParamsWithValues(map[string]interface{}{"conf": cfg})
-	res, it := GetImports(c, p)
-	if it != nil {
-		t.Errorf("Interrupt value non-nil")
-	}
-	bres, ok := res.(bool)
-	if !ok || bres {
-		t.Errorf("Result was non-bool or true: ok=%t bres=%t", ok, bres)
-	}
-}
+import "github.com/Masterminds/cookoo"
 
 func SilenceLogs(c cookoo.Context) {
 	p := cookoo.NewParamsWithValues(map[string]interface{}{"quiet": true})

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -154,3 +154,74 @@ func fileExist(name string) (bool, error) {
 	}
 	return true, err
 }
+
+// We copy the directory here rather than jumping out to a shell so we can
+// support multiple operating systems.
+func copyDir(source string, dest string) error {
+
+	// get properties of source dir
+	si, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(dest, si.Mode())
+	if err != nil {
+		return err
+	}
+
+	d, _ := os.Open(source)
+
+	objects, err := d.Readdir(-1)
+
+	for _, obj := range objects {
+
+		sp := filepath.Join(source, "/", obj.Name())
+
+		dp := filepath.Join(dest, "/", obj.Name())
+
+		if obj.IsDir() {
+			err = copyDir(sp, dp)
+			if err != nil {
+				return err
+			}
+		} else {
+			// perform copy
+			err = copyFile(sp, dp)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func copyFile(source string, dest string) error {
+	s, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+
+	defer s.Close()
+
+	d, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	defer d.Close()
+
+	_, err = io.Copy(d, s)
+	if err != nil {
+		return err
+	}
+
+	si, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(dest, si.Mode())
+
+	return err
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -198,6 +198,10 @@ func copyDir(source string, dest string) error {
 }
 
 func copyFile(source string, dest string) error {
+	ln, err := os.Readlink(source)
+	if err == nil {
+		return os.Symlink(ln, dest)
+	}
 	s, err := os.Open(source)
 	if err != nil {
 		return err

--- a/glide.go
+++ b/glide.go
@@ -177,6 +177,10 @@ func commands(cxt cookoo.Context, router *cookoo.Router) []cli.Command {
 					Name:  "insecure",
 					Usage: "Use http:// rather than https:// to retrieve pacakges.",
 				},
+				cli.BoolFlag{
+					Name:  "cache",
+					Usage: "Setting will only and use files from the cache (excluding the GOPATH)",
+				},
 			},
 			Action: func(c *cli.Context) {
 				if len(c.Args()) < 1 {
@@ -186,6 +190,7 @@ func commands(cxt cookoo.Context, router *cookoo.Router) []cli.Command {
 				cxt.Put("packages", []string(c.Args()))
 				cxt.Put("skipFlatten", !c.Bool("no-recursive"))
 				cxt.Put("insecure", c.Bool("insecure"))
+				cxt.Put("forceCache", c.Bool("cache"))
 				// FIXME: Are these used anywhere?
 				if c.Bool("import") {
 					cxt.Put("importGodeps", true)
@@ -347,6 +352,10 @@ Example:
 					Name:  "file, f",
 					Usage: "Save all of the discovered dependencies to a Glide YAML file.",
 				},
+				cli.BoolFlag{
+					Name:  "cache",
+					Usage: "Setting will only and use files from the cache (excluding the GOPATH)",
+				},
 			},
 			Action: func(c *cli.Context) {
 				cxt.Put("deleteOptIn", c.Bool("delete"))
@@ -355,6 +364,7 @@ Example:
 				cxt.Put("deleteFlatten", c.Bool("delete-flatten"))
 				cxt.Put("toPath", c.String("file"))
 				cxt.Put("toStdout", false)
+				cxt.Put("forceCache", c.Bool("cache"))
 				if c.Bool("import") {
 					cxt.Put("importGodeps", true)
 					cxt.Put("importGPM", true)
@@ -459,10 +469,12 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Using("conf").From("cxt:cfg").
 		Using("insecure").From("cxt:insecure").
 		Using("home").From("cxt:home").
+		Using("cache").From("cxt:forceCache").
 		Does(cmd.Flatten, "flatten").Using("conf").From("cxt:cfg").
 		Using("packages").From("cxt:packages").
 		Using("force").From("cxt:forceUpdate").
 		Using("home").From("cxt:home").
+		Using("cache").From("cxt:forceCache").
 		Does(cmd.WriteYaml, "out").
 		Using("conf").From("cxt:cfg").
 		Using("filename").WithDefault("glide.yaml").From("cxt:yaml")
@@ -490,12 +502,14 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Using("force").From("cxt:forceUpdate").
 		Using("packages").From("cxt:packages").
 		Using("home").From("cxt:home").
+		Using("cache").From("cxt:forceCache").
 		Does(cmd.SetReference, "version").Using("conf").From("cxt:cfg").
 		Does(cmd.Flatten, "flattened").Using("conf").From("cxt:cfg").
 		Using("packages").From("cxt:packages").
 		Using("force").From("cxt:forceUpdate").
 		Using("skip").From("cxt:skipFlatten").
 		Using("home").From("cxt:home").
+		Using("cache").From("cxt:forceCache").
 		Does(cmd.VendoredCleanUp, "_").
 		Using("conf").From("cxt:cfg").
 		Using("update").From("cxt:updateVendoredDeps").

--- a/glide.go
+++ b/glide.go
@@ -458,6 +458,7 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Using("packages").From("cxt:packages").
 		Using("conf").From("cxt:cfg").
 		Using("insecure").From("cxt:insecure").
+		Using("home").From("cxt:home").
 		Does(cmd.Flatten, "flatten").Using("conf").From("cxt:cfg").
 		Using("packages").From("cxt:packages").
 		Using("force").From("cxt:forceUpdate").

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
     subpackages:
       - .
   - package: github.com/Masterminds/vcs
-    version: ^1.1.4
+    version: master
   - package: github.com/codegangsta/cli
   - package: github.com/Masterminds/semver
     version: ^1.0.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
     subpackages:
       - .
   - package: github.com/Masterminds/vcs
-    version: master
+    version: ^1.2.0
   - package: github.com/codegangsta/cli
   - package: github.com/Masterminds/semver
     version: ^1.0.0

--- a/yaml/yaml.go
+++ b/yaml/yaml.go
@@ -72,7 +72,7 @@ type Config struct {
 	Parent     *Config
 	Name       string       `yaml:"package"`
 	Imports    Dependencies `yaml:"import"`
-	DevImports Dependencies `yaml:"devimport"`
+	DevImports Dependencies `yaml:"devimport,omitempty"`
 }
 
 // HasDependency returns true if the given name is listed as an import or dev import.


### PR DESCRIPTION
This uses either the GOPATH or the $HOME/.glide/cache to store repos. They are copied to the right location from there. This works with repos (as opposed to just package names so forks still work). The GOPATH is used only when the repo exactly matches.

By default the GOPATH is used as the cache unless there is something blocking or the `--cache` flag is used on `glide up` or `glide get`. This is to have one directory with all the caches for things like CI.