### PR TITLE
Add a --no-color flag to remove color codes from output

### DIFF
--- a/cmd/msg.go
+++ b/cmd/msg.go
@@ -25,6 +25,9 @@ const (
 // The following will print the string "Foo" in yellow:
 //     fmt.Print(Color(Yellow, "Foo"))
 func Color(code, msg string) string {
+	if NoColor {
+		return msg
+	}
 	return fmt.Sprintf("\033[%sm%s\033[m", code, msg)
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -16,12 +16,20 @@ import (
 // Quiet, when set to true, can suppress Info and Debug messages.
 var Quiet = false
 var IsDebugging = false
+var NoColor = false
 
 // BeQuiet supresses Info and Debug messages.
 func BeQuiet(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
 	Quiet = p.Get("quiet", false).(bool)
 	IsDebugging = p.Get("debug", false).(bool)
 	return Quiet, nil
+}
+
+// CheckColor turns off the colored output (and uses plain text output) for
+// logging depending on the value of the "no-color" flag.
+func CheckColor(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	NoColor = p.Get("no-color", false).(bool)
+	return NoColor, nil
 }
 
 // ReadyToGlide fails if the environment is not sufficient for using glide.

--- a/glide.go
+++ b/glide.go
@@ -94,6 +94,10 @@ func main() {
 			Name:  "debug",
 			Usage: "Print Debug messages (verbose)",
 		},
+		cli.BoolFlag{
+			Name:  "no-color",
+			Usage: "Turn off colored output for log messages",
+		},
 	}
 	app.CommandNotFound = func(c *cli.Context, command string) {
 		cxt.Put("os.Args", os.Args)
@@ -419,6 +423,7 @@ Example:
 func setupHandler(c *cli.Context, route string, cxt cookoo.Context, router *cookoo.Router) {
 	cxt.Put("q", c.GlobalBool("quiet"))
 	cxt.Put("debug", c.GlobalBool("debug"))
+	cxt.Put("no-color", c.GlobalBool("no-color"))
 	cxt.Put("yaml", c.GlobalString("yaml"))
 	cxt.Put("cliArgs", c.Args())
 	if err := router.HandleRequest(route, cxt, false); err != nil {
@@ -433,6 +438,8 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Does(cmd.BeQuiet, "quiet").
 		Using("quiet").From("cxt:q").
 		Using("debug").From("cxt:debug").
+		Does(cmd.CheckColor, "no-color").
+		Using("no-color").From("cxt:no-color").
 		Does(cmd.VersionGuard, "v")
 
 	reg.Route("@ready", "Prepare for glide commands.").


### PR DESCRIPTION
This is incredibly useful for certain environments which do not support ansi color codes. For example, in my use case, we were running glide install in jenkins, where the color codes do not work and just add junk to the output.