### PR TITLE
Make glide "go installable"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _vendor
-vendor/
 glide
 *.a
 *.sublime-project

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,19 @@ clean:
 	rm -rf ./dist
 
 bootstrap:
+	rm -rf ./vendor
 	mkdir ./vendor
+	
 	git clone https://github.com/Masterminds/cookoo vendor/github.com/Masterminds/cookoo
+	rm -rf vendor/github.com/Masterminds/cookoo/.git
 	git clone https://github.com/Masterminds/vcs vendor/github.com/Masterminds/vcs
+	rm -rf vendor/github.com/Masterminds/vcs/.git
 	git clone https://gopkg.in/yaml.v2 vendor/gopkg.in/yaml.v2
+	rm -rf vendor/gopkg.in/yaml.v2/.git
 	git clone https://github.com/codegangsta/cli vendor/github.com/codegangsta/cli
+	rm -rf vendor/github.com/codegangsta/cli/.git
 	git clone https://github.com/Masterminds/semver vendor/github.com/Masterminds/semver
+	rm -rf vendor/github.com/Masterminds/semver/.git
 
 bootstrap-dist:
 	go get -u github.com/mitchellh/gox

--- a/vendor/github.com/Masterminds/cookoo/.gitignore
+++ b/vendor/github.com/Masterminds/cookoo/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+github.com
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.test
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/Masterminds/cookoo/.travis.yml
+++ b/vendor/github.com/Masterminds/cookoo/.travis.yml
@@ -1,0 +1,33 @@
+language: go
+
+go:
+  - 1.3
+
+notifications:
+  irc: "irc.freenode.net#masterminds"
+
+before_script:
+  - go get code.google.com/p/go.tools/cmd/cover
+  - go get github.com/hailiang/goveralls
+
+# Doing the test coverage piece part until Go supports it natively. See
+# http://code.google.com/p/go/issues/detail?id=6909 for more details.
+# script:
+#   - go test -v -covermode=count -coverprofile=profile.cov ./...
+#   - ~/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci -repotoken=$COVERALLS_TOKEN
+script:
+  - go test -v -covermode=count -coverprofile=cookoo.part .
+  - go test -v -covermode=count -coverprofile=cli.part ./cli
+  - go test -v -covermode=count -coverprofile=convert.part ./convert
+  - go test -v -covermode=count -coverprofile=databaseactive.part ./database/active
+  - go test -v -covermode=count -coverprofile=databasesql.part ./database/sql
+  - go test -v -covermode=count -coverprofile=io.part ./io
+  - go test -v -covermode=count -coverprofile=web.part ./web
+  - go test -v -covermode=count -coverprofile=webauth.part ./web/auth
+  - 'echo "mode: count" >coverage.out'
+  - 'grep -h -v "mode: count" *.part >>coverage.out'
+  - ~/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN
+
+env:
+  global:
+    secure: "ZlEeo3TEMbtU+YtdKY22wDykRlXYzm27pdZzmyCaqv0kZcMdS0+8rjoy+H3kHBlGOjbdFFMPimuFOGCZ1+Z9934RwPzkVMN7TIAhZfb40xG5m+qU8cugBoW2hc1RT5wniPJkDz+9SF4EMWslNgLfOJtcuAdDuC0Spqhb9yuJRQQ="

--- a/vendor/github.com/Masterminds/cookoo/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/cookoo/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## v1.2.0 (2015-06-16)
+
+* EXPERIMENTAL: Added support for CmdDef, a tool for writing structs
+  that manage types for cookoo commands.
+* Added support for an alternative Route declaration syntax that does
+  not use method chaining.
+* Added support for @shutdown routes on web.Serve().
+* Added safely.GoDo(cxt, GoDoer)
+* NewReroute(route string) can be used to create Reroutes now.
+* From() now takes an vararg of strings: `From("cxt:foo", "cxt:bar")`.
+  It can still take a space-delimited set of strings, too. In fact, both
+  can be used together:`From("cxt:foo", "cxt:bar cxt:baz")`.
+* Added Getter interface
+* Added the Get* and Has* utility functions (getter.go)
+* Added GetFromFirst(string, interface) (Contextvalue, Getter) function
+* Added DefaultGetter struct
+* Added 'subcommand' param to cli.ParseArgs
+* Added 'cli.New' and 'cli.Runner'
+* Added 'fmt' package
+
+## v1.1.0 (2014-06-06)
+
+* Added SyncContext function so Contexts are kept in sync via read/write mutex.
+* Improved debugging for panics.
+* Documentation fixes.
+
+## v1.0.0 (2014-04-23)
+
+* Initial release.

--- a/vendor/github.com/Masterminds/cookoo/LICENSE.txt
+++ b/vendor/github.com/Masterminds/cookoo/LICENSE.txt
@@ -1,0 +1,20 @@
+Cookoo
+Copyright (C) 2013, 2014 Masterminds
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/cookoo/README.md
+++ b/vendor/github.com/Masterminds/cookoo/README.md
@@ -1,0 +1,157 @@
+Cookoo
+======
+
+A chain-of-command framework written in Go
+
+[![Build Status](https://travis-ci.org/Masterminds/cookoo.png?branch=master)](https://travis-ci.org/Masterminds/cookoo) [![GoDoc](https://godoc.org/github.com/Masterminds/cookoo?status.png)](https://godoc.org/github.com/Masterminds/cookoo)
+
+## Usage
+
+```
+$ cd $GOPATH
+$ go get github.com/Masterminds/cookoo
+```
+
+Use it as follows (from `example/example.go`):
+
+~~~go
+package main
+
+import (
+	// This is the path to Cookoo
+	"fmt"
+	"github.com/Masterminds/cookoo"
+)
+
+func main() {
+
+	// Build a new Cookoo app.
+	registry, router, context := cookoo.Cookoo()
+
+	// Fill the registry.
+	registry.AddRoutes(
+		cookoo.Route{
+			Name: "TEST",
+			Help: "A test route",
+			Does: cookoo.Tasks{
+				cookoo.Cmd{
+					Name: "hi",
+					Fn:   HelloWorld,
+				},
+			},
+		},
+	)
+
+	// Execute the route.
+	router.HandleRequest("TEST", context, false)
+}
+
+func HelloWorld(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	fmt.Println("Hello World")
+	return true, nil
+}
+~~~
+
+## Documentation
+
+- The [Web App tutorial](https://github.com/Masterminds/cookoo-web-tutorial)
+- The [CLI Tutorial](https://github.com/Masterminds/cookoo-cli-tutorial)
+- The [API
+  Reference](https://godoc.org/github.com/Masterminds/cookoo)
+
+## A Real Example
+
+For a real example of Cookoo, take a look at
+[Skunk](https://github.com/technosophos/Skunk).
+
+Here's what Skunk's registry looks like:
+
+```go
+	registry.
+	Route("scaffold", "Scaffold a new app.").
+		Does(LoadSettings, "settings").
+			Using("file").WithDefault(homedir + "/settings.json").From("cxt:SettingsFile").
+		Does(MakeDirectories, "dirs").
+			Using("basedir").From("cxt:basedir").
+			Using("directories").From("cxt:directories").
+		Does(RenderTemplates, "template").
+			Using("tpldir").From("cxt:homedir").
+			Using("basedir").From("cxt:basedir").
+			Using("templates").From("cxt:templates").
+	Route("help", "Print help").
+		Does(Usage, "Testing")
+```
+
+This has two routes:
+
+- scaffold
+- help
+
+The `help` route just runs the command `Usage`, which looks like this:
+
+```go
+func Usage(cxt cookoo.Context, params *cookoo.Params) interface{} {
+	fmt.Println("Usage: skunk PROJECTNAME")
+	return true
+}
+```
+
+That is a good example of a basic command.
+
+The `scaffold` route is more complex. It performs the following commands
+(in order):
+
+- LoadSettings: Load a `settings.json` file into the context.
+- MakeDirectories: Make a bunch of directories.
+- RenderTemplates: Perform template conversions on some files.
+
+The `MakeDirectories` command is an example of a more complex command.
+It takes two parameters (declared with `Using().From()`):
+
+1. basedir: The base directory where the new subdirectories will be
+   created. This comes from the `cxt:basedir` source, which means Cookoo
+   looks in the `Context` object for a value named `basedir`.
+2. directoies: An array of directory names that this command will
+   create. These come from `cxt:directories`, which means that the
+   `Context` object is queried for the value of `directories`. In this
+   case, that value is actually loaded from the `settings.json` file into
+   the context by the `LoadSettings` command.`
+
+With that in mind, let's look at the command:
+
+```go
+// The MakeDirectories command.
+// All commands take a Context and a Params object, and return an
+// interface{}
+func MakeDirectories(cxt cookoo.Context, params *cookoo.Params) interface{} {
+
+	// This is how we get something out of the Params object. This is the
+	// value that was passed in by `Using('basedir').From('cxt:basedir')
+	basedir := params.Get("basedir", ".").(string)
+
+	// This is another way to get a parameter value. This form allows us
+	// to conveniently check that the parameter exists.
+	d, ok := params.Has("directories")
+	if !ok {
+		// Did nothing. But we don't want to raise an error.
+		return false
+	}
+
+	// We do have to do an explicit type conversion.
+	directories := d.([]interface{})
+
+	// Here we do the work of creating directories.
+	for _, dir := range directories {
+		dname := path.Join(basedir, dir.(string))
+		os.MkdirAll(dname, 0755)
+	}
+
+	// We don't really have anything special to return, so we just
+	// indicate that the command was successful.
+	return true
+}
+```
+
+This is a basic example of working with Cookoo. But far more
+sophisticated workflows can be built inexpensively and quickly, and in a
+style that encourages building small and re-usable chunks of code.

--- a/vendor/github.com/Masterminds/cookoo/cli/commands.go
+++ b/vendor/github.com/Masterminds/cookoo/cli/commands.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"github.com/Masterminds/cookoo"
+	"io"
+	"os"
+	"strings"
+	//"log"
+)
+
+// Parse arguments for a "subcommand"
+//
+// The cookoo.cli.RequestResolver allows you to specify global level flags. This command
+// allows you to augment those with subcommand flags. Example:
+//
+// 		$ myprog -foo=yes subcommand -bar=no
+//
+// In the above example, `-foo` is a global flag (set before the subcommand), while
+// `-bar` is a local flag. It is specific to `subcommand`. This command lets you parse
+// an arguments list given a pointer to a `flag.FlagSet`.
+//
+// Like the cookoo.cli.RequestResolver, this will place the parsed params directly into the
+// context. For this reason, you ought not use the same flag names at both global and local
+// flag levels. (The local will overwrite the global.)
+//
+// Params:
+//
+// 	- args: (required) A slice of arguments. Typically, this is `cxt:args` as set by
+// 		cookoo.cli.RequestResolver.
+// 	- flagset: (required) A set if flags (see flag.FlagSet) to parse.
+//
+// A slice of all non-flag arguments remaining after the parse are returned into the context.
+//
+// For example, if ['-foo', 'bar', 'some', 'other', 'data'] is passed in, '-foo' and 'bar' will
+// be parsed out, while ['some', 'other', 'data'] will be returned into the context. (Assuming, of
+// course, that the flag definition for -foo exists, and is a type that accepts a value).
+//
+// Thus, you will have `cxt:foo` available (with value `bar`) and everything else will be available
+// in the slice under this command's context entry.
+func ParseArgs(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	params.Requires("args", "flagset")
+	flagset := params.Get("flagset", nil).(*flag.FlagSet)
+	args := params.Get("args", nil).([]string)
+
+	// If this is true, we shift the args first.
+	if params.Get("subcommand", false).(bool) {
+		args = args[1:]
+	}
+
+
+	flagset.Parse(args)
+	addFlagsToContext(flagset, cxt)
+	return flagset.Args(), nil
+
+}
+
+// Show help.
+// This command is useful for placing at the front of a CLI "subcommand" to have it output
+// help information. It will only trigger when "show" is set to true, so another command
+// can, for example, check for a "-h" or "-help" flag and set "show" based on that.
+//
+// Params:
+// 	- show (bool): If `true`, show help.
+// 	- summary (string): A one-line summary of the command.
+// 	- description (string): A short description of what the command does.
+// 	- usage (string): usage information.
+// 	- flags (FlagSet): Flags that are supported. The FlagSet will be converted to help text.
+// 	- writer (Writer): The location that this will write to. Default is os.Stdout
+// 	- subcommands ([]string): A list of subcommands. This will be formatted as help text.
+func ShowHelp(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	showHelp := false
+	showHelpO := params.Get("show", false)
+	switch showHelpO.(type) {
+	case string:
+		showHelp = strings.ToLower(showHelpO.(string)) == "true"
+	case bool:
+		showHelp = showHelpO.(bool)
+	}
+
+	writer := params.Get("writer", os.Stdout).(io.Writer)
+
+	pmap := params.AsMap()
+
+	// Last resort: If no summary, pull it from the route description.
+	if summary, ok := pmap["summary"]; !ok || len(summary.(string)) == 0 {
+		pmap["summary"] = cxt.Get("route.Description", "").(string)
+	}
+
+	sections := []string{"summary", "description", "usage"}
+	if _, ok := params.Has("subcommands"); ok {
+		sections = append(sections, "subcommands")
+	}
+
+	if showHelp {
+		displayHelp(sections, pmap, writer)
+		return true, new(cookoo.Stop)
+	}
+
+	return false, nil
+}
+
+func displayHelp(keys []string, params map[string]interface{}, out io.Writer) {
+	for i := range keys {
+		key := keys[i]
+		if msg, ok := params[key]; ok && len(msg.(string)) > 0 {
+			spacer := strings.Repeat("=", len(key))
+			fmt.Fprintf(out, "\n%s\n%s\n\n%s\n", strings.ToUpper(key), spacer, msg)
+		}
+	}
+	fmt.Fprintf(out, "\n")
+
+	// Handle the flags, if set.
+	args, ok := params["flags"]
+	if ok {
+		fmt.Fprintf(out, "FLAGS\n=====\n")
+		// Name: Description (default)
+		filter := "\t-%s: %s (Default: '%s')\n"
+		args.(*flag.FlagSet).VisitAll(func(f *flag.Flag) {
+			fmt.Fprintf(out, filter, f.Name, f.Usage, f.DefValue)
+		})
+	}
+}
+
+// Run a subcommand.
+//
+// Params:
+// 	- args: a string[] of arguments, like you get from os.Args. This will assume the first arg
+// 	  is a subcommand. If you have options, you should parse those out first with ParseArgs.
+// 	- default: The default subcommand to run if none is found.
+// 	- offset: By default, this assumes an os.Args, and looks up the item in os.Args[1]. You can
+// 	  override this behavior by setting offset to something else.
+// 	- ignoreRoutes: A []string of routes that should not be executed.
+func RunSubcommand(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	params.Requires("args")
+
+	args := params.Get("args", nil).([]string)
+	offset := params.Get("offset", 1).(int)
+	var route string
+	if len(args) <= offset {
+		route = params.Get("default", "default").(string)
+	} else {
+		route = args[offset]
+	}
+
+	stoplist := params.Get("ignoreRoutes", []string{}).([]string)
+	if len(stoplist) > 0 {
+		for _, stop := range stoplist {
+			if stop == route {
+				return nil, &cookoo.FatalError{"Illegal route."}
+			}
+		}
+	}
+
+	return nil, &cookoo.Reroute{route}
+}
+
+// Shift the args N (default 1) times, returning the last shifted value.
+//
+// Params:
+// 	- n: The number of times to shift. Only the last value is returned.
+// 	- args: The name of the context slice/array to modify. This value will be retrieved
+// 	 from the context. Default: "os.Args"
+func ShiftArgs(c cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+
+	n := params.Get("n", 1).(int)
+	argName := params.Get("args", "os.Args").(string)
+
+	args, ok := c.Get(argName, nil).([]string)
+	if !ok {
+		return nil, &cookoo.FatalError{"Could not get arg out of context: No such arg name."}
+	}
+
+	if len(args) < n {
+		c.Put(argName, make([]string, 0))
+		//log.Printf("Not enough args in %s", argName)
+		return nil, &cookoo.RecoverableError{"Not enough arguments."}
+	}
+	targetArg := n - 1
+	shifted := args[targetArg]
+	c.Put(argName, args[n:])
+
+	return shifted, nil
+}

--- a/vendor/github.com/Masterminds/cookoo/cli/commands_test.go
+++ b/vendor/github.com/Masterminds/cookoo/cli/commands_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"flag"
+	"github.com/Masterminds/cookoo"
+	"strings"
+	"testing"
+	//"fmt"
+)
+
+func Barf(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	return nil, cookoo.FatalError{"Intentional fail!"}
+}
+
+func TestShowHelp(t *testing.T) {
+	registry, router, context := cookoo.Cookoo()
+
+	var out bytes.Buffer
+
+	registry.Route("test", "Testing help.").Does(ShowHelp, "didShowHelp").
+		Using("show").WithDefault(true).
+		Using("writer").WithDefault(&out).
+		Using("summary").WithDefault("This is a summary.").
+		Does(Barf, "Fail if help doesn't stop.")
+
+	e := router.HandleRequest("test", context, false)
+
+	if e != nil {
+		t.Error("! Unexpected error.")
+	}
+
+	res := context.Get("didShowHelp", false).(bool)
+
+	if !res {
+		t.Error("! Expected help to be shown.")
+	}
+
+	msg := out.String()
+	if !strings.Contains(msg, "SUMMARY\n") {
+		t.Error("! Expected 'summary' as a header.")
+	}
+	if !strings.Contains(msg, "This is a summary.") {
+		t.Error("! Expected 'This is a summary' to be in the output. Got ", msg)
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	registry, router, cxt := cookoo.Cookoo()
+
+	flags := flag.NewFlagSet("test flags", flag.ContinueOnError)
+	flags.String("foo", "binky", "Test foo flag.")
+	flags.Bool("baz", false, "Baz flag")
+	flags.Int("unused", 123, "Unused int flag.")
+
+	registry.Route("test", "Testing parse arguments.").
+		Does(ParseArgs, "args").
+		Using("args").WithDefault([]string{"-foo", "bar", "-baz", "arg1"}).
+		Using("flagset").WithDefault(flags)
+
+	if router.HandleRequest("test", cxt, false) != nil {
+		t.Error("! Request failed.")
+		return
+	}
+
+	foo := cxt.Get("foo", "").(string)
+	if foo != "bar" {
+		t.Error("Expected 'bar'; got ", foo)
+		return
+	}
+
+	bazO, ok := cxt.Has("baz")
+	if !ok {
+		t.Error("Expected to find 'baz' in context.")
+		return
+	}
+	baz := bazO.(string)
+	// fmt.Printf("baz is %v", baz)
+	if baz != "true" {
+		t.Error("Expected 'baz' to be true. Got false.")
+		return
+	}
+
+	unused := cxt.Get("unused", 321).(string)
+	if unused != "123" {
+		t.Error("Expected 'unused' to be int 123. Got ", unused)
+		return
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/cli/requestresolver.go
+++ b/vendor/github.com/Masterminds/cookoo/cli/requestresolver.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"flag"
+	"github.com/Masterminds/cookoo"
+	//"os"
+	"strings"
+)
+
+
+// A CLI-centered request resolver with support for command line flags.
+//
+// When this resolver finds "globalFlags" in the base context, it
+// attempts to parse out the flags from the `path` string.
+//
+// You must specify arguments as a `flag.FlagSet` (see the Go documentation).
+//
+// Parsed commanline arguments are put directly into the context (though later we may put them
+// in a datasource instead). Currently, all parameter values -- even booleans -- are stored
+// as strings. If it is important to you to store them as more complex types, you may need to
+// use `FlagSet.*Var()` functions.
+//
+// Splitting the path string into arguments is done naively by splitting the string on the
+// space (%20) character.
+//
+// Arguments are parsed when the request resolver is asked to resolve (no earlier). Thus the FlagSet
+// may be placed into the context at any time prior to cookoo.Router.HandleRequest().
+//
+// CONTEXT VALUES
+// - globalFlags: A `flag.FlagSet`. If this is present and not empty, the path will be parsed.
+type RequestResolver struct {
+	registry *cookoo.Registry
+}
+
+func (r *RequestResolver) Init(registry *cookoo.Registry) {
+	r.registry = registry
+}
+
+func (r *RequestResolver) Resolve(path string, cxt cookoo.Context) (string, error) {
+	// Parse out any flags. Maybe flag specs are in context?
+
+	flagsetO, ok := cxt.Has("globalFlags")
+	if !ok {
+		// No args to parse. Just return path.
+		return path, nil
+	}
+	flagset := flagsetO.(*flag.FlagSet)
+	flagset.Parse(strings.Split(path, " "))
+	addFlagsToContext(flagset, cxt)
+	args := flagset.Args()
+
+	// This is a failure condition... Need to fix Cookoo to support error return.
+	if len(args) == 0 {
+		return path, &cookoo.RouteError{"Could not resolve route " + path}
+	}
+
+	// Put the rest of the args to the context.
+	cxt.Put("args", args[1:])
+
+	// Parse argv[0] as subcommand
+	return args[0], nil
+}
+
+func addFlagsToContext(flagset *flag.FlagSet, cxt cookoo.Context) {
+	store := func(f *flag.Flag) {
+		// fmt.Printf("Storing %s in context with value %s.\n", f.Name, f.Value.String())
+
+		// Basically, we can tell the difference between booleans and strings, and that's it.
+		// Other types are a loss.
+		/*
+			if f.IsBoolFlag != nil {
+				cxt.Put(f.Name, f.Value.String() == "true")
+			} else {
+				cxt.Put(f.Name, f.Value.String())
+			}
+		*/
+		cxt.Put(f.Name, f.Value.String())
+	}
+
+	flagset.VisitAll(store)
+}

--- a/vendor/github.com/Masterminds/cookoo/cli/requestresolver_test.go
+++ b/vendor/github.com/Masterminds/cookoo/cli/requestresolver_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"github.com/Masterminds/cookoo"
+	"testing"
+)
+
+func Nothing(cxt cookoo.Context, params *cookoo.Params) (res interface{}, i cookoo.Interrupt) {
+	//fmt.Printf("Nothing command was run.\n")
+	return true, nil
+}
+
+func TestResolvingSimpleRoute(t *testing.T) {
+	registry, router, context := cookoo.Cookoo()
+
+	resolver := new(RequestResolver)
+	resolver.Init(registry)
+
+	router.SetRequestResolver(resolver)
+
+	registry.Route("test", "A simple test").Does(Nothing, "nada")
+
+	e := router.HandleRequest("test", context, false)
+
+	if e != nil {
+		t.Error("! Failed 'test' route.")
+	}
+}
+
+func TestResolvingWithFlags(t *testing.T) {
+	registry, router, context := cookoo.Cookoo()
+
+	resolver := new(RequestResolver)
+	resolver.Init(registry)
+
+	flagset := flag.NewFlagSet("test", flag.ExitOnError)
+	flagset.String("foo", "bar", "this is a test")
+	context.Add("globalFlags", flagset)
+
+	router.SetRequestResolver(resolver)
+
+	registry.Route("test", "Test flag parsing.").Does(Nothing, "nada")
+
+	e := router.HandleRequest("-foo arg1 test -foo arg2 arg3 arg4", context, false)
+	if e != nil {
+		t.Error("! Failed 'test' route.", e)
+		return
+	}
+
+	nada, ok := context.Has("nada")
+	if !ok {
+		t.Error("! Expected to find a context entry for 'nada'")
+		return
+	}
+	if !nada.(bool) {
+		t.Error("! Expected 'nada' to be set to TRUE")
+		return
+	}
+
+	fooArgO, ok := context.Has("foo")
+	if !ok {
+		t.Error("! Expected to find 'foo' in context, but it's not there.", ok)
+		return
+	}
+	fooArg := fooArgO.(string)
+	if fooArg != "arg1" {
+		t.Error("! Expected 'arg1' in context 'foo'; got ", fooArg)
+		return
+	}
+
+	argsListO, ok := context.Has("args")
+	if !ok {
+		t.Error("! Expected to find a list of args in the context as 'args'")
+		return
+	}
+
+	argsList := argsListO.([]string)
+	if len(argsList) != 4 {
+		t.Error("! Expected to find 4 arguments in the list. Found ", len(argsList))
+		t.Error(fmt.Sprintf("Arguments left: %v\n", argsList))
+		return
+	}
+
+	if argsList[0] != "-foo" {
+		t.Error("! Expected argList[0] to be '-foo'. Got ", argsList[0])
+	}
+
+	if argsList[3] != "arg4" {
+		t.Error("! Expected argList[3] to be 'arg4'. Got ", argsList[3])
+	}
+
+}

--- a/vendor/github.com/Masterminds/cookoo/cli/runner.go
+++ b/vendor/github.com/Masterminds/cookoo/cli/runner.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"github.com/Masterminds/cookoo"
+	"flag"
+	"fmt"
+	"os"
+
+	"strings"
+)
+
+
+// New creates a new CLI instance.
+//
+// It takes a flagset for parsing command line options, and creates a new
+// CLI application initialized. Flags are placed into the context.
+//
+// By default, the `cookoo.BasicRequestResolver` is used for resolving request.
+// This works well with the subcommand model of delegating commands.
+//
+// If a '@startup' route is inserted into the registry, it will be run first
+// upon any call to `Router.HandleRequest`. If not, the default startup will
+// be run. That routine includes displaying help text if the -h or -help
+// flags are passed in.
+//
+// The `summary` is a one line explanation of the program used in help text.
+//
+// The `usage` is a detailed help message, often several paragraphs.
+//
+// The `globalFlags` are a `flag.FlagSet` for the top level of this program. If
+// you use subcommands and want subcommand-specific flags, use the `ParseArgs`
+// command in this package.
+//
+// Typical usage:
+//
+// 	package main
+//
+// 	import(
+// 		"github.com/Masterminds/cookoo"
+// 		"github.com/Masterminds/cookoo/cli"
+// 		"flag"
+// 	)
+//
+// 	var Summary := "A program that does stuff."
+// 	var Description := `Full text description goes here.`
+// 	func main() {
+// 		flags := flag.FlagSet("global", flag.PanicOnError)
+// 		// Define any flags here...
+// 		flags.Bool("h", false, "Show help text")
+//
+// 		reg, router, cxt := cookoo.Cookoo()
+// 		reg.Route("hello", "Does nothing")
+//
+// 		cli.New(reg, router, cxt).Help(Summary, Description, flags).Run("hello")
+// 	}
+//
+// The simple program above can be run any of these ways:
+//
+// 	$ mycli       # Will run 'hello', which does nothing
+//  $ mycli -h    # Will show help
+//
+// If we were to substitute `RunSubcommand` instead of `Run`:
+//
+// 	cli.New(reg, router, cxt).Help(Summary, Description, flags).RunSubcommand()
+//
+// The above would do the following:
+// 	$ mycli       # Will show help
+//  $ mycli -h    # Will show help
+//  $ mycli help  # Will show help
+//  $ mycli hello # Will run hte "hello" route, which does nothing.
+//
+func New(reg *cookoo.Registry, router *cookoo.Router, cxt cookoo.Context) *Runner {
+	return &Runner{reg: reg, router: router, cxt: cxt}
+}
+
+// Runner is a CLI runner.
+//
+// It provides a nice abstraction for simply and easily running CLI
+// commands.
+type Runner struct {
+	reg *cookoo.Registry
+	router *cookoo.Router
+	cxt cookoo.Context
+
+	summary, usage string
+	flags *flag.FlagSet
+}
+
+// Help sets the help text and support flags for the app.
+//
+// It is strongly advised to use this function for all CLI runner apps.
+func (r *Runner) Help(summary, usage string, flags *flag.FlagSet) *Runner {
+	r.summary = summary
+	r.usage = usage
+	r.flags = flags
+	return r
+}
+
+// Subcommand sets up the basics for a subcommand.
+//
+// It creates a route complete with help and flags parser, then returns that
+// route for you to add commands.
+//
+// Example:
+// 	package main
+
+// 	import (
+// 		"github.com/Masterminds/cookoo"
+// 		"github.com/Masterminds/cookoo/cli"
+// 		"github.com/Masterminds/cookoo/fmt"
+//
+// 		"flag"
+// 	)
+//
+// 	func main() {
+// 		reg, router, cxt := cookoo.Cookoo()
+//
+// 		// global flags
+// 		flags := flag.NewFlagSet("global", flag.PanicOnError)
+// 		flags.Bool("h", false, "Print help")
+//
+// 		// Create a new app
+// 		app := cli.New(reg, router, cxt).Help("Test", "test -h", flags)
+//
+// 		// Create a new subcommand on that app
+// 		app.Subcommand("test", "A test route.", "example test", nil).
+// 			Does(fmt.Println, "out").Using("content").WithDefault("Hello World")
+//
+// 		helloFlags := flag.NewFlagSet("test", flag.ContinueOnError)
+// 		helloFlags.Bool("h", false, "Print help")
+// 		helloFlags.String("n", "World!", "A name to greet.")
+// 		app.Subcommand("hello", "Print hello.", "example hello -n Matt", helloFlags).
+// 			Does(fmt.Printf, "out").
+// 				Using("format").WithDefault("Hello %s\n").
+// 				Using("0").WithDefault("World").From("cxt:n")
+//
+// 		// Run the app, and let it figure out which subcommand to run.
+// 		app.RunSubcommand()
+// 	}
+//
+// The above declares two subcommands: 'test' and 'hello'. If the flags argument
+// is nil, the Subcommand will automatically create a default flagset with 
+// '-h' mapped to the help.
+//
+// Any remaining arguments are placed into the context as "subcommand.Args"
+func (r *Runner) Subcommand(name, summary, usage string, flags *flag.FlagSet) *cookoo.Registry {
+	if flags == nil {
+		flags = flag.NewFlagSet("nada", flag.ContinueOnError)
+		flags.Bool("h", false, "Show help")
+	}
+	return r.reg.Route(name, summary).
+		Does(ShiftArgs, "_").Using("n").WithDefault(1).
+		Does(ParseArgs, "subcommand.Args").
+			Using("flagset").WithDefault(flags).
+			Using("args").From("cxt:os.Args").
+		Does(ShowHelp, "subcommandHelp").
+			Using("show").From("cxt:h").
+			Using("summary").WithDefault(summary).
+			Using("usage").WithDefault(usage).
+			Using("flags").WithDefault(flags)
+}
+
+func (r *Runner) startup() {
+
+	if r.flags == nil {
+		r.flags = flag.NewFlagSet("globalFlags", flag.PanicOnError)
+		r.flags.Bool("h", false, "Show this help text.")
+		r.flags.Bool("help", false, "Show this help text.")
+	}
+
+	r.cxt.Put("globalFlags", r.flags)
+	r.cxt.Put("os.Args", os.Args)
+
+	// Allow route to be overwritten.
+	if _, ok := r.reg.RouteSpec("@startup"); !ok {
+		r.reg.Route("@startup", "Prepare to run a route.").
+			Does(ShiftArgs, "_").Using("n").WithDefault(1).
+			Does(ParseArgs, "runner.Args").
+				Using("flagset").WithDefault(r.flags).
+				Using("args").From("cxt:os.Args").
+			Does(ShowHelp, "help").
+				Using("show").From("cxt:h").
+				Using("summary").WithDefault(r.summary).
+				Using("usage").WithDefault(r.usage).
+				Using("flags").WithDefault(r.flags).
+				Using("subcommands").From("cxt:subcommandHelp").
+			Does(ShowHelp, "-help"). // Stupid hack. FIXME.
+				Using("show").From("cxt:help").
+				Using("summary").WithDefault(r.summary).
+				Using("usage").WithDefault(r.usage).
+				Using("flags").WithDefault(r.flags).
+				Using("subcommands").From("cxt:subcommandHelp")
+	}
+	if _, ok := r.reg.RouteSpec("@subcommand"); !ok {
+		r.reg.Route("@subcommand", "Startup and run subcommand").
+			Includes("@startup").
+			Does(RunSubcommand, "subcommand").
+			Using("default").WithDefault("help").From("cxt:defaultRoute").
+			Using("offset").WithDefault(0).
+			Using("args").From("cxt:runner.Args").
+			Using("ignoreRoutes").WithDefault([]string{"@startup", "@subcommand"})
+	}
+
+	if _, ok := r.reg.RouteSpec("help"); !ok {
+		r.reg.Route("help", "Show help.").
+			Does(ShowHelp, "help").
+			Using("show").WithDefault(true).
+			Using("summary").WithDefault(r.summary).
+			Using("usage").WithDefault(r.usage).
+			Using("flags").WithDefault(r.flags)
+	}
+}
+
+// Run runs a given route.
+//
+// It first runs the '@startup' route, and then runs whatever the named route
+// is.
+//
+// If the flags `-h` or `-help` are specified, then the presence of those
+// flags will automatically trigger help text.
+//
+// Additionally, the command `help` is predefined to generate help text.
+func (r *Runner) Run(route string) error {
+	r.startup()
+	if err := r.router.HandleRequest("@startup", r.cxt, false); err != nil {
+		fmt.Printf("Failed to startup: %s", err)
+		os.Exit(1)
+		//return err
+	}
+	if r.cxt.Get("help", false).(bool) {
+		return nil
+	}
+	// FIXME: Hack
+	if r.cxt.Get("-help", false).(bool) {
+		return nil
+	}
+	return r.router.HandleRequest(route, r.cxt, true)
+}
+
+// RunSubcommand uses the first non-flag argument in args as a route name.
+//
+// For example:
+// 	$ mycli -foo=bar myroute
+//
+// The above will see 'myroute' as a subcommand, and match it to a route named
+// 'subcommand'. In the event that the route is not present, the help text
+// will be displayed.
+//
+//
+func (r *Runner) RunSubcommand() error {
+	r.startup()
+	shelp := subcommandHelp(r.reg)
+	r.cxt.Put("subcommandHelp", shelp)
+	return r.router.HandleRequest("@subcommand", r.cxt, false)
+}
+
+func subcommandHelp(reg *cookoo.Registry) string {
+	names := reg.RouteNames()
+	helptext := make([]string, 0, len(names))
+	for _, name := range names {
+		if strings.HasPrefix(name, "@") {
+			continue
+		}
+
+		rs, _ := reg.RouteSpec(name)
+		help := fmt.Sprintf("\t%s: %s", name, cookoo.RouteDetails(rs).Description())
+		helptext = append(helptext, help)
+	}
+	return strings.Join(helptext, "\n")
+}

--- a/vendor/github.com/Masterminds/cookoo/commands.go
+++ b/vendor/github.com/Masterminds/cookoo/commands.go
@@ -1,0 +1,56 @@
+package cookoo
+
+// LogMessage prints a message to the log.
+//
+// Params
+//
+// 	- msg: The message to print
+// 	- level: The log level (default: "info")
+func LogMessage(cxt Context, params *Params) (interface{}, Interrupt) {
+	msg := params.Get("msg", "tick")
+	level := params.Get("level", "info").(string)
+	cxt.Log(level, msg)
+	return nil, nil
+}
+
+// AddToContext adds all of the param name/value pairs into the context.
+//
+// Params
+//
+// 	- Any params will be added into the context.
+func AddToContext(cxt Context, params *Params) (interface{}, Interrupt) {
+	p := params.AsMap()
+	for k, v := range p {
+		cxt.Put(k, v)
+	}
+	return true, nil
+}
+
+// ForwardTo forwards to the given route name.
+//
+// To prevent possible loops or problematic re-routes, use ignoreRoutes.
+//
+// Params
+//
+// 	- route: The route to forward to. This is required.
+// 	- ignoreRoutes: Route names that should be ignored (generate recoverable errors).
+func ForwardTo(cxt Context, params *Params) (interface{}, Interrupt) {
+	ok, _ := params.Requires("route")
+
+	if !ok {
+		return nil, &FatalError{"Expected a 'route'"}
+	}
+
+	route := params.Get("route", "default").(string)
+
+	stoplist := params.Get("ignoreRoutes", []string{}).([]string)
+	if len(stoplist) > 0 {
+		for _, stop := range stoplist {
+			if stop == route {
+				return nil, &RecoverableError{"Ignored route " + route}
+			}
+		}
+	}
+
+	return nil, &Reroute{route}
+}

--- a/vendor/github.com/Masterminds/cookoo/commands_test.go
+++ b/vendor/github.com/Masterminds/cookoo/commands_test.go
@@ -1,0 +1,117 @@
+// Copyright 2013 Masterminds
+
+package cookoo
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+)
+
+func TestLogMessage(t *testing.T) {
+	registry, router, context := Cookoo()
+
+	logger := new(bytes.Buffer)
+	context.AddLogger("test", logger)
+
+	registry.Route("test", "Testing.").
+		Does(LogMessage, "logmsg").
+		Using("msg").WithDefault("a test").
+		Using("level").WithDefault("error")
+
+	e := router.HandleRequest("test", context, false)
+
+	if e != nil {
+		t.Error("! Unexpected error.")
+	}
+
+	line := logger.String()
+	line = line[0 : len(line)-1]
+	pattern := "a test$"
+	matched, err := regexp.MatchString(pattern, line)
+	if err != nil {
+		t.Fatal("! Regex Pattern did not compile:", err)
+	}
+	if !matched {
+		t.Errorf("! Message was not logged to first test logger: %q", line)
+	}
+}
+
+func TestAddToContext(t *testing.T) {
+	registry, router, context := Cookoo()
+
+	registry.Route("test", "Testing.").
+		Does(AddToContext, "addtocontext").
+		Using("foo").WithDefault("baz").
+		Using("bar").WithDefault("qux")
+
+	e := router.HandleRequest("test", context, false)
+
+	if e != nil {
+		t.Error("! Unexpected error.")
+	}
+
+	if context.Get("foo", "") != "baz" {
+		t.Error("! foo was not added to the context with a value of baz.")
+	}
+	if context.Get("bar", "") != "qux" {
+		t.Error("! bar was not added to the context with a value of qux.")
+	}
+}
+
+func TestForwardTo(t *testing.T) {
+	registry, router, context := Cookoo()
+
+	registry.
+		// Routes to test a basic working forward.
+		Route("test", "Testing.").
+		Does(ForwardTo, "forwardto").
+		Using("route").WithDefault("test2").
+		Route("test2", "A second test route").
+		Does(AddToContext, "addtocontext").
+		Using("bar").WithDefault("qux").
+
+		// Route to test forward when no route supplied.
+		Route("nope", "A test route to fatal error").
+		Does(ForwardTo, "forwardto").
+		Does(AddToContext, "addtocontext").
+		Using("foo").WithDefault("baz").
+
+		// Route to test with an ignored route.
+		Route("test3", "Testing.").
+		Does(ForwardTo, "forwardto").
+		Using("route").WithDefault("nope").
+		Using("ignoreRoutes").WithDefault([]string{"nope"}).
+		Does(AddToContext, "addtocontext").
+		Using("bar").WithDefault("qux")
+
+	// Testing the case the required route is not supplied.
+	e := router.HandleRequest("nope", context, false)
+	if e == nil {
+		t.Error("! Expected error executing nope")
+	}
+	v := context.Get("foo", nil)
+	if v != nil {
+		t.Error("! Expected AddToContext to not be executed.")
+	}
+
+	// Test a successful jump.
+	e = router.HandleRequest("test", context, false)
+	if e != nil {
+		t.Error("! Unexpected error.")
+	}
+	v = context.Get("bar", nil)
+	if v != "qux" {
+		t.Error("! Expected test route to forward to test to adding bar to the context.")
+	}
+
+	// Test an ignored route
+	e = router.HandleRequest("test3", context, false)
+	if e != nil {
+		t.Error("! Unexpected error.")
+	}
+	v = context.Get("bar", nil)
+	if v != "qux" {
+		t.Error("! Expected test3 route to forward to test to adding bar to the context.")
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/context.go
+++ b/vendor/github.com/Masterminds/cookoo/context.go
@@ -1,0 +1,336 @@
+package cookoo
+
+// Copyright 2013, 1014 Masterminds
+
+import (
+	cio "github.com/Masterminds/cookoo/io"
+	"io"
+	"log"
+)
+
+// A Context is a collection of data that is associated with the current
+// request.
+//
+// Contexts are used to exchange information from command to command inside
+// of a particular chain of commands (a route). Commands may access the
+// data inside of a context, and may also modify a context.
+//
+// A context maintains two different types of data: *context variables* and
+// *datasources*.
+//
+// Context variables are data that can be passed, in current form, from
+// command to command -- analogous to passing variables via parameters in
+// function calls.
+//
+// Datasources are (as the name implies) sources of data. For example, a
+// database, a file, a cache, and a key-value store are all datasources.
+//
+// For long-running apps, it is generally assumed (though by no means
+// required) that datasources are "long lived" and context variables are
+// "short lived." While modifying a data source may impact other requests,
+// generally it is safe to assume that modifying a variable is localized to
+// the particular request.
+//
+// Correct Usage
+//
+// A word of warning.
+//
+// The Cookoo system was designed around the theory that commands should
+// generally work with datasources *directly* and context variables
+// *indirectly*. Context variables should generally be passed into a command
+// via a cookoo.Param. And a command generally should return a value that
+// can then be placed into the context on its behalf.
+//
+// The reason for this design is that it then makes it much easier for higher-
+// level programming, such as changing input or modifying output at the
+// registry level, not within the commands themselves.
+//
+// Datasources, on the other hand, are designed to be leveraged primarily by
+// commands. This involves a layer of conventionality, but it also pushes
+// data access logic into the commands where it belongs.
+//
+// So, for example, a SQL-based datasource should be *declared* at the top
+// level of a program (where it will be added to the context), but the actual
+// interaction with that datasource should happen inside of commands themselves,
+// not at the registry level.
+type Context interface {
+	// Add puts a name/value pair to the context.
+	// DEPRECATED. This will be removed in Cookoo 2.0. Use
+	// Put instead.
+	Add(string, ContextValue)
+
+	// Put inserts a name/value pair into the context.
+	//
+	// This is used to add data to a context. The context does nothing
+	// to manage manipulation of context values. Values are placed in
+	// as-is, and are retrieved as-is. Unless an implementor has
+	// made a value immutable, context values are mutable.
+	Put(string, ContextValue)
+
+	// Given a name, get a value from the context.
+	//
+	// Get requires a default value (which may be nil).
+	//
+	// Example:
+	// 	ip := cxt.Get("ip", "127.0.0.1").(string)
+	//
+	// Contrast this usage with that of cxt.Has(), which may be used for more
+	// traditional field checking:
+	//
+	// Example:
+	// 	ip, ok := cxt.Has("ip")
+	// 	if !ok {
+	// 		// do something error-ish
+	// 	}
+	// 	ipStr := ip.(string)
+	//
+	// The cxt.Get() call avoids the cumbersome check/type-assertion combo
+	// that occurs with cxt.Has().
+	Get(string, interface{}) ContextValue
+	// Given a name, check if the key exists, and if it does return the value.
+	Has(string) (ContextValue, bool)
+	// Get a datasource by name.
+	Datasource(string) Datasource
+	// Get a map of all datasources.
+	Datasources() map[string]Datasource
+	// Check if a datasource exists, and return it if it does.
+	HasDatasource(string) (Datasource, bool)
+	// Add a datasource.
+	AddDatasource(string, Datasource)
+	// Remove a datasource from the context.
+	RemoveDatasource(string)
+	// Get the length of the context. This is the number of context values.
+	// Datsources are not counted.
+	Len() int
+	// Make a shallow copy of the context.
+	Copy() Context
+	// Get the content (no datasources) as a map.
+	AsMap() map[string]ContextValue
+	// Get a logger.
+	Logger(name string) (io.Writer, bool)
+	// Add a logger.
+	AddLogger(name string, logger io.Writer)
+	// Remove a logger.
+	RemoveLogger(name string)
+	// Send a log with a prefix.
+	Log(prefix string, v ...interface{})
+	// Send a log and formatting string with a prefix.
+	Logf(prefix string, format string, v ...interface{})
+}
+
+// ContextValue is an empty interface defining a context value.
+// Semantically, this is the same as interface{}
+type ContextValue interface{}
+
+// Datasource is an empty interface defining a Datasource.
+// Semantically, this is the same as interface{}
+type Datasource interface{}
+
+// ExecutionContext is the core implementation of a Context.
+//
+// An ExecutionContext is an unordered map-based context.
+type ExecutionContext struct {
+	datasources map[string]Datasource // Datasources are things like MySQL connections.
+
+	// The Context values.
+	values map[string]ContextValue
+
+	loggers          io.Writer
+	loggerRegistered bool
+	skiplist         map[string]bool
+}
+
+// KeyValueDatasource is a datasource that can retrieve values by (string) keys.
+// Datsources can be just about anything. But a key/value datasource
+// can be used for a special purpose. They can be accessed in From()
+// clauses in a registry configuration.
+type KeyValueDatasource interface {
+	Value(key string) interface{}
+}
+
+// NewContext creates a new empty cookoo.ExecutionContext and calls its Init() method.
+func NewContext() Context {
+	cxt := new(ExecutionContext).Init()
+	return cxt
+}
+
+
+// Init initializes a context.
+//
+// If an existing context is re-initialized, all of its associated
+// values, datasources, and loggers will be unset.
+func (cxt *ExecutionContext) Init() *ExecutionContext {
+	cxt.datasources = make(map[string]Datasource)
+	cxt.values = make(map[string]ContextValue)
+	cxt.loggers = cio.NewMultiWriter()
+	cxt.loggerRegistered = false
+	cxt.skiplist = map[string]bool{}
+	return cxt
+}
+
+// Add a name/value pair to the context.
+// DEPRECATED: Use Put instead.
+func (cxt *ExecutionContext) Add(name string, value ContextValue) {
+	cxt.Log("warn", "ExecutionContext.Add() is deprecated. Use Put() instead.")
+	cxt.Put(name, value)
+}
+
+// Put inserts a value into the context.
+func (cxt *ExecutionContext) Put(name string, value ContextValue) {
+	cxt.values[name] = value
+}
+
+// AsMap returns the values of the context as a map keyed by a string.
+func (cxt *ExecutionContext) AsMap() map[string]ContextValue {
+	return cxt.values
+}
+
+// Get retrieves a value from the context given a name. If a value does not
+// exist on the context the default is returned.
+func (cxt *ExecutionContext) Get(name string, defaultValue interface{}) ContextValue {
+	val, ok := cxt.values[name]
+	if !ok {
+		return defaultValue
+	}
+	return val
+}
+
+// GetAll gets a map of all name/value pairs in the present context.
+func (cxt *ExecutionContext) GetAll() map[string]ContextValue {
+	return cxt.values
+}
+
+// Has is a special form of Get that also returns a flag indicating if the value
+// is found. This fetches the value and also returns a flag indicating if the
+// value was found. This is useful in cases where the value may legitimately be 0.
+func (cxt *ExecutionContext) Has(name string) (value ContextValue, found bool) {
+	value, found = cxt.values[name]
+	return
+}
+
+// Datasource get a datasource from the map of datasources.
+// A datasource (e.g., a connection to a database) is retrieved as an interface
+// so its type will need to be specified before it can be used. Take an example
+// of the variable foo that is a struct of type Foo.
+// foo = cxt.Datasource("foo").(*Foo)
+func (cxt *ExecutionContext) Datasource(name string) Datasource {
+	return cxt.datasources[name]
+}
+
+// Datasources gets the map of datasources.
+func (cxt *ExecutionContext) Datasources() map[string]Datasource {
+	return cxt.datasources
+}
+
+// HasDatasource checks whether the named datasource exists, and return it if it does.
+func (cxt *ExecutionContext) HasDatasource(name string) (Datasource, bool) {
+	value, found := cxt.datasources[name]
+	return value, found
+}
+
+// AddDatasource adds a datasource to the map of datasources.
+// A datasource is typically something like a connection to a database that you
+// want to keep open persistently and share between requests. To add a datasource
+// to the map just add it with a name. e.g. cxt.AddDatasource("mysql", foo) where
+// foo is the struct for the datasource.
+func (cxt *ExecutionContext) AddDatasource(name string, ds Datasource) {
+	cxt.datasources[name] = ds
+}
+
+// RemoveDatasource removes a datasouce from the map of datasources.
+func (cxt *ExecutionContext) RemoveDatasource(name string) {
+	delete(cxt.datasources, name)
+}
+
+// Logger gets a logger. The logging system can have one or more loggers that
+// are stored keyed by name.
+func (cxt *ExecutionContext) Logger(name string) (io.Writer, bool) {
+	writer, found := cxt.loggers.(*cio.MultiWriter).Writer(name)
+	return writer, found
+}
+
+// AddLogger adds a logger. The logging system can have one of more loggers keyed
+// by name.
+func (cxt *ExecutionContext) AddLogger(name string, logger io.Writer) {
+	cxt.loggers.(*cio.MultiWriter).AddWriter(name, logger)
+
+	// Waiting until the first logger is attached before telling the Go log
+	// system what the output is.
+	if cxt.loggerRegistered == false {
+		log.SetOutput(cxt.loggers)
+		cxt.loggerRegistered = true
+	}
+}
+
+// RemoveLogger removes a logger. The logging system can have one of more
+// loggers keyed by name.
+func (cxt *ExecutionContext) RemoveLogger(name string) {
+	cxt.loggers.(*cio.MultiWriter).RemoveWriter(name)
+}
+
+// SkipLogPrefix ignores logging messages to any of the given prefixes.
+//
+// While this is not a part of the Context interface, the
+// ExecutionContext allows you to ignore certain logging prefixes. For
+// example, to ignore the `debug` and `info` messages, you might want to do
+// something like this:
+//
+// 	cxt.(*ExecutionContext).SkipLogPrefix("debug", "info")
+// 	cxt.Logf("debug", "This message will be ignored.")
+//
+// In the above case, the subsequent call to `Logf()` is ignored.
+func (cxt *ExecutionContext) SkipLogPrefix(prefixes ...string) {
+	cxt.skiplist = make(map[string]bool, len(prefixes))
+	for _, pre := range prefixes {
+		cxt.skiplist[pre] = true
+	}
+}
+
+// Log logs a message to one of more loggers.
+func (cxt *ExecutionContext) Log(prefix string, v ...interface{}) {
+	if _, ok := cxt.skiplist[prefix]; ok {
+		return
+	}
+	tmpPrefix := log.Prefix()
+	log.SetPrefix(prefix)
+	log.Print(v...)
+	log.SetPrefix(tmpPrefix)
+}
+
+// Logf logs a message to one or more loggers and uses a format string.
+func (cxt *ExecutionContext) Logf(prefix string, format string, v ...interface{}) {
+	if _, ok := cxt.skiplist[prefix]; ok {
+		return
+	}
+	tmpPrefix := log.Prefix()
+	log.SetPrefix(prefix)
+	log.Printf(format, v...)
+	log.SetPrefix(tmpPrefix)
+}
+
+// Len returns the length of the context as in the length of the values stores.
+func (cxt *ExecutionContext) Len() int {
+	return len(cxt.values)
+}
+
+// Copy the context into a new context.
+func (cxt *ExecutionContext) Copy() Context {
+	newCxt := NewContext()
+	vals := cxt.GetAll()
+	ds := cxt.Datasources()
+
+	for k, v := range vals {
+		newCxt.Put(k, v)
+	}
+
+	for k, datasource := range ds {
+		newCxt.AddDatasource(k, datasource)
+	}
+
+	newEC := newCxt.(*ExecutionContext)
+	newEC.loggers = cxt.loggers 
+	newEC.skiplist = cxt.skiplist
+	newEC.loggerRegistered = cxt.loggerRegistered
+
+	return newCxt
+}

--- a/vendor/github.com/Masterminds/cookoo/context_test.go
+++ b/vendor/github.com/Masterminds/cookoo/context_test.go
@@ -1,0 +1,198 @@
+// Copyright 2013 Masterminds
+
+// This package provides the execution context for a Cookoo request.
+package cookoo
+
+import (
+	"bytes"
+	"log"
+	"reflect"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+// An example datasource as can add to our store.
+type ExampleDatasource struct {
+	name string
+}
+
+// A simple equal function.
+func equal(t *testing.T, a interface{}, b interface{}) {
+	result := reflect.DeepEqual(a, b)
+	if !result {
+		_, file, line, _ := runtime.Caller(1)
+		t.Errorf("Failed equals in %s:%d", file, line)
+	}
+}
+
+func TestDatasource(t *testing.T) {
+	foo := new(ExampleDatasource)
+	foo.name = "bar"
+
+	cxt := NewContext()
+
+	cxt.AddDatasource("foo", foo)
+
+	foo2 := cxt.Datasource("foo").(*ExampleDatasource)
+
+	equal(t, foo, foo2)
+	equal(t, "bar", foo2.name)
+
+	cxt.RemoveDatasource("foo")
+
+	equal(t, nil, cxt.Datasource("foo"))
+}
+
+func TestAddGet(t *testing.T) {
+	cxt := NewContext()
+
+	cxt.Put("test1", 42)
+	cxt.Put("test2", "Geronimo!")
+	cxt.Put("test3", func() string { return "Hello" })
+
+	// Test Get
+	equal(t, 42, cxt.Get("test1", nil))
+	equal(t, "Geronimo!", cxt.Get("test2", nil))
+
+	// Test has
+	val, ok := cxt.Has("test1")
+	if !ok {
+		t.Error("! Failed to get 'test1'")
+	}
+	equal(t, 42, cxt.Get("test1", nil))
+
+	_, ok = cxt.Has("test999")
+	if ok {
+		t.Error("! Unexpected result for 'test999'")
+	}
+
+	val, ok = cxt.Has("test3")
+	fn := val.(func() string)
+	if ok {
+		equal(t, "Hello", fn())
+	} else {
+		t.Error("! Expected a function.")
+	}
+
+	m := cxt.AsMap()
+	if m["test1"] != 42 {
+		t.Error("! Error retrieving context as a map.")
+	}
+}
+
+type LameStruct struct {
+	stuff []string
+}
+
+func TestCopy(t *testing.T) {
+	lame := new(LameStruct)
+	lame.stuff = []string{"O", "Hai"}
+	c := NewContext()
+	c.Put("a", lame)
+	c.Put("b", "This is the song that never ends")
+
+	foo := new(ExampleDatasource)
+	foo.name = "bar"
+	c.AddDatasource("foo", foo)
+
+	c2 := c.Copy()
+
+	c.Put("c", 1234)
+
+	if c.Len() != 3 {
+		t.Error("! Canary failed. c should be 3")
+	}
+
+	if c2.Len() != 2 {
+		t.Error("! c2 should be 2.")
+	}
+
+	c.Put("b", "FOO")
+	if c2.Get("b", nil) == "FOO" {
+		t.Error("! b should not have changed in C2.")
+	}
+
+	lame.stuff[1] = "Noes"
+
+	v1 := c2.Get("a", nil).(*LameStruct)
+	if v1.stuff[1] != "Noes" {
+		t.Error("! Expected shallow copy of array. Got ", v1)
+	}
+
+	d2 := new(ExampleDatasource)
+	d2.name = "bar"
+	c.AddDatasource("d2", d2)
+	_, found := c2.HasDatasource("d2")
+	if found == true {
+		t.Error("! Datasource inadvertently copied from one context to another.")
+	}
+}
+
+func TestLogging(t *testing.T) {
+	logger := new(bytes.Buffer)
+	c := NewContext()
+	c.AddLogger("test", logger)
+	foo, found := c.Logger("test")
+
+	if found == false {
+		t.Error("! Logger not found.")
+	}
+
+	if foo != logger {
+		t.Error("! Loggers do not match.")
+	}
+
+	logger2 := new(bytes.Buffer)
+	c.AddLogger("test2", logger2)
+
+	c.(*ExecutionContext).SkipLogPrefix("tinker", "bell")
+
+	log.Print("a test")
+	line := logger.String()
+	line = line[0 : len(line)-1]
+	pattern := "a test$"
+	matched, err := regexp.MatchString(pattern, line)
+	if err != nil {
+		t.Fatal("! Regex Pattern did not compile:", err)
+	}
+	if !matched {
+		t.Errorf("! Message was not logged to first test logger: %q", line)
+	}
+
+	logger2.Reset()
+	c.Log("foo", "this is a test")
+	line = logger2.String()
+	line = line[0 : len(line)-1]
+	pattern = "^foo.*this is a test$"
+	matched, err = regexp.MatchString(pattern, line)
+	if err != nil {
+		t.Fatal("! Regex Pattern did not compile:", err)
+	}
+	if !matched {
+		t.Errorf("! Log to second logger did not happen correctly: %q", line)
+	}
+
+	logger.Reset()
+	c.Logf("tinker", "ignore")
+	c.Logf("bar", "foo %d baz", 2)
+	c.Log("bell", "ignore")
+	line = logger.String()
+	line = line[0 : len(line)-1]
+	pattern = "^bar.*foo 2 baz$"
+	matched, err = regexp.MatchString(pattern, line)
+	if err != nil {
+		t.Fatal("! pattern did not compile:", err)
+	}
+	if !matched {
+		t.Errorf("! Logf to first logger did now happen correctly: %q", line)
+	}
+
+	c.RemoveLogger("test")
+	_, found = c.Logger("test")
+
+	if found == true {
+		t.Error("! Logger found but should have been removed.")
+	}
+
+}

--- a/vendor/github.com/Masterminds/cookoo/convert/commands.go
+++ b/vendor/github.com/Masterminds/cookoo/convert/commands.go
@@ -1,0 +1,25 @@
+package convert
+/*
+Conversion commands.
+
+Convert one type to another.
+
+This package provides conversions that can be used in chains of commands.
+*/
+
+import (
+	"github.com/Masterminds/cookoo"
+	"strconv"
+)
+
+// Convert a string to an integer.
+//
+// Params:
+// 	- str (string): A string that contains a number.
+//
+// Returns:
+// 	- An integer.
+func Atoi(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	src := p.Get("str", "0").(string)
+	return strconv.Atoi(src)
+}

--- a/vendor/github.com/Masterminds/cookoo/convert/commands_test.go
+++ b/vendor/github.com/Masterminds/cookoo/convert/commands_test.go
@@ -1,0 +1,26 @@
+package convert
+
+import (
+	"github.com/Masterminds/cookoo"
+	"testing"
+)
+
+func TestAtoi(t *testing.T) {
+	reg, router, c := cookoo.Cookoo()
+	reg.Route("test", "Test convert.").Does(Atoi, "i").Using("str").From("cxt:a")
+
+	c.Put("a", "100")
+	e := router.HandleRequest("test", c, false)
+
+	if e != nil {
+		t.Errorf("! Failed during HandleRequest: %s", e)
+		return
+	}
+	i, ok := c.Has("i")
+	if !ok {
+		t.Error("! Expected to find 'a' in context, but it was missing.")
+	}
+	if i.(int) != 100 {
+		t.Errorf("! Expected '100' to be converted to 100. Got %d", i)
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/cookoo.go
+++ b/vendor/github.com/Masterminds/cookoo/cookoo.go
@@ -1,0 +1,133 @@
+// Package cookoo is a Chain-of-Command (CoCo) framework for writing
+// applications.
+//
+// Tutorials
+//
+// * Building Web Apps with Cookoo: https://github.com/Masterminds/cookoo-web-tutorial
+//
+// * Building CLI Apps with Cookoo: https://github.com/Masterminds/cookoo-cli-tutorial
+//
+// A chain of command framework works as follows:
+//
+// 	* A "route" is constructed as a chain of commands -- a series of
+// 	single-purpose tasks that are run in sequence.
+// 	* An application is composed of one or more routes.
+// 	* Commands in a route communicate using a Context.
+// 	* An application Router is used to receive a route name and then
+// 	execute the appropriate chain of commands.
+//
+// To create a new Cookoo application, use cookoo.Cookoo(). This will
+// configure and create a new registry, request router, and context.
+// From there, use the Registry to build chains of commands, and then
+// use the Router to execute chains of commands.
+//
+// Unlike other CoCo implementations (like Pronto.js or Fortissimo),
+// Cookoo commands are just functions.
+//
+// Interrupts
+//
+// There are four types of interrupts that you may wish to return:
+//
+// 	1. FatalError: This will stop the route immediately.
+// 	2. RecoverableError: This will allow the route to continue moving.
+// 	3. Stop: This will stop the current request, but not as an error.
+// 	4. Reroute: This will stop executing the current route, and switch to executing another route.
+//
+// To learn how to write Cookoo applications, you may wish to examine
+// the small Skunk application: https://github.com/technosophos/skunk.
+package cookoo
+
+// VERSION provides the current version of Cookoo.
+const VERSION = "1.3.0"
+
+// Cookoo creates a new Cookoo app.
+//
+// This is the main progenitor of a Cookoo application. Whether a plain
+// Cookoo app, or a Web or CLI program, this is the function you will use
+// to bootstrap.
+//
+// The `*Registry` is used to declare new routes, where a "route" may be thought
+// of as a task composed of a series of steps (commands).
+//
+// The `*Router` is responsible for the actual execution of a Cookoo route. The
+// main method used to call a route is `Router.HandleRequest()`.
+//
+// The `Context` is a container for passing information down a chain of commands.
+// Apps may insert "global" information to a context at startup and make it
+// available to all commands.
+func Cookoo() (reg *Registry, router *Router, cxt Context) {
+	cxt = NewContext()
+	reg = NewRegistry()
+	router = NewRouter(reg)
+	return
+}
+
+// Command executes a command and returns a result.
+// A Cookoo app has a registry, which has zero or more routes. Each route
+// executes a sequence of zero or more commands. A command is of this type.
+type Command func(cxt Context, params *Params) (interface{}, Interrupt)
+
+// Interrupt is a generic return for a command.
+// Generally, a command should return one of the following in the interrupt slot:
+// - A FatalError, which will stop processing.
+// - A RecoverableError, which will continue the chain.
+// - A Reroute, which will cause a different route to be run.
+type Interrupt interface{}
+
+// Creates a new Reroute.
+func NewReroute(route string) *Reroute {
+	return &Reroute{route}
+}
+
+// Reroute is a command can return a Reroute to tell the router to execute a
+// different route.
+//
+// A `Command` may return a `Reroute` to cause Cookoo to stop executing the
+// current route and jump to another.
+//
+// 	func Forward(c Context, p *Params) (interface{}, Interrupt) {
+// 		return nil, &Reroute{"anotherRoute"}
+// 	}
+type Reroute struct {
+	Route string
+}
+
+// RouteTo returns the route to reroute to.
+func (rr *Reroute) RouteTo() string {
+	return rr.Route
+}
+
+// Stop a route, but not as an error condition.
+//
+// When Cookoo encounters a `Stop`, it will not execute any more commands on a
+// given route. However, it will not emit an error, either.
+type Stop struct{}
+
+// RecoverableError is an error that should not cause the router to stop processing.
+//
+// When Cookoo encounters a `RecoverableError`, it will log the error as a
+// warning, but will then continue to execute the next command in the route.
+type RecoverableError struct {
+	Message string
+}
+
+// Error returns the error message.
+func (err *RecoverableError) Error() string {
+	return err.Message
+}
+
+// FatalError is a fatal error, which will stop the router from continuing a route.
+//
+// When Cookoo encounters a `FatalError`, it will log the error and immediately
+// stop processing the route.
+//
+// Note that by default Cookoo treats and unhandled `error` as if it were a
+// `FatalError`.
+type FatalError struct {
+	Message string
+}
+
+// Error returns the error message.
+func (err *FatalError) Error() string {
+	return err.Message
+}

--- a/vendor/github.com/Masterminds/cookoo/cookoo_test.go
+++ b/vendor/github.com/Masterminds/cookoo/cookoo_test.go
@@ -1,0 +1,109 @@
+package cookoo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Example() {
+	// This is an admittedly contrived example in which we first store a
+	// "Hello World" message, and then tell the logger to get that stored
+	// message and write it to the log.
+	reg, router, cxt := Cookoo()
+	reg.AddRoute(Route{
+		Name: "hello",
+		Help: "Sends the log message 'Hello World'",
+		Does: Tasks{
+			// First, store the message "Hello World" in the context.
+			Cmd{
+				Name: "message",
+				Fn:   AddToContext,
+				Using: []Param{
+					Param{
+						Name:         "hello",
+						DefaultValue: "Hello World",
+					},
+				},
+			},
+			// Now get that message and write it to the log.
+			Cmd{
+				Name: "log",
+				Fn:   LogMessage,
+				Using: []Param{
+					Param{
+						Name: "msg",
+						From: "cxt:message",
+					},
+				},
+			},
+		},
+	})
+
+	router.HandleRequest("hello", cxt, false)
+}
+
+func ExampleCookoo() {
+	reg, router, cxt := Cookoo()
+	reg.AddRoute(Route{
+		// The name of the route. You execute routes by name. (See router.HandleRequest below)
+		Name: "hello",
+		// This is for documentation/help tools.
+		Help: "Print a message on standard output",
+
+		// This is a list of things you want this route to do. When executed,
+		// it will run these commands in order.
+		Does: Tasks{
+			// Declare a new command.
+			Cmd{
+				// Give the command a name. Programs reference command output
+				// by this name.
+				Name: "print",
+
+				// Tell Cookoo what function to execute when we get to this
+				// step.
+				//
+				// Usually we define functions elsewhere so we can re-use them.
+				Fn: func(c Context, p *Params) (interface{}, Interrupt) {
+					// Print whatever the content of the 'msg' parameter is.
+					fmt.Println(p.Get("msg", "").(string))
+					return nil, nil
+				},
+				// Send some parameters into Fn. Here we define the 'msg'
+				// parameter that Fn prints. While we just use a default
+				// value here, Cookoo can get that information from another
+				// source and then send it into Fn.
+				Using: []Param{
+					Param{
+						Name:         "msg",
+						DefaultValue: "Hello World",
+					},
+				},
+			},
+		},
+	})
+
+	// Now we execute the "hello" chain of commands.
+	router.HandleRequest("hello", cxt, false)
+	// Output:
+	// Hello World
+}
+
+func TestCookooForCoCo(t *testing.T) {
+	registry, router, cxt := Cookoo()
+
+	cxt.Put("Answer", 42)
+
+	lifeUniverseEverything := cxt.Get("Answer", nil)
+
+	if lifeUniverseEverything != 42 {
+		t.Error("! Context is not working.")
+	}
+
+	registry.Route("foo", "test")
+
+	ok := router.HasRoute("foo")
+
+	if !ok {
+		t.Error("! Router does not have 'foo' route.")
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/database/active/record.go
+++ b/vendor/github.com/Masterminds/cookoo/database/active/record.go
@@ -1,0 +1,82 @@
+// active package contains basic Active Record support.
+//
+// This package contains support for the design pattern called
+// "Active Record". This pattern combines a structural data representation
+// with the code necessary to persist the data.
+//
+// In the typical implementation, a record is stored in a relational
+// database, and each record corresponds to a row in the database. The
+// pattern here does not enforce use of an RDB. You may use whatever
+// storage you see fit.
+//
+// This is not an active record *implementation*. It is only a set of
+// interfaces describing what an active record should look like.
+//
+// Significantly, this does not specify how the record object obtains a
+// handle to the underlying database. The assumption is that a constructor
+// function will handle this detail.
+package active
+
+import (
+	"github.com/Masterminds/cookoo"
+)
+
+// Record describes the data storage methods on an active record.
+type Record interface {
+
+	// Insert adds a new record.
+	//
+	// Implementations *should* set an attribute to the value of the
+	// unique ID of the record.
+	Insert() error
+
+	// Update modifies an existing record.
+	Update() error
+	// Save creates a new record if non exists, and modifies an existing record.
+	//
+	// If a new record is created, implementations should set an attribute to the
+	// unique ID of the record.
+	Save() error
+
+
+	// Load should load the data from persistent storage and set the local
+	// attributes accordingly.
+	//
+	// For this to work correctly, it may require that the local unique ID attribute
+	// be manually set.
+	//
+	// Attribute values on the struct may be overwritten when this is executed.
+	//
+	// Load MUST NOT have side-effects when a load fails to find a record. It MUST
+	// NOT alter the existing record if it fails to find a new record.
+	//
+	// This allows the following desired behavior:
+	//
+	// 	r := NewRecord()
+	//  r.Id = someId
+	// 	r.Load()
+	// 	r.Save() // Creates record with someId if none was found.
+	Load() error
+
+}
+
+// Records describes the data access methods on a collection of records.
+type Records interface {
+	// Fetch all of the records of this type.
+	All() ([]interface{}, error)
+	// Fetch paged records for this type.
+	Paged(offset, limit int) ([]interface{}, error)
+	// Find all records that map the given filter.
+	// Find(filter map[string]interface{}, offset, limit int) ([]interface{}, error)
+}
+
+// Load loads an already initialized record.
+func Load(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	r := p.Get("record", nil).(Record)
+	return r, r.Load()	
+}
+
+func Save(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	r := p.Get("record", nil).(Record)
+	return r, r.Save()	
+}

--- a/vendor/github.com/Masterminds/cookoo/database/sql/commands.go
+++ b/vendor/github.com/Masterminds/cookoo/database/sql/commands.go
@@ -1,0 +1,111 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/Masterminds/cookoo"
+	"strings"
+)
+
+// Ping a database.
+//
+// If the Ping fails, this will return an error.
+//
+// Params
+// - dbname: (required) the name of the database datasource.
+//
+// Returns:
+// - boolean flag set to true if the Ping was successful.
+func Ping(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	ok, _ := params.Requires("dbname")
+	if !ok {
+		e := &cookoo.RecoverableError{"Expected a dbname param."}
+		return false, e
+	}
+
+	dbname := params.Get("dbname", nil).(string)
+
+	db, err := GetDb(cxt, dbname)
+	if err != nil {
+		return false, err
+	}
+
+	err = db.Ping()
+
+	if err != nil {
+		return fatalError(err)
+	}
+	return true, nil
+}
+
+// A command that can be used during a shutdown chain.
+//
+// Params:
+// - dbname (required): the name of the db datasource.
+func Close(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	ok, _ := params.Requires("dbname")
+	if !ok {
+		return nil, &cookoo.FatalError{"Expected dbname param."}
+	}
+
+	dbname := params.Get("dbname", nil).(string)
+
+	db, err := GetDb(cxt, dbname)
+	if err != nil {
+		return fatalError(err)
+	}
+	return nil, db.Close()
+}
+
+// This is a utility function for executing statements.
+//
+// While we don't wrap all SQL statements, this particular command is here to
+// facilitate creating databases. In other situations, it is assumed that the
+// commands will handle SQL internally, and not use high-level commands to run
+// each query.
+//
+// Params:
+// - "statement": The statement to execute (as a string)
+// - "dbname": The name of the datasource that references the DB.
+//
+// Returns:
+// - database.sql.Result (core Go API)
+//
+// Example:
+//	req.Route("install", "Create DB").
+//		Does(sql.Execute, "exec").
+//		Using("dbname").WithDefault("db").
+//		Using("statement").WithDefault("CREATE TABLE IF NOT EXISTS names (id INT, varchar NAME)")
+func Execute(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	ok, missing := params.Requires("statement", "dbname")
+	if !ok {
+		return nil, &cookoo.FatalError{fmt.Sprintf("Missing params: %s", strings.Join(missing, ","))}
+	}
+
+	dbname := params.Get("dbname", nil).(string)
+	statement := params.Get("statement", nil).(string)
+	db, err := GetDb(cxt, dbname)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := db.Exec(statement)
+	if err != nil {
+		return fatalError(err)
+	}
+
+	return res, nil
+}
+
+// Utility function to get the database from a datasource.
+func GetDb(cxt cookoo.Context, dbname string) (*sql.DB, error) {
+	dbO, ok := cxt.HasDatasource(dbname)
+	if !ok {
+		return nil, &cookoo.FatalError{fmt.Sprintf("No DB datasource named '%s' found.", dbname)}
+	}
+	return dbO.(*sql.DB), nil
+}
+
+func fatalError(err error) (interface{}, *cookoo.FatalError) {
+	return nil, &cookoo.FatalError{fmt.Sprintf("%v", err)}
+}

--- a/vendor/github.com/Masterminds/cookoo/database/sql/datasource.go
+++ b/vendor/github.com/Masterminds/cookoo/database/sql/datasource.go
@@ -1,0 +1,134 @@
+// SQL datasource and commands for Cookoo.
+// This provides basic SQL support for Cookoo.
+package sql
+
+import (
+	dbsql "database/sql"
+	"sync"
+)
+
+// NewDbDatasource creates a new SQL datasource.
+//
+// Currently, this returns an actual *"database/sql".Db instance. Note that
+// you do not *need* to use this function in order to create a new database
+// datasource. You can simply place a database handle into the context
+// as a datasource.
+//
+// Example:
+//	ds, err := sql.NewDatasource("mysql", "root@/mpbtest")
+//	if err != nil {
+//		panic("Could not create a database connection.")
+//		return
+//	}
+//
+//	cxt.AddDatasource("db", ds)
+//
+// In the example above, we create a new datasource and then add it to
+// the context. This should be done at server init, before web.Serve
+// or router.HandleRequest().
+func NewDbDatasource(driverName, datasourceName string) (*dbsql.DB, error) {
+	return dbsql.Open(driverName, datasourceName)
+}
+
+// NewStmtCache creates a new cache for prepared statements.
+//
+// Initial capacity determines how big the cache will be.
+//
+// Warning: The implementation of the caching layer will likely
+// change from relatively static to an LRU. To avoid memory leaks, the
+// statement cache will automatically clear itself each time it hits
+// 1000 distinct statements.
+func NewStmtCache(dbHandle *dbsql.DB, initialCapacity int) StmtCache {
+	c := new(StmtCacheMap)
+	c.cache = make(map[string]*dbsql.Stmt, initialCapacity)
+	c.capacity = initialCapacity
+	c.dbh = dbHandle
+
+	return c
+}
+
+// A StmtCache caches SQL prepared statements.
+//
+// It's intended use is as a datsource for a long-running SQL-backed
+// application. Prepared statements can exist across requests and be
+// shared by separate goroutines. For frequently executed statements,
+// this is both more performant and more secure (at least for some
+// drivers).
+//
+// IMPORTANT: Statments are cached by string key, so it is important that to
+// get the most out of the cache, you re-use the same strings. Otherwise,
+// 'SELECT surname, name FROM names' will generate a different cache entry
+// than 'SELECT name, surname FROM names'.
+//
+// The cache is driver-agnostic.
+type StmtCache interface {
+	Prepare(statement string) (*dbsql.Stmt, error)
+	Clear() error
+}
+
+type StmtCacheMap struct {
+	cache    map[string]*dbsql.Stmt
+	capacity int
+	dbh      *dbsql.DB
+	mu sync.Mutex
+}
+
+// Deprecated. Use Prepare()
+/*
+func (c *StmtCacheMap) Get(statement string) (*dbsql.Stmt, error) {
+	return c.Prepare(statement)
+}
+*/
+
+// Prepare gets a prepared statement from a SQL string.
+//
+// This will return a cached statement if one exists, otherwise
+// this will generate one, insert it into the cache, and return
+// the new statement.
+//
+// It is assumed that the underlying database layer can handle
+// parallelism with prepared statements, and we make no effort
+// to deal with locking or synchronization.
+// For compatibility with database/sql.DB.Prepare
+func (c *StmtCacheMap) Prepare(statement string) (*dbsql.Stmt, error) {
+	// Protect the statment cache.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if stmt, ok := c.cache[statement]; ok {
+		return stmt, nil
+	}
+	// Else we prepare the statement and then cache it.
+	stmt, err := c.dbh.Prepare(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hack: Until we have a statement cache, we stop memory leaks by clearing
+	// the entire cache when it hits 1000.
+	if len(c.cache) > 1000 {
+		c.cache = make(map[string]*dbsql.Stmt, c.capacity)
+	}
+
+	// Cache by string key.
+	c.cache[statement] = stmt
+	return stmt, nil
+}
+
+// Clear clears the cache.
+//
+// Right now, it is suggested that the 
+func (c *StmtCacheMap) Clear() error {
+	// While I don't think this is a good idea, it might be necessary. On the
+	// flip side, it might cause race conditions if one goroutine is running
+	// a query while another is clearing the cache. For now, leaving this
+	// to the memory manager.
+	//for _, stmt := range c.cache {
+	//	stmt.Close()
+	//}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache = make(map[string]*dbsql.Stmt, c.capacity)
+	return nil
+}

--- a/vendor/github.com/Masterminds/cookoo/database/sql/datasource_test.go
+++ b/vendor/github.com/Masterminds/cookoo/database/sql/datasource_test.go
@@ -1,0 +1,12 @@
+package sql
+
+import (
+	"testing"
+)
+
+func TestSqlDatasource(t *testing.T) {
+	// Canary
+
+	// TODO: Need to find a testing database layer to test building a
+	// statement cache.
+}

--- a/vendor/github.com/Masterminds/cookoo/doc/README.md
+++ b/vendor/github.com/Masterminds/cookoo/doc/README.md
@@ -1,0 +1,1 @@
+Placeholder for documentation.

--- a/vendor/github.com/Masterminds/cookoo/doc/cli.md
+++ b/vendor/github.com/Masterminds/cookoo/doc/cli.md
@@ -1,0 +1,233 @@
+# Writing a CLI
+
+**Note:** There is now an official [CLI Tutorial](https://github.com/Masterminds/cookoo-cli-tutorial)
+that explains by example how to build Cookoo CLIs.
+
+The shortest Cookoo CLI you can write is this:
+
+```go
+package main
+
+import (
+	"github.com/Masterminds/cookoo"
+	"github.com/Masterminds/cookoo/cli"
+)
+
+func main() {
+	cli.New(cookoo.Cookoo()).Run("help")
+}
+```
+
+This, however, doesn't do much. It simply prints the generic help text
+and exits.
+
+## New-Style (Simple) CLI
+
+The new-style CLI is great for building either a simple single-command
+CLI or a more complex command with subcommands.
+
+Here is a more representative CLI app:
+
+```go
+package main
+
+import (
+	"github.com/Masterminds/cookoo"
+	"github.com/Masterminds/cookoo/cli"
+	"github.com/Masterminds/cookoo/fmt"
+
+	"flag"
+)
+
+var Summary = "Example CLI"
+var Description = "Full help text goes here."
+
+func main() {
+	reg, router, cxt := cookoo.Cookoo()
+
+  // Create flags
+	flags := flag.NewFlagSet("global", flag.PanicOnError)
+	flags.Bool("h", false, "Show help")
+
+	// A simple hello world route
+	reg.Route("hello", "Show hello message").
+		Does(fmt.Printf, "out").Using("format").WithDefault("Hello World\n")
+
+  // This creates and executes a CLI app.
+	cli.New(reg, router, cxt).Help(Summary, Description, flags).Run("hello")
+}
+```
+
+Assuming the above has been compiled into `example`, here are the ways
+the above could be called:
+
+```
+$ example     # Prints "Hello World"
+$ example -h  # Prints help text
+```
+
+With a small change, we can re-build our app to support subcommands. We
+can change the last line of the `main()` function to this:
+
+```go
+cli.New(reg, router, cxt).Help(Summary, Description, flags).RunSubcommand
+```
+
+Now we can call it in the following ways:
+
+```
+$ example        # Prints help text
+$ example -h     # Prints help text
+$ example help   # Prints help text
+$ example hello  # Prints "Hello World"
+```
+
+This is all you need to begin writing new-style CLI apps.
+
+### A Few Helpful Facts
+
+- The context (`cxt`) contains `os.Args` and `runner.Args`, where the
+  first is the OS args, and the second are the args remaining after
+  flags are parsed.
+- The flags are always available in the context as `globalFlags`.
+- While you are **strongly** encouraged to use `Runner.Help()`, if you
+  don't, very basic help text will be generated.
+- If you want to use flags on your subcommands, you can parse those
+  using the `cli.ParseArgs` command on your route. Pass it
+  `runner.Args`.
+
+Everything else in this document describes complex use cases.
+
+## Old-style or Special Case CLIs
+
+Here is a basic scaffold of a CLI application that uses subcommands.
+Here, we're building the command `foo` that has the subcommand `bar`,
+which can be invoked like this from tthe commandline: `foo bar`.
+
+foo.go:
+```go
+package main
+
+import(
+  "github.com/Masterminds/cookoo"
+  "github.com/Masterminds/cookoo/cli"
+  "fmt"
+  "os"
+)
+
+func main() {
+	// Start a cookoo app.
+	reg, router, cxt := cookoo.Cookoo();
+
+	// Put the arguments into the context.
+	cxt.Put("os.Args", os.Args)
+
+	// Create help text
+	reg.Route("help", "Show application-scoped help.").
+		Does(cli.ShowHelp, "help").
+			Using("show").WithDefault(true).
+			Using("summary").WithDefault("This is the help text.")
+
+	// Handle the "bar" subcommand
+	reg.Route("bar", "Do something").
+		Does(MyBarCommand, "bar")
+
+	// This is the main runner. It proxies to subcommands.
+	reg.Route("run", "Run the app.").
+		// Shift off two args: the app name and then the subcommand.
+		// The subcommand is then put in the context as "subcommand"
+		Does(cli.ShiftArgs, "subcommand").
+			Using("n").WithDefault(2).
+		Does(cookoo.ForwardTo, "sub").
+			Using("route").From("cxt:subcommand").WithDefault("help").
+			Using("ignoreRoutes").WithDefault([]string{"subcommand"}).
+
+	// This starts the app.	If a fatal error occurs, we
+	// display the error.
+	e := router.HandleRequest("run", cxt, true)
+	if e != nil {
+		fmt.Printf("Error: %s\n", e)
+	}
+}
+
+// This is our command.
+func MyBarCommand(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	fmt.Printf("OH HAI")
+	return nil, nil
+}
+```
+
+When we run `foo bar` (or `go run foo.go bar`), here's what happens:
+
+1. main() is run. It creates a Cookoo app, defines the registry, and
+   then runs `router.HandleRequest("run", ...)`
+2. The "run" route is run. This reads the `os.Args` and sees that it
+   should execute the subcommand `bar`.
+3. The "bar" route is run, which executes it's one command:
+   `MyBarCommand`.
+4. `MyBarCommand` runs, printing "OH HAI" to stdout.
+
+If you were to run `foo` or `foo help`, then the chain would execute
+like this:
+
+1. main() runs, and passes to `router.HandleRequest("run"...)
+2. "run" will execute `ShiftArgs` and then `ForwardTo`, which will resolve the subcommand
+   to "help" (which is the default target).
+3. The "help" route will be run, which will print out simple help:
+
+```
+go run foo.go
+SUMMARY
+
+This is the help text.
+```
+
+## Using Flags (Advanced)
+
+Go provides the `flag` package with many utilities for working with
+command-line flags. We can use those in Cookoo.
+
+Here's a snippet of code that could be worked into the previous example:
+
+``` 
+	reg.Route("add-user", "Add a new account.").
+		Does(cli.ParseArgs, "args").
+			Using("flagset").WithDefault(AddUserFlags()).
+			Using("args").From("cxt:os.Args").
+		Does(cli.ShowHelp, "help").
+			Using("show").From("cxt:h").
+			Using("summary").WithDefault("Add a new account.").
+			Using("usage").WithDefault("tool add-user -a NAME -p PASSWORD").
+			Using("flags").WithDefault(AccountAddFlags()).
+		// ... do the rest...
+```
+
+With the example above, we can generate our flags like this:
+
+```
+func AddUserFlags() *flag.FlagSet {
+	flags := flag.NewFlagSet("account", flag.PanicOnError)
+	flags.Bool("h", false, "Print help text.")
+	flags.String("a", nil, "Account name.")
+	flags.String('p', nil, "User's new password.")
+
+	return flags
+}
+```
+
+The arguments are parsed by `cli.ParseArgs`. Each flag is then placed
+directly into the context. (See how we access `-h` with `From(cxt:h)`
+above?)
+
+In addition to using flags for processing, `cli.ShowHelp` can take a
+`*flag.FlagSet` and automatically generate help text.
+
+While this example shows providing flags for subcommands, higher level
+flags can be handled in much the same way. For example, we could use
+them in our `run` route, too.
+
+
+## Where to from here?
+
+From this starting point, you should be able to assemble your own
+routes, where each new route represents a subcommand.

--- a/vendor/github.com/Masterminds/cookoo/doc/webserver.go
+++ b/vendor/github.com/Masterminds/cookoo/doc/webserver.go
@@ -1,0 +1,39 @@
+/* Examples and documentation for Cookoo.
+*/
+package main
+
+import (
+	"github.com/Masterminds/cookoo"
+	"github.com/Masterminds/cookoo/web"
+	"github.com/Masterminds/cookoo/fmt"
+)
+
+// main is an example of a simple Web server written in Cookoo.
+func main() {
+	// First, we create a new Cookoo app.
+	reg, router, cxt := cookoo.Cookoo()
+
+	// We declare a route that answers GET requests for the path /
+	//
+	// By default, this will be running on http://localhost:8080/
+	reg.Route("GET /", "Simple test route.").
+		Does(web.Flush, "out").
+			Using("content").WithDefault("OH HAI!")
+
+	// We declare a route that answers GET requests for the path /test
+	// This one uses a basic template.
+	//
+	// By default, this will be running on http://localhost:8080/
+	//
+	// Because we use `query:you`, try hitting the app on this URL:
+	// http://localhost:8080/test?you=Matt
+	reg.Route("GET /test", "Simple test route.").
+		Does(fmt.Template, "content").
+			Using("template").WithDefault("Hello {{.you}}").
+		Using("you").WithDefault("test").From("query:you").
+		Does(web.Flush, "out").
+			Using("content").From("cxt:content")
+
+	// Start the server.
+	web.Serve(reg, router, cxt)
+}

--- a/vendor/github.com/Masterminds/cookoo/env.sh
+++ b/vendor/github.com/Masterminds/cookoo/env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+here=$(pwd)
+export GOPATH=$GOPATH:$here
+export PATH=$PATH:$here/bin

--- a/vendor/github.com/Masterminds/cookoo/example/example.go
+++ b/vendor/github.com/Masterminds/cookoo/example/example.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	// This is the path to Cookoo
+	"fmt"
+	"github.com/Masterminds/cookoo"
+)
+
+func main() {
+
+	// Build a new Cookoo app.
+	registry, router, context := cookoo.Cookoo()
+
+	// Fill the registry.
+	registry.AddRoutes(
+		cookoo.Route{
+			Name: "TEST",
+			Help: "A test route",
+			Does: cookoo.Tasks{
+				cookoo.Cmd{
+					Name: "hi",
+					Fn:   HelloWorld,
+				},
+			},
+		},
+	)
+
+	// Execute the route.
+	router.HandleRequest("TEST", context, false)
+}
+
+func HelloWorld(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	fmt.Println("Hello World")
+	return true, nil
+}

--- a/vendor/github.com/Masterminds/cookoo/fmt/fmt.go
+++ b/vendor/github.com/Masterminds/cookoo/fmt/fmt.go
@@ -1,0 +1,166 @@
+/* The Cookoo `fmt` package provides utility wrappers for formatting text.
+
+The commands in this package provide simple string formatting and printing
+at the command level.
+
+For convenience, a basic "text/template" wrapper is included in this library,
+though a more robust "html/template" set of commands are provided in
+"github.com/Masterminds/cookoo/web".
+
+Example usage:
+
+	reg.Route("test", "Test").
+	Does(Template, "out").
+	Using("template").WithDefault("{{.Hello}} {{.one}}").
+	Using("Hello").WithDefault("Hello").
+	Using("one").WithDefault(1)
+
+Or
+
+	reg.Route("test", "Test").
+	Does(Sprintf, "out").
+	Using("format").WithDefault("%s %d").
+	Using("0").WithDefault("Hello").
+	Using("1").WithDefault(1)
+
+
+*/
+package fmt
+
+import (
+	"github.com/Masterminds/cookoo"
+	"text/template"
+	"crypto/md5"
+	"bytes"
+	"fmt"
+)
+
+// Template is a template-based text formatter.
+//
+// This uses the core `text/template` to process a given string template.
+//
+// Params
+// 	- template (string): A template string.
+// 	- template.Context (bool): If true, the context will be placed into the
+// 		template renderer as 'Cxt', and can be used as `{{.Cxt.Foo}}`. False
+// 		by default.
+// 	- ... (interface{}): Values passed into the template.
+//
+// Conventionally, template variables should start with an initial capital.
+//
+// Returns a formatted string.
+func Template(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	format := cookoo.GetString("template", "", p)
+	withCxt := cookoo.GetBool("template.Context", false, p)
+
+	name := fmt.Sprintf("%x", md5.Sum([]byte(format)))
+
+	//c.Logf("debug", "Template %s is '%s'\n", name, format)
+
+	tpl, err := template.New(name).Parse(format)
+	if err != nil {
+		return "", err
+	}
+
+	data := p.AsMap()
+	if withCxt {
+		//c.Logf("debug", "Adding context.")
+		data["Cxt"] = c.AsMap()
+	}
+
+	var out bytes.Buffer
+	if err := tpl.Execute(&out, data); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}
+
+// Println prints a string to standard output, and appends a newline.
+//
+// Also see web.Flush.
+//
+// Params:
+// 	- content (string): The string to print.
+func Println(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	msg := cookoo.GetString("content", "", p)
+	fmt.Println(msg)
+	return msg, nil
+}
+
+// Printf formats a string and then sends it to standard out.
+//
+// This is a command wrapper for the core `fmt.Printf` function, but tooled
+// to work the Cookoo way.
+//
+// The following prints 'Hello' to standard out.
+//
+// 	//...
+// 	Does(Printf, "out").
+// 	Using("format").WithDefault("%s\n")
+// 	Using("0").WithDefault("Hello")
+//
+// Params:
+// 	- format (string): The format string
+// 	- "0"... (string): String representation of an integer ascending from 0.
+// 	  These are treated as positional.
+func Printf(c cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	msg := params.Get("format", "").(string)
+
+	maxP := len(params.AsMap())
+	vals := make([]interface{}, 0, maxP - 1)
+
+	var istr string
+	var i = 0
+	for i < maxP {
+		istr = fmt.Sprintf("%d", i) // FIXME
+		if v, ok := params.Has(istr); ok {
+			//fmt.Printf("%d: Found %v\n", i, v)
+			vals = append(vals, v)
+			i++
+		} else {
+			break
+		}
+	}
+	fmt.Printf(msg, vals...)
+	return true, nil
+}
+// Sprintf formats a string and then returns the result to the context.
+//
+// This is a command wrapper for the core `fmt.Sprintf` function, but tooled
+// to work the Cookoo way.
+//
+// The following returns 'Hello World' to the context.
+//
+// 	//...
+// 	Does(Sprintf, "out").
+// 	Using("format").WithDefault("%s %s\n")
+// 	Using("0").WithDefault("Hello")
+// 	Using("1").WithDefault("World")
+//
+// Params:
+// 	- format (string): The format string
+// 	- "0"... (string): String representation of an integer ascending from 0.
+// 	  These are treated as positional.
+func Sprintf(c cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	msg := params.Get("format", "").(string)
+
+	maxP := len(params.AsMap())
+	vals := make([]interface{}, 0, maxP - 1)
+
+	var istr string
+	var i = 0
+	for i < maxP {
+		istr = fmt.Sprintf("%d", i) // FIXME
+		if v, ok := params.Has(istr); ok {
+			//fmt.Printf("%d: Found %v\n", i, v)
+			vals = append(vals, v)
+			i++
+		} else {
+			break
+		}
+	}
+
+	return fmt.Sprintf(msg, vals...), nil
+}
+

--- a/vendor/github.com/Masterminds/cookoo/fmt/fmt_test.go
+++ b/vendor/github.com/Masterminds/cookoo/fmt/fmt_test.go
@@ -1,0 +1,56 @@
+package fmt
+
+import (
+	"github.com/Masterminds/cookoo"
+	"testing"
+)
+
+func TestSprintf(t *testing.T) {
+	reg, router, cxt := cookoo.Cookoo();
+
+	reg.Route("test", "Test").
+	Does(Sprintf, "out").
+	Using("format").WithDefault("%s %d").
+	Using("0").WithDefault("Hello").
+	Using("1").WithDefault(1)
+
+	if err := router.HandleRequest("test", cxt, false); err != nil {
+		t.Errorf("Failed route: %s", err)
+	}
+
+	if res := cxt.Get("out", "absolutely nothin"); res != "Hello 1" {
+		t.Errorf("Expected 'Hello 1', got %s", res)
+	}
+}
+
+func TestTemplate(t *testing.T) {
+	reg, router, cxt := cookoo.Cookoo();
+
+	reg.Route("test", "Test").
+	Does(Template, "out").
+	Using("template").WithDefault("{{.Hello}} {{.one}}").
+	Using("Hello").WithDefault("Hello").
+	Using("one").WithDefault(1)
+
+	if err := router.HandleRequest("test", cxt, false); err != nil {
+		t.Errorf("Failed route: %s", err)
+	}
+
+	if res := cxt.Get("out", "nada"); res != "Hello 1" {
+		t.Errorf("Expected 'Hello 1', got %s", res)
+	}
+
+	reg.Route("test2", "Test 2").
+	Does(cookoo.AddToContext, "_").Using("Foo").WithDefault("lambkin").
+	Does(Template, "out2").
+	Using("template.Context").WithDefault(true).
+	Using("template").WithDefault("Hello {{.Cxt.Foo}}")
+
+	if err := router.HandleRequest("test2", cxt, false); err != nil {
+		t.Errorf("Failed route: %s", err)
+	}
+
+	if res := cxt.Get("out2", "nada"); res != "Hello lambkin" {
+		t.Errorf("Expected 'Hello lambkin', got %s", res)
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/getter.go
+++ b/vendor/github.com/Masterminds/cookoo/getter.go
@@ -1,0 +1,294 @@
+package cookoo
+
+/*
+This file contains mainly convenience functions for working with Params,
+Context, and KeyValueDatasource.
+
+Many of these functions are forward-looking to Cookoo 2.x, where Context and
+KeyValueDatasource will both be Getter implementations.
+*/
+
+import (
+	"reflect"
+)
+
+// Getter can get values in two ways.
+//
+// A Get() can be given a default value, in which case it will return either
+// the value associated with the key or, if that's not found, the default value.
+//
+// A Has() doesn't take a default value, but instead returns both the value
+// (if found) and a boolean flag indicating whether it is found.
+//
+// In Cookoo 1.x, Context's Get() function returns a ContextValue instead of
+// an interface. For that reason, you may need to wrap Cxt in GettableCxt
+// to make it a true Getter.
+//
+// In Cookoo 1.x, KeyValueDatasource uses Value() instead of Get()/Has(). For
+// that reason, you can wrap a KeyValueDatasource in a GettableDS() to make
+// it behave like a Getter.
+type Getter interface {
+	Get(string, interface{}) interface{}
+	Has(string) (interface{}, bool)
+}
+
+// GettableDS makes a KeyValueDatasource into a Getter.
+//
+// This is forward-compatibility code, and will be rendered unnecessary in
+// Cookoo 2.x.
+func GettableDS(ds KeyValueDatasource) Getter {
+	return &gettableDatasource{ds}
+}
+
+// GettableCxt makes a Context into a Getter.
+//
+// This is forward-compatibility code, and will be rendered unnecessary in
+// Cookoo 2.x.
+func GettableCxt(cxt Context) Getter {
+	return &gettableContext{cxt}
+}
+
+// GettableDatasource Makes a KeyValueDatasource match the Getter interface.
+//
+// In future versions of Cookoo, core Datasources will directly implement Getter.
+type gettableDatasource struct {
+	KeyValueDatasource
+}
+
+func (g *gettableDatasource) Get(key string, defaultVal interface{}) interface{} {
+	ret := g.KeyValueDatasource.Value(key)
+	if ret == nil || !reflect.ValueOf(ret).IsValid() {
+		return defaultVal
+	}
+	return ret
+}
+
+func (g *gettableDatasource) Has(key string) (interface{}, bool) {
+	ret := g.KeyValueDatasource.Value(key)
+	if ret == nil || !reflect.ValueOf(ret).IsValid() {
+		return nil, false
+	}
+	return ret, true
+}
+
+// GettableContext wraps a context and makes it a Getter.
+// Since Context returns ContextValue objects, we have to write this stupid wrapper.
+type gettableContext struct {
+	Context
+}
+
+func (g *gettableContext) Get(key string, defaultVal interface{}) interface{} {
+	return g.Context.Get(key, defaultVal)
+}
+
+func (g *gettableContext) Has(key string) (interface{}, bool) {
+	return g.Context.Has(key)
+}
+
+// GetString is a convenience function for getting strings.
+//
+// This simplifies getting strings from a Context, a Params, or a
+// GettableDatasource.
+func GetString(key, defaultValue string, source Getter) string {
+	out := source.Get(key, defaultValue)
+	ret, ok := out.(string)
+	if !ok {
+		return defaultValue
+	}
+	return ret
+}
+
+// GetBool gets a boolean value from any Getter.
+func GetBool(key string, defaultValue bool, source Getter) bool {
+	out := source.Get(key, defaultValue)
+	ret, ok := out.(bool)
+	if !ok {
+		return defaultValue
+	}
+	return ret
+}
+
+// GetInt gets an int from any Getter.
+func GetInt(key string, defaultValue int, source Getter) int {
+	out := source.Get(key, defaultValue)
+	ret, ok := out.(int)
+	if !ok {
+		return defaultValue
+	}
+	return ret
+}
+
+// GetInt64 gets an int64 from any Getter.
+func GetInt64(key string, defaultValue int64, source Getter) int64 {
+	out := source.Get(key, defaultValue)
+	ret, ok := out.(int64)
+	if !ok {
+		return defaultValue
+	}
+	return ret
+}
+
+// GetInt32 gets an int32 from any Getter.
+func GetInt32(key string, defaultValue int32, source Getter) int32 {
+	out := source.Get(key, defaultValue)
+	ret, ok := out.(int32)
+	if !ok {
+		return defaultValue
+	}
+	return ret
+}
+
+// GetUint64 gets a uint64 from any Getter.
+func GetUint64(key string, defaultVal uint64, source Getter) uint64 {
+	out := source.Get(key, defaultVal)
+	ret, ok := out.(uint64)
+	if !ok {
+		return defaultVal
+	}
+	return ret
+}
+
+// GetFloat64 gets a float64 from any Getter.
+func GetFloat64(key string, defaultVal float64, source Getter) float64 {
+	out := source.Get(key, defaultVal)
+	ret, ok := out.(float64)
+	if !ok {
+		return defaultVal
+	}
+	return ret
+}
+
+// HasString is a convenience function to perform Has() and return a string.
+func HasString(key string, source Getter) (string, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return "", ok
+	}
+	strval, kk := v.(string)
+	if !kk {
+		return "", kk
+	}
+	return strval, kk
+}
+
+// HasBool returns the value and a flag indicated whether the flag value was found.
+//
+// Default value is false if ok is false.
+func HasBool(key string, source Getter) (bool, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return false, ok
+	}
+	strval, kk := v.(bool)
+	if !kk {
+		return false, kk
+	}
+	return strval, kk
+}
+
+// HasInt returns the int value for key, and a flag indicated if it was found.
+//
+// If ok is false, the int value will be 0
+func HasInt(key string, source Getter) (int, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return 0, ok
+	}
+	val, kk := v.(int)
+	if !kk {
+		return 0, kk
+	}
+	return val, kk
+}
+
+// HasInt64 returns the int64 value for key, and a flag indicated if it was found.
+//
+// If ok is false, the int value will be 0
+func HasInt64(key string, source Getter) (int64, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return 0, ok
+	}
+	val, kk := v.(int64)
+	if !kk {
+		return 0, kk
+	}
+	return val, kk
+}
+
+// HasInt32 returns the int32 value for key, and a flag indicated if it was found.
+//
+// If ok is false, the int value will be 0
+func HasInt32(key string, source Getter) (int32, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return 0, ok
+	}
+	val, kk := v.(int32)
+	if !kk {
+		return 0, kk
+	}
+	return val, kk
+}
+
+// HasUint64 returns the uint64 value for key, and a flag indicated if it was found.
+//
+// If ok is false, the int value will be 0
+func HasUint64(key string, source Getter) (uint64, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return 0, ok
+	}
+	val, kk := v.(uint64)
+	if !kk {
+		return 0, kk
+	}
+	return val, kk
+}
+
+// HasFloat64 returns the float64 value for key, and a flag indicated if it was found.
+//
+// If ok is false, the float value will be 0
+func HasFloat64(key string, source Getter) (float64, bool) {
+	v, ok := source.Has(key)
+	if !ok {
+		return 0, ok
+	}
+	val, kk := v.(float64)
+	if !kk {
+		return 0, kk
+	}
+	return val, kk
+}
+
+// GetFromFirst gets the value from the first Getter that has the key.
+//
+// This provides a method for scanning, for example, Params, Context, and
+// KeyValueDatasource and returning the first one that matches.
+//
+// If no Getter has the key, the default value is returned, and the returned
+// Getter is an instance of DefaultGetter.
+func GetFromFirst(key string, defaultVal interface{}, sources ...Getter) (interface{}, Getter) {
+	for _, s := range sources {
+		val, ok := s.Has(key)
+		if ok {
+			return val, s
+		}
+	}
+
+	return defaultVal, &DefaultGetter{defaultVal}
+}
+
+// DefaultGetter represents a Getter instance for a default value.
+//
+// A default getter always returns the given default value.
+type DefaultGetter struct {
+	val interface{}
+}
+
+func (e *DefaultGetter) Get(name string, value interface{}) interface{} {
+	return e.val
+}
+func (e *DefaultGetter) Has(name string) (interface{}, bool) {
+	return e.val, true
+}

--- a/vendor/github.com/Masterminds/cookoo/getter_test.go
+++ b/vendor/github.com/Masterminds/cookoo/getter_test.go
@@ -1,0 +1,103 @@
+package cookoo
+
+import "testing"
+
+type testDs struct {
+	val string
+}
+func (d *testDs) Value(key string) interface{} {
+	return d.val
+}
+
+func TestGettableDS (t *testing.T) {
+
+	ds := &testDs{"hello"}
+	gds := GettableDS(ds)
+
+	if "hello" != gds.Get("foo", "bar").(string) {
+		t.Error("Expected hello.")
+	}
+}
+func TestGettableContext (t *testing.T) {
+
+	c := NewContext()
+	c.Put("foo", "hello")
+	gcx := GettableCxt(c)
+
+	if "hello" != gcx.Get("foo", "bar").(string) {
+		t.Error("Expected hello.")
+	}
+}
+
+func TestGetters (t *testing.T) {
+
+	p := NewParamsWithValues(map[string]interface{} {
+		"bool": true,
+		"string": "hello",
+		"int64": int64(-1234567890),
+		"uint64": uint64(1234567890),
+		"float64": float64(0.1234),
+	})
+
+	if !GetBool("bool", false, p) {
+		t.Error("Expected true")
+	}
+	if "hello" != GetString("string", "boo", p) {
+		t.Error("Expected hello.")
+	}
+
+	if int64(-1234567890) != GetInt64("int64", 0, p) {
+		t.Error("Expected -1234567890")
+	}
+
+	if uint64(1234567890) != GetUint64("uint64", 0, p) {
+		t.Error("Expected 1234567890")
+	}
+
+	if float64(0.1234) != GetFloat64("float64", 0, p) {
+		t.Error("Expected 0.1234")
+	}
+
+	if v, ok := HasBool("bool", p); !ok {
+		t.Errorf("Expected to find bool")
+	} else if !v {
+		t.Errorf("Expected book to be true")
+	}
+
+	if v, ok := HasString("string", p); !ok {
+		t.Error("Expected to find string")
+	} else if v != "hello" {
+		t.Errorf("Expected to get the string hello")
+	}
+}
+
+func TestGetFromFirst(t *testing.T) {
+	ds := &testDs{"hello"}
+	gds := GettableDS(ds)
+	c := NewContext()
+	c.Put("test", "world")
+	gcxt := GettableCxt(c)
+
+	first, foundIn := GetFromFirst("test", "foo", gcxt, gds)
+	if "world" != first {
+		t.Errorf("Expected 'world', but got '%s'", first)
+	}
+	if _, ok := foundIn.(*gettableContext); !ok {
+		t.Error("Expected to find in context.")
+	}
+
+	second, _ := GetFromFirst("bar", "foo", gcxt, gds)
+	if "hello" != second {
+		t.Errorf("Expected hello, got %s", second)
+	}
+
+	third, defSrc := GetFromFirst("bar", "foo", gcxt)
+	if "foo" != third {
+		t.Errorf("Expected foo, got %s", third)
+	}
+
+	if GetString("***", "***", defSrc) != "foo" {
+		t.Errorf("Expected default datasource to always return foo.")
+	}
+}
+

--- a/vendor/github.com/Masterminds/cookoo/glide.yaml
+++ b/vendor/github.com/Masterminds/cookoo/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/Masterminds/cookoo
+
+import:
+  # Use 'go get' to fetch a package:
+  #- package: github.com/Masterminds/cookoo
+  # Get and manage a package with Git:
+  #- package: github.com/Masterminds/cookoo
+  #  # The repository URL
+  #  repo: git@github.com:Masterminds/cookoo.git
+  #  # A tag, branch, or SHA
+  #  ref: 1.1.0
+  #  # the VCS type (compare to bzr, hg, svn). You should
+  #  # set this if you know it.
+  #  vcs: git

--- a/vendor/github.com/Masterminds/cookoo/io/colorizer.go
+++ b/vendor/github.com/Masterminds/cookoo/io/colorizer.go
@@ -1,0 +1,67 @@
+package io
+
+import (
+	cio "io"
+	"strings"
+)
+
+// Colorizer is a Colorizing logger middleman.
+//
+// This can be used to colorize logs as they pass through to another writer. The
+// colorization uses the UNIX-style shell color coding.
+//
+// TODO: This is a very basic implementation, and could use some TLC.
+//
+// Example Usage:
+//
+//  import (
+// 		"github.com/Masterminds/cookoo"
+// 		"github.com/Masterminds/cookoo/io"
+// 		// And other stuff
+// 		cio "io"
+// 	)
+// 	func main() {
+// 		reg, router, cxt := cookoo.Cookoo()
+// 		clogger := io.NewColorizer(cio.Stdout)
+// 		cxt.AddLogger("stdout", clogger)
+// 		// etc.
+// 	}
+//
+// Given the above, log messages will be colorized before written
+// to `io.Stdout`.
+type Colorizer struct {
+	writer cio.Writer
+}
+
+// NewColorizer creates a new colorizer that wraps a given io.Writer.
+func NewColorizer(writer cio.Writer) *Colorizer {
+	c := new(Colorizer)
+	c.writer = writer
+
+	return c
+}
+
+// Write colorizes a message and then passes it to the underlying writer.
+func (r *Colorizer) Write(data []byte) (int, error) {
+
+	str := string(data)
+	if strings.HasPrefix(str, "error") {
+		str = "\033[0;31m" + str + "\033[m"
+	} else if strings.HasPrefix(str, "warn") {
+		str = "\033[0;33m" + str + "\033[m"
+	} else if strings.HasPrefix(str, "info") {
+		str = "\033[0;36m" + str + "\033[m"
+	}
+
+	wlen, err := r.writer.Write([]byte(str))
+
+	dlen := len(data)
+
+	// Short write.
+	if wlen < dlen {
+		return wlen, err
+	}
+
+	return dlen, err
+
+}

--- a/vendor/github.com/Masterminds/cookoo/io/colorizer_test.go
+++ b/vendor/github.com/Masterminds/cookoo/io/colorizer_test.go
@@ -1,0 +1,38 @@
+package io
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestColorizer(t *testing.T) {
+
+	buffer := new(bytes.Buffer)
+	colorizer := NewColorizer(buffer)
+	msg := []byte("error test")
+
+	colorizer.Write(msg)
+	line := buffer.String()
+	if line != "\033[0;31merror test\033[m" {
+		t.Errorf("! Error message was not colorized.")
+	}
+
+	buffer = new(bytes.Buffer)
+	colorizer = NewColorizer(buffer)
+	msg = []byte("warn test")
+	colorizer.Write(msg)
+	line = buffer.String()
+	if line != "\033[0;33mwarn test\033[m" {
+		t.Errorf("! Warn message was not colorized.")
+	}
+
+	buffer = new(bytes.Buffer)
+	colorizer = NewColorizer(buffer)
+	msg = []byte("info test")
+	colorizer.Write(msg)
+	line = buffer.String()
+	if line != "\033[0;36minfo test\033[m" {
+		t.Errorf("! Info message was not colorized.")
+	}
+
+}

--- a/vendor/github.com/Masterminds/cookoo/io/multi.go
+++ b/vendor/github.com/Masterminds/cookoo/io/multi.go
@@ -1,0 +1,70 @@
+package io
+
+import (
+	"io"
+	"os"
+	"fmt"
+)
+
+// MultiWriter enables you to have a writer that passes on the writing to one
+// of more Writers where the write is duplicated to each Writer. MultiWriter
+// is similar to the multiWriter that is part of Go. The difference is
+// this MultiWriter allows you to manager the Writers attached to it via CRUD
+// operations. To do this you will need to mock the type. For example,
+// mw := NewMultiWriter()
+// mw.(*MultiWriter).AddWriter("foo", foo)
+type MultiWriter struct {
+	writers map[string]io.Writer
+}
+
+// Write sends the bytes to each of the attached writers to be written.
+func (t *MultiWriter) Write(p []byte) (n int, err error) {
+	for name, w := range t.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			// One broken logger should not stop the others.
+			fmt.Fprintf(os.Stderr, "Error logging to '%s': %s", name, err)
+			continue
+		}
+		if n < len(p) {
+			// One broken logger should not stop the others.
+			err = io.ErrShortWrite
+			fmt.Fprintf(os.Stderr, "Short write logging to '%s': Expected to write %d (%V), wrote %d", name, len(p), w, n)
+			continue
+		}
+	}
+	return len(p), err
+}
+
+// Init initializes the MultiWriter.
+func (t *MultiWriter) Init() *MultiWriter {
+	t.writers = make(map[string]io.Writer)
+	return t
+}
+
+// Writer retrieves a given io.Writer given its name.
+func (t *MultiWriter) Writer(name string) (io.Writer, bool) {
+	value, found := t.writers[name]
+	return value, found
+}
+
+// Writers retrieves a map of all io.Writers keyed by name.
+func (t *MultiWriter) Writers() map[string]io.Writer {
+	return t.writers
+}
+
+// AddWriter adds an io.Writer with an associated name.
+func (t *MultiWriter) AddWriter(name string, writer io.Writer) {
+	t.writers[name] = writer
+}
+
+// RemoveWriter removes an io.Writer given a name.
+func (t *MultiWriter) RemoveWriter(name string) {
+	delete(t.writers, name)
+}
+
+// NewMultiWriter returns an initialized MultiWriter.
+func NewMultiWriter() io.Writer {
+	w := new(MultiWriter).Init()
+	return w
+}

--- a/vendor/github.com/Masterminds/cookoo/io/multi_test.go
+++ b/vendor/github.com/Masterminds/cookoo/io/multi_test.go
@@ -1,0 +1,102 @@
+package io
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakewriter1 is a fake writer that throws an error when used for testing.
+type fakewriter1 struct{}
+
+func (f *fakewriter1) Write(p []byte) (n int, err error) {
+	return len(p), errors.New("boom")
+}
+
+// fakewriter2 is a fake writer that sends back an incorrect n.
+type fakewriter2 struct{}
+
+func (f *fakewriter2) Write(p []byte) (n int, err error) {
+	return len(p) - 1, nil
+}
+
+func TestMultiWrite(t *testing.T) {
+	sha1 := sha1.New()
+	sink := new(bytes.Buffer)
+	mw := NewMultiWriter()
+	mw.(*MultiWriter).AddWriter("sha1", sha1)
+	mw.(*MultiWriter).AddWriter("sink", sink)
+
+	sourceString := "My input text."
+	source := strings.NewReader(sourceString)
+	written, err := io.Copy(mw, source)
+
+	if written != int64(len(sourceString)) {
+		t.Errorf("short write of %d, not %d", written, len(sourceString))
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	sha1hex := fmt.Sprintf("%x", sha1.Sum(nil))
+	if sha1hex != "01cb303fa8c30a64123067c5aa6284ba7ec2d31b" {
+		t.Error("incorrect sha1 value")
+	}
+
+	if sink.String() != sourceString {
+		t.Errorf("expected %q; got %q", sourceString, sink.String())
+	}
+}
+
+func TestMultiWriterCRUD(t *testing.T) {
+	sha1 := sha1.New()
+	mw := NewMultiWriter()
+	mw.(*MultiWriter).AddWriter("sha1", sha1)
+
+	sha1a, found := mw.(*MultiWriter).Writer("sha1")
+
+	if found == false {
+		t.Error("Did not find sha1 as expected.")
+	}
+	if sha1a != sha1 {
+		t.Error("Expected sha1 returned from MultiWriter to be what was set. They were different.")
+	}
+
+	writers := mw.(*MultiWriter).Writers()
+	if writers["sha1"] != sha1 {
+		t.Error("! Expected sha1 to be available on map of writers.")
+	}
+
+	mw.(*MultiWriter).RemoveWriter("sha1")
+	_, found = mw.(*MultiWriter).Writer("sha1")
+
+	if found == true {
+		t.Error("Expected sha1 to be removed from MultiWriter but it was not.")
+	}
+
+}
+
+func TestMultiWriterErrors(t *testing.T) {
+	mw := NewMultiWriter()
+	foo := new(fakewriter1)
+	mw.(*MultiWriter).AddWriter("test", foo)
+	msg := []byte("test")
+	_, e := mw.Write(msg)
+	if e == nil {
+		t.Error("! Error was expected and did now occur.")
+	}
+
+	mw = NewMultiWriter()
+	foo2 := new(fakewriter2)
+	mw.(*MultiWriter).AddWriter("test", foo2)
+	msg = []byte("test")
+	_, e = mw.Write(msg)
+	if e == nil {
+		t.Error("! Error was expected and did now occur.")
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/log/log.go
+++ b/vendor/github.com/Masterminds/cookoo/log/log.go
@@ -1,0 +1,177 @@
+/* Package log contains logging helpers.
+
+EXPERIMENTAL! This may change prior to the final release of this version!
+
+This package provides syslog-style logging messages. See `log/syslog` in Go's
+documentation. A notable difference, though, is that this also provides
+formatter variants for all of the log levels.
+
+This uses the Context.Log* functions beneath the hood, so any logger
+configuration for that will also hold true for this.
+*/
+package log
+
+import (
+	"runtime"
+
+	"github.com/Masterminds/cookoo"
+)
+
+// LogLevel describes the log levels.
+type LogLevel uint8
+
+// Log levels correspond to UNIX/syslog logging levels.
+const (
+	LogEmerg LogLevel = iota
+	LogAlert
+	LogCrit
+	LogErr
+	LogWarning
+	LogNotice
+	LogInfo
+	LogDebug
+)
+
+// Labels for log levels.
+const (
+	LabelEmerg   = "[emergency] "
+	LabelAlert   = "[alert] "
+	LabelCrit    = "[critical] "
+	LabelErr     = "[error] "
+	LabelWarning = "[warning] "
+	LabelNotice  = "[notice] "
+	LabelInfo    = "[info] "
+	LabelDebug   = "[debug] "
+)
+
+var Label = [8]string{
+	LabelEmerg,
+	LabelAlert,
+	LabelCrit,
+	LabelErr,
+	LabelWarning,
+	LabelNotice,
+	LabelInfo,
+	LabelDebug,
+}
+
+var Level LogLevel = LogDebug
+
+// Debugging returns true if the level is set to allow debugging.
+//
+// Whether or not the log message is sent to the underlying logger is determined
+// based on the Level. However, using checks like this can prevent doing
+// costly debug computations just for the sake of logging.
+//
+// 	if Debugging() {
+// 		// Do something expensive.
+// 		costlyOperation()
+//
+// 		Debug(c, "msg")
+// 	}
+//
+// Otherwise, this will write the message to the lower-level logger, which can
+// then decide (presumably based on Level) what to do with the message.
+func Debugging() bool {
+	return Level >= LogDebug
+}
+
+// Emergf logs an emergency.
+func Emergf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogEmerg, msg, args...)
+}
+
+// Alertf logs an alert.
+func Alertf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogAlert, msg, args...)
+}
+
+// Critf logs a critical message.
+func Critf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogCrit, msg, args...)
+}
+
+// Errf logs an error message.
+func Errf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogErr, msg, args...)
+}
+
+// Warnf logs a warning.
+func Warnf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogWarning, msg, args...)
+}
+
+// Noticef logs a notice.
+func Noticef(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogNotice, msg, args...)
+}
+
+// Infof logs an informational message.
+func Infof(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogInfo, msg, args...)
+}
+
+// Debugf logs a debug message.
+func Debugf(c cookoo.Context, msg string, args ...interface{}) {
+	sendf(c, LogDebug, msg, args...)
+}
+
+// Emergf logs an emergency.
+func Emerg(c cookoo.Context, args ...interface{}) {
+	send(c, LogEmerg, args...)
+}
+
+// Alertf logs an alert.
+func Alert(c cookoo.Context, args ...interface{}) {
+	send(c, LogAlert, args...)
+}
+
+// Critf logs a critical message.
+func Crit(c cookoo.Context, args ...interface{}) {
+	send(c, LogCrit, args...)
+}
+
+// Errf logs an error message.
+func Err(c cookoo.Context, args ...interface{}) {
+	send(c, LogErr, args...)
+}
+
+// Warnf logs a warning.
+func Warn(c cookoo.Context, args ...interface{}) {
+	send(c, LogWarning, args...)
+}
+
+// Noticef logs a notice.
+func Notice(c cookoo.Context, args ...interface{}) {
+	send(c, LogNotice, args...)
+}
+
+// Infof logs an informational message.
+func Info(c cookoo.Context, args ...interface{}) {
+	send(c, LogInfo, args...)
+}
+
+// Debugf logs a debug message.
+func Debug(c cookoo.Context, args ...interface{}) {
+	send(c, LogDebug, args...)
+}
+
+// Stack dumps a stack trace to the log. It uses the LogDebug level.
+//
+// This limits the size of the returned stack to 4096 bytes.
+func Stack(c cookoo.Context, msg string) {
+	buff := make([]byte, 4096)
+	runtime.Stack(buff, false)
+	send(c, LogDebug, msg, string(buff))
+}
+
+func send(c cookoo.Context, l LogLevel, args ...interface{}) {
+	if Level >= l {
+		c.Log(Label[l], args...)
+	}
+}
+func sendf(c cookoo.Context, l LogLevel, msg string, args ...interface{}) {
+	if Level >= l {
+		c.Logf(Label[l], msg, args...)
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/log/log_test.go
+++ b/vendor/github.com/Masterminds/cookoo/log/log_test.go
@@ -1,0 +1,76 @@
+package log
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/cookoo"
+)
+
+func Example() {
+	_, _, c := cookoo.Cookoo()
+
+	// Set logging to go to Stdout.
+	c.AddLogger("stdout", os.Stdout)
+
+	// Set the log level to any of the Log* constants.
+	Level = LogInfo
+
+	// Functions are named as they are in log/syslog.
+	Err(c, "Failed to do something.")
+
+	// There are also formatting versions of every log function.
+	Infof(c, "Informational message with %s.", "formatting")
+
+	// Shorthand for if Level >= LogDebug
+	if Debugging() {
+		Debug(c, "This is a debug message.")
+	}
+
+	// You can test for any level.
+	if Level >= LogWarning {
+		Warn(c, "And this is a warning.")
+	}
+
+	Stack(c, "Stack trace from here.")
+}
+
+func TestLog(t *testing.T) {
+	_, _, c := cookoo.Cookoo()
+	var b bytes.Buffer
+	c.AddLogger("stdout", &b)
+	Errf(c, "Failed %s", "now")
+
+	if !strings.Contains(b.String(), "Failed now") {
+		t.Fatalf("Expected '%s' to contain 'Failed now'", b.String())
+	}
+
+	if Level != LogDebug {
+		t.Errorf("Expected log level %d, got %d", LogDebug, Level)
+	}
+
+	if Label[Level] != LabelDebug {
+		t.Errorf("Expected log label '%s', got '%s'", LabelDebug, Label[Level])
+	}
+
+	Level = LogErr
+	t.Logf("Set level to %d", LogErr)
+
+	b.Reset()
+	if LogDebug <= Level {
+		Debug(c, "foo")
+	}
+	if b.Len() > 0 {
+		t.Errorf("Expected empty buffer. Got %s", b.String)
+	}
+
+	Alert(c, "test")
+	if !strings.Contains(b.String(), "test") {
+		t.Errorf("Expected alert to get logged on log level %s", Label[Level])
+	}
+
+	Stack(c, "Stack trace from here.")
+	t.Log(b.String())
+}

--- a/vendor/github.com/Masterminds/cookoo/mapper.go
+++ b/vendor/github.com/Masterminds/cookoo/mapper.go
@@ -1,0 +1,150 @@
+package cookoo
+
+import (
+	//"fmt"
+	"reflect"
+	"strings"
+)
+
+// CommandDefinition defines what a command objects looks like.
+//
+// Fields on a command struct may be annotated with tags.
+// A tag looks like this:
+// 	type Foo struct {
+// 		Field         string `coo:"myfield"`
+// 		AnotherField  string `coo:"-" // - means skip this field.
+// 		LastField     string `coo:"lastfield,cxt"
+// 	}
+//
+// A tag has the format `coo:"NAME,MODIFIERS"`.
+//
+// When NAME is present, the reader will look in the params list for a field
+// my that name. If no tag is present or the name field is blank, the field's
+// name will be used instead.
+//
+// As with the JSON tags, if the field has the name "-" it will be skipped. No
+// value will be set for it.
+//
+// The following modifiers are defined:
+// 	- cxt: Get the value from the context. (EXPERIMENTAL)
+// 	- ds: Get the value from the Datasources list. (EXPERIMENTAL)
+// 	- param: Get the value from Params (default). (EXPERIMENTAL)
+//
+// When more than one is present (coo:"foo,cxt,ds") they will be tried in order.
+// In this case, first the Context will be checked for foo, then the datasources.
+//
+// When no such modifier is present, the value is gotten only from the params list.
+
+// CommandDefinition describes the fields that should be attached to a Command.
+//
+// CommandDefinitions should be composed of public fields and a Run method.
+//
+// 	type Person struct {
+// 		Name string
+// 		Age int
+//		IgnoreMe string `coo:"-"`
+// 	}
+type CommandDefinition interface {
+	// Run provides the same functionality as a Command function, but with
+	// the added benefit of having all of the fields present on the struct. For that
+	// reason, there is no Params attached.
+	Run(c Context) (interface{}, Interrupt)
+}
+
+// Map merges params into a CommandDefinition and returns a Command Definition.
+func Map(c Context, p *Params, d CommandDefinition) (CommandDefinition, Interrupt) {
+
+	// For each field on the command definition, attempt to give it a value
+	// from the params.
+	v := reflect.Indirect(reflect.ValueOf(d))
+	t := v.Type()
+	count := t.NumField()
+
+	// Make a new instance of the d
+	def := reflect.New(t)
+
+	// Iterate through all the fields on the struct. We want to
+	// find the name of the field, or perhaps the tag's name.
+	for i := 0; i < count; i++ {
+		f := t.Field(i)
+
+		fieldName := f.Name
+		tag := []string{fieldName}
+
+		// If there are tags, we need to parse them.
+		if len(f.Tag) != 0 {
+			//fmt.Printf("Need to parse tags %s.\n", f.Tag)
+			t := f.Tag.Get("coo")
+			if len(tag) > 0 {
+				tag = parseTag(fieldName, t)
+			}
+		}
+
+		fv := reflect.Indirect(def).FieldByName(f.Name)
+
+		if err := populate(f, fv, c, p, tag); err != nil {
+			return nil, err
+		}
+	}
+
+	iface := def.Interface()
+	return iface.(CommandDefinition), nil
+}
+
+// parseTag parses the contents of a coo tag.
+func parseTag(fieldName, tag string) []string {
+	parts := strings.Split(tag, ",")
+	if len(parts) == 0 {
+		return []string{fieldName}
+	}
+	return parts
+}
+
+func populate(f reflect.StructField, v reflect.Value, c Context, p *Params, tag []string) error {
+
+	//fmt.Printf("Reflecting on %s for %s\n", f.Name, tag[0])
+
+	// Ignore fields with name "-".
+	if tag[0] == "-" {
+		return nil
+	}
+
+	//if !v.CanSet() {
+	//	return fmt.Errorf("Field %s cannot be set.", f.Name)
+	//}
+
+	// Get only from Params.
+	if len(tag) == 1 {
+		val, ok := p.Has(tag[0])
+		if ok {
+			v.Set(reflect.ValueOf(val))
+		}
+		return nil
+	}
+
+	for i := 1; i < len(tag); i++ {
+		switch tag[i] {
+		case "cxt":
+			val, ok := c.Has(tag[0])
+			if ok {
+				v.Set(reflect.ValueOf(val))
+				return nil
+			}
+		case "param":
+			val, ok := p.Has(tag[0])
+			if ok {
+				v.Set(reflect.ValueOf(val))
+				return nil
+			}
+		case "ds":
+			val, ok := c.HasDatasource(tag[0])
+			if ok {
+				v.Set(reflect.ValueOf(val))
+				return nil
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/vendor/github.com/Masterminds/cookoo/mapper_test.go
+++ b/vendor/github.com/Masterminds/cookoo/mapper_test.go
@@ -1,0 +1,108 @@
+package cookoo
+
+import (
+	"testing"
+)
+
+func TestMap(t *testing.T) {
+	cxt := NewContext()
+	params := NewParamsWithValues(map[string]interface{}{
+		"funty":          1,
+		"FloatField":     float32(2.3),
+		"StrField":       "hello",
+		"BoolField":      true,
+		"SliceField":     []int{1, 2, 3},
+		"MapField":       map[string]bool{"true": true},
+		"StructField":    basic{true},
+		"StructPtrField": &basic{false},
+	})
+	s := &mystruct{}
+
+	def, err := Map(cxt, params, s)
+	if err != nil {
+		t.Errorf("Failed: %s", err)
+	}
+
+	res := def.(*mystruct)
+
+	if res.IntField != 1 {
+		t.Errorf("Expected 1, got %d", res.IntField)
+	}
+
+	if res.FloatField != 2.3 {
+		t.Errorf("Expected 2.3, got %f", res.FloatField)
+	}
+
+	if res.StrField != "hello" {
+		t.Errorf("Expected hello, got %s", res.StrField)
+	}
+
+	if !res.BoolField {
+		t.Errorf("BoolField is false")
+	}
+
+	if len(res.SliceField) != 3 {
+		t.Errorf("Expected slice of 2.")
+	}
+	if !res.MapField["true"] {
+		t.Errorf("Expected true:true.")
+	}
+
+	if !res.StructField.hai {
+		t.Errorf("expected basic to have true")
+	}
+
+	if res.StructPtrField.hai {
+		t.Errorf("expected *basic to have false.")
+	}
+
+}
+
+func TestMappedRoute(t *testing.T) {
+	reg, router, cxt := Cookoo()
+	reg.AddRoute(Route{
+		Name: "test",
+		Does: Tasks{
+			CmdDef{
+				Name: "cmdDef",
+				Def:  &mystruct{},
+				Using: []Param{
+					{Name: "funty", DefaultValue: 5},
+					{Name: "StrField", DefaultValue: "Batty"},
+				},
+			},
+		},
+	})
+
+	if err := router.HandleRequest("test", cxt, true); err != nil {
+		t.Error(err)
+	}
+
+	cmdDef := cxt.Get("cmdDef", nil).(*mystruct)
+	if cmdDef.IntField != 5 {
+		t.Errorf("Expected 5, got %d", cmdDef.IntField)
+	}
+	if cmdDef.StrField != "Batty" {
+		t.Errorf("Expected Batty, got %s", cmdDef.StrField)
+	}
+
+}
+
+type mystruct struct {
+	IntField       int `coo:"funty"`
+	FloatField     float32
+	StrField       string
+	BoolField      bool
+	SliceField     []int
+	MapField       map[string]bool
+	StructField    basic
+	StructPtrField *basic
+}
+
+func (m *mystruct) Run(c Context) (interface{}, Interrupt) {
+	return m, nil
+}
+
+type basic struct {
+	hai bool
+}

--- a/vendor/github.com/Masterminds/cookoo/params.go
+++ b/vendor/github.com/Masterminds/cookoo/params.go
@@ -1,0 +1,135 @@
+package cookoo
+
+type Params struct {
+	storage map[string]interface{}
+}
+
+// NewParamsWithValues initializes a Params object with the given values.
+//
+// Create a new Params instance, initialized with the given map.
+// Note that the given map is actually used (not copied).
+func NewParamsWithValues(initialVals map[string]interface{}) *Params {
+	p := new(Params)
+	p.Init(initialVals)
+	return p
+}
+
+// NewParams creates a Params object of a given size.
+func NewParams(size int) *Params {
+	p := new(Params)
+	p.storage = make(map[string]interface{}, size)
+	return p
+}
+
+// Init initializes a Params object with an initial map of values.
+func (p *Params) Init(initialValues map[string]interface{}) {
+	p.storage = initialValues
+}
+
+func (p *Params) set(name string, value interface{}) bool {
+	_, ret := p.storage[name]
+	p.storage[name] = value
+	return ret
+}
+
+// Has checks if a parameter exists, and return it if found.
+func (p *Params) Has(name string) (value interface{}, ok bool) {
+	value, ok = p.storage[name]
+	if value == nil {
+		ok = false
+	}
+	return
+}
+
+// Get gets a parameter value, or returns the default value.
+func (p *Params) Get(name string, defaultValue interface{}) interface{} {
+	val, ok := p.Has(name)
+	if ok {
+		return val
+	}
+	return defaultValue
+}
+
+// Requires verifies that the given keys exist in the Params.
+//
+// Require that a given list of parameters are present.
+// If they are all present, ok = true. Otherwise, ok = false and the
+// `missing` array contains a list of missing params.
+func (p *Params) Requires(paramNames ...string) (ok bool, missing []string) {
+	missing = make([]string, 0, len(p.storage))
+	for _, val := range paramNames {
+		_, ok := p.storage[val]
+		if !ok {
+			missing = append(missing, val)
+		}
+
+	}
+	ok = len(missing) == 0
+	return
+}
+
+// RequiresValue verifies that the given keys exist and that their values are
+// non-empty.
+//
+// Requires that given parameters are present and non-empty.
+// This is more powerful than Requires(), which simply checks to see if the the Using() clause declared
+// the value.
+func (p *Params) RequiresValue(paramNames ...string) (ok bool, missing []string) {
+	missing = make([]string, 0, len(p.storage))
+	for _, val := range paramNames {
+		vv, ok := p.storage[val]
+		switch vv.(type) {
+		default:
+			if vv == nil {
+				ok = false
+			}
+		case string:
+			if vv == nil || len(vv.(string)) == 0 {
+				ok = false
+			}
+		case []interface{}:
+			if vv == nil || len(vv.([]interface{})) == 0 {
+				ok = false
+			}
+		case map[interface{}]interface{}:
+			if vv == nil || len(vv.(map[interface{}]interface{})) == 0 {
+				ok = false
+			}
+		}
+
+		if !ok {
+			missing = append(missing, val)
+		}
+	}
+	ok = len(missing) == 0
+	return
+}
+
+// AsMap returns all parameters as a map[string]interface{}.
+//
+// This does no checking of the parameters.
+func (p *Params) AsMap() map[string]interface{} {
+	return p.storage
+}
+
+// Len returns the number of params.
+func (p *Params) Len() int {
+	return len(p.storage)
+}
+
+// Validate provides a validator callback for params.
+// Given a name and a validation function, return a valid value.
+// If the value is not valid, ok = false.
+func (p *Params) Validate(name string, validator func(interface{}) bool) (value interface{}, ok bool) {
+	value, ok = p.storage[name]
+	if !ok {
+		return
+	}
+
+	if !validator(value.(interface{})) {
+		// XXX: For safety, we set a failed value to nil.
+		value = nil
+		ok = false
+	}
+	return
+}

--- a/vendor/github.com/Masterminds/cookoo/params_test.go
+++ b/vendor/github.com/Masterminds/cookoo/params_test.go
@@ -1,0 +1,65 @@
+package cookoo
+
+import (
+	"testing"
+)
+
+func TestParams(t *testing.T) {
+	params := NewParamsWithValues(map[string]interface{}{
+		"Test":  123,
+		"Test2": "Hello",
+		"Test3": NewContext(),
+	})
+
+	if v, ok := params.Has("Test"); !ok {
+		t.Error("Expected to find 123, got NADA")
+	} else if v != 123 {
+		t.Error("! Expected 123, got ", v)
+	}
+
+	// A really lame validator.
+	fn := func(value interface{}) bool {
+		return true
+	}
+
+	// Test the validator.
+	if v, ok := params.Validate("Test2", fn); !ok {
+		t.Error("! Expected a valid string.")
+	} else if v != "Hello" {
+		t.Error("! Expected 'Hello', got ", v)
+	}
+
+	alwaysFails := func(value interface{}) bool {
+		return false
+	}
+	// Test the validator.
+	if _, ok := params.Validate("Test2", alwaysFails); ok {
+		t.Error("! Expected a failed validation.")
+	}
+
+	if v, ok := params.Has("Test3"); !ok {
+		t.Error("! Expected a context in Test3.")
+	} else if _, ok = v.(Context); !ok {
+		t.Error("! Expected the value to be a Context.")
+	}
+
+	if ok, missing := params.Requires("Test", "Test3"); !ok {
+		t.Error("Expected to find params. Missing ", missing)
+	}
+
+	if ok, missing := params.Requires("Test", "Test4"); ok {
+		t.Error("! Expected to be missing something", missing)
+	} else if missing[0] != "Test4" {
+		t.Error("! Expected to be missing Test4")
+	}
+
+	get := params.Get("Test2", "NOT IT")
+	if get != "Hello" {
+		t.Error("! Expected Hello, got ", get)
+	}
+
+	get = params.Get("NotThere", "YES")
+	if get != "YES" {
+		t.Error("! Expected YES, got ", get)
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/registry.go
+++ b/vendor/github.com/Masterminds/cookoo/registry.go
@@ -1,0 +1,366 @@
+package cookoo
+
+// Copyright 2013 Masterminds.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Registry contains the the callback routes and the commands each
+// route executes.
+type Registry struct {
+	routes            map[string]*routeSpec
+	orderedRouteNames []string
+	currentRoute      *routeSpec
+}
+
+// NewRegistry returns a new initialized registry.
+func NewRegistry() *Registry {
+	r := new(Registry)
+	r.Init()
+	return r
+}
+
+// Init initializes a registry. If a Registry is created through a means other
+// than NewRegistry Init should be called on it.
+func (r *Registry) Init() *Registry {
+	// Why 8?
+	r.routes = make(map[string]*routeSpec, 8)
+	r.orderedRouteNames = make([]string, 0, 8)
+	return r
+}
+
+// Route specifies a new route to add to the registry.
+func (r *Registry) Route(name, description string) *Registry {
+
+	// Create the route spec.
+	route := new(routeSpec)
+	route.name = name
+	route.description = description
+	route.commands = make([]*commandSpec, 0, 4)
+
+	// Add the route spec.
+	r.currentRoute = route
+	r.routes[name] = route
+	r.orderedRouteNames = append(r.orderedRouteNames, name)
+
+	return r
+}
+
+func (r *Registry) DoesCmdDef(cd CommandDefinition, name string) *Registry {
+	// Configure command spec.
+	spec := new(commandSpec)
+	spec.name = name
+	spec.command = func(c Context, p *Params) (interface{}, Interrupt) {
+		// We don't have to clone cmd.Def because Map builds
+		// a new copy.
+		o, err := Map(c, p, cd)
+		if err != nil {
+			return nil, err
+		}
+		return o.Run(c)
+	}
+
+	// Add command spec.
+	r.currentRoute.commands = append(r.currentRoute.commands, spec)
+
+	return r
+}
+
+// Does adds a command to the end of the chain of commands for the current
+// (most recently specified) route.
+func (r *Registry) Does(cmd Command, commandName string) *Registry {
+
+	// Configure command spec.
+	spec := new(commandSpec)
+	spec.name = commandName
+	spec.command = cmd
+
+	// Add command spec.
+	r.currentRoute.commands = append(r.currentRoute.commands, spec)
+
+	return r
+}
+
+// Using specifies a paramater to use for the most recently specified command
+// as set by Does.
+func (r *Registry) Using(name string) *Registry {
+	// Look up the last command added.
+	lastCommand := r.lastCommandAdded()
+
+	// Create a new spec.
+	spec := new(paramSpec)
+	spec.name = name
+
+	// Add it to the list.
+	lastCommand.parameters = append(lastCommand.parameters, spec)
+	return r
+}
+
+// WithDefault specifies the default value for the most recently specified
+// parameter as set by Using.
+func (r *Registry) WithDefault(value interface{}) *Registry {
+	param := r.lastParamAdded()
+	param.defaultValue = value
+	return r
+}
+
+// From sepcifies where to get the value from for the most recently specified
+// paramater as set by Using.
+func (r *Registry) From(fromVal ...string) *Registry {
+	param := r.lastParamAdded()
+
+	// This is sort of a hack. Really, we should make params.from a []string.
+	param.from = strings.Join(fromVal, " ")
+	return r
+}
+
+// Get the last parameter for the last command added.
+func (r *Registry) lastParamAdded() *paramSpec {
+	cspec := r.lastCommandAdded()
+	last := len(cspec.parameters) - 1
+	return cspec.parameters[last]
+}
+
+// Includes makes the commands from another route avaiable on this route.
+func (r *Registry) Includes(route string) *Registry {
+
+	// Not that we don't clone commands; we just add the pointer to the current
+	// route.
+	spec := r.routes[route]
+	if spec == nil {
+		panicString := fmt.Sprintf("Could not find route %s. Skipping include.", route)
+		panic(panicString)
+	}
+	for _, cmd := range spec.commands {
+		r.currentRoute.commands = append(r.currentRoute.commands, cmd)
+	}
+	return r
+}
+
+// RouteSpec gets a ruote cased on its name.
+func (r *Registry) RouteSpec(routeName string) (spec *routeSpec, ok bool) {
+	spec, ok = r.routes[routeName]
+	return
+}
+
+// Routes gets an unordered map of routes names to route specs.
+//
+// If order is important, use RouteNames to get the names (in order).
+func (r *Registry) Routes() map[string]*routeSpec {
+	return r.routes
+}
+
+// RouteNames gets a slice containing the names of every registered route.
+//
+// The route names are returned in the order they were added to the
+// registry. This is useful to some resolvers, which apply rules in order.
+func (r *Registry) RouteNames() []string {
+	return r.orderedRouteNames
+	/*
+		names := make([]string, len(r.routes))
+		i := 0
+		for k := range r.routes {
+			names[i] = k
+			i++
+		}
+		return names
+	*/
+}
+
+// Look up the last command.
+func (r *Registry) lastCommandAdded() *commandSpec {
+	lastIndex := len(r.currentRoute.commands) - 1
+	return r.currentRoute.commands[lastIndex]
+}
+
+type RouteDetails interface {
+	Name() string
+	Description() string
+}
+
+type routeSpec struct {
+	name, description string
+	commands          []*commandSpec
+}
+
+func (r *routeSpec) Name() string {
+	return r.name
+}
+
+func (r *routeSpec) Description() string {
+	return r.description
+}
+
+type commandSpec struct {
+	name       string
+	command    Command
+	parameters []*paramSpec
+}
+
+type paramSpec struct {
+	name         string
+	defaultValue interface{}
+	from         string
+}
+
+// New public API
+
+// AddRoute adds a single route to the registry.
+func (r *Registry) AddRoute(route Route) error {
+	return r.AddRoutes(route)
+}
+
+func extractParams(cmd Task) []*paramSpec {
+	var paramspecs []*paramSpec
+
+	// FIXME: This is a horrible way to do this.
+	paramspecs = make([]*paramSpec, len(cmd.getParams()))
+	for j, prm := range cmd.getParams() {
+		pspec := &paramSpec{
+			name:         prm.Name,
+			defaultValue: prm.DefaultValue,
+			from:         prm.From,
+		}
+		paramspecs[j] = pspec
+	}
+	return paramspecs
+}
+
+// AddRoutes adds one or more routes to the registry.
+func (r *Registry) AddRoutes(routes ...Route) error {
+	for _, route := range routes {
+
+		cmdspecs := make([]*commandSpec, 0, len(route.Does))
+		for _, cmd := range route.Does {
+			switch cmd := cmd.(type) {
+			case CmdDef:
+				// This wraps the CmdDef inside of a command.
+				paramspecs := extractParams(cmd)
+				cmdspec := &commandSpec{
+					name: cmd.Name,
+					command: func(c Context, p *Params) (interface{}, Interrupt) {
+						// We don't have to clone cmd.Def because Map builds
+						// a new copy.
+						o, err := Map(c, p, cmd.Def)
+						if err != nil {
+							return nil, err
+						}
+						return o.Run(c)
+					},
+					parameters: paramspecs,
+				}
+				cmdspecs = append(cmdspecs, cmdspec)
+
+			case Cmd:
+				paramspecs := extractParams(cmd)
+
+				cmdspec := &commandSpec{
+					name:       cmd.Name,
+					command:    cmd.Fn,
+					parameters: paramspecs,
+				}
+				cmdspecs = append(cmdspecs, cmdspec)
+			case Include:
+				other, ok := r.RouteSpec(cmd.Path)
+				if !ok {
+					// Route not found.
+					return fmt.Errorf("Route '%s' not found.", cmd.Path)
+				}
+				cmdspecs = append(cmdspecs, other.commands...)
+
+			}
+		}
+
+		rspec := &routeSpec{
+			name:        route.Name,
+			description: route.Help,
+			commands:    cmdspecs,
+		}
+		// Add the route spec.
+		r.currentRoute = rspec
+		r.routes[rspec.name] = rspec
+		r.orderedRouteNames = append(r.orderedRouteNames, rspec.name)
+	}
+	return nil
+}
+
+// Route declares a new Cookoo route.
+//
+// A Route has a name, which is used to identify and call it, and Help. The
+// Help can be used by other tools to generate help text or information about
+// an application's structure.
+//
+// Routes are composed of a series of Tasks, each of which is executed in
+// order.
+type Route struct {
+	Name, Help string
+	Does       Tasks
+}
+
+// Tasks represents a list of discrete tasks that are run on a Route.
+//
+// There are two kinds of Tasks: Cmd (a command) and Include, which imports a
+// Tasks list from another route.
+type Tasks []Task
+
+// Cmd associates a cookoo.Command to a Route.
+//
+// The Name is the direct reference to a command. When a Command returns output,
+// that output is inserted into the Context with the key Name.
+//
+// Fn specifies which cookoo.Command should be executed during this step.
+//
+// Using contains a list of Parameters that Cookoo can pass into the Command
+// at execution time.
+type Cmd struct {
+	Name  string
+	Fn    Command
+	Using Parameters
+}
+
+// Include imports all of the Tasks on another route into the present Route.
+type Include struct {
+	Path string
+}
+
+type CmdDef struct {
+	Name  string
+	Def   CommandDefinition
+	Using Parameters
+}
+
+// A Task can be either an Include or a Cmd. This is a very lame way of
+// making this behavior private.
+
+type Task interface {
+	getParams() Parameters
+}
+
+func (i Include) getParams() Parameters {
+	return Parameters{}
+}
+func (c Cmd) getParams() Parameters {
+	return c.Using
+}
+func (c CmdDef) getParams() Parameters {
+	return c.Using
+}
+
+type Parameters []Param
+
+// Param describes an individual parameter which will be passed to a Command.
+//
+// The Name is the name of the parameter. The Command itself dictates which
+// Names it uses.
+//
+// The DefaultValue is the value of the Parameter if nothing else is specified.
+//
+// From indicates where the Param value may come from. Examples: `From("cxt:foo")`
+// gets the value from the value of the key 'foo' in the Context.
+type Param struct {
+	Name         string
+	DefaultValue interface{}
+	From         string
+}

--- a/vendor/github.com/Masterminds/cookoo/registry_test.go
+++ b/vendor/github.com/Masterminds/cookoo/registry_test.go
@@ -1,0 +1,287 @@
+package cookoo
+
+import (
+	"testing"
+	//	"registry"
+	"fmt"
+)
+
+type FooType struct {
+	test int
+}
+
+func FakeCommand(cxt Context, params Params) (interface{}, Interrupt) {
+	fmt.Println("Got here")
+
+	var ret bool = true
+
+	p := &ret
+
+	return p, nil
+}
+
+func AnotherCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	//ret := func() bool {return true;}
+	ret := new(FooType)
+	ret.test = 5
+
+	return ret, nil
+}
+
+type Dossier struct {
+	Name    string
+	Age     int
+	Alias   string `coo:"AKA"`
+	RealAge int    `coo:"-"`
+}
+
+func (a *Dossier) Run(c Context) (interface{}, Interrupt) {
+	return true, nil
+}
+
+func TestBasicRoute(t *testing.T) {
+	reg := new(Registry)
+	reg.Init()
+
+	reg.Route("foo", "A test route")
+	reg.Does(AnotherCommand, "fakeCommand").Using("param").WithDefault("value")
+
+	// Now do something to test.
+	routes := reg.Routes()
+
+	if len(routes) != 1 {
+		t.Error("! Expected one route.")
+	}
+
+	rspec := routes["foo"]
+
+	if rspec.name != "foo" {
+		t.Error("! Expected route to be named 'foo'")
+	}
+	if rspec.description != "A test route" {
+		t.Error("! Expected description to be 'A test route'")
+	}
+
+	if len(rspec.commands) != 1 {
+		t.Error("! Expected exactly one command. Found ", len(rspec.commands))
+	}
+
+	cmd := rspec.commands[0]
+	if "fakeCommand" != cmd.name {
+		t.Error("! Expected to find fakeCommand command.")
+	}
+
+	if len(cmd.parameters) != 1 {
+		t.Error("! Expected exactly one paramter. Found ", len(cmd.parameters))
+	}
+
+	pspec := cmd.parameters[0]
+	if pspec.name != "param" {
+		t.Error("! Expected the first param to be 'param'")
+	}
+
+	if pspec.defaultValue != "value" {
+		t.Error("! Expected the value to be 'value'")
+	}
+	fakeCxt := new(ExecutionContext)
+	fakeParams := NewParamsWithValues(map[string]interface{}{"foo": "bar", "baz": 2})
+	rr, err := cmd.command(fakeCxt, fakeParams)
+
+	if err != nil {
+		t.Error("! Expected no errors.")
+	}
+
+	cRet := rr.(*FooType)
+
+	if cRet.test != 5 {
+		t.Error("! Expected 'test' to be 5")
+	}
+
+}
+
+func TestRouteIncludes(t *testing.T) {
+	reg := new(Registry)
+	reg.Init()
+
+	reg.Route("foo", "A test route").
+		Does(AnotherCommand, "fakeCommand").
+		Using("param").WithDefault("foo").
+		Route("bar", "Another test route").
+		Does(AnotherCommand, "fakeCommand2").
+		Using("param").WithDefault("bar").
+		Includes("foo").
+		Does(AnotherCommand, "fakeCommand3").
+		Using("param").WithDefault("baz")
+
+	expecting := []string{"fakeCommand2", "fakeCommand", "fakeCommand3"}
+	spec, ok := reg.RouteSpec("bar")
+	if !ok {
+		t.Error("! Expected to find a route named 'bar'")
+	}
+	for i, k := range expecting {
+		if k != spec.commands[i].name {
+			t.Error(fmt.Sprintf("Expecting %s at position %d; got %s", k, i, spec.commands[i].name))
+		}
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("! Failed to panic when including commands for a route that does not exist.")
+		}
+	}()
+	reg2 := new(Registry)
+	reg2.Init()
+
+	reg2.Route("foo", "A test route").
+		Includes("bar")
+}
+
+func TestRouteSpec(t *testing.T) {
+	reg := new(Registry)
+	reg.Init()
+
+	reg.Route("foo", "A test route").
+		Does(AnotherCommand, "fakeCommand").
+		Using("param").WithDefault("value").
+		Using("something").WithDefault(NewContext())
+
+	spec, ok := reg.RouteSpec("foo")
+
+	if !ok {
+		t.Error("! Expected to find a route named 'foo'")
+	}
+
+	if spec.name != "foo" {
+		t.Error("! Expected a spec named 'foo'")
+	}
+
+	param := spec.commands[0].parameters[1]
+	if v, ok := param.defaultValue.(Context); !ok {
+		t.Error("! Expected an execution context.")
+	} else {
+		// Canary
+		v.Put("test", "test")
+	}
+}
+
+func TestRouteNames(t *testing.T) {
+	reg := new(Registry)
+	reg.Init()
+	reg.Route("one", "A route").Does(AnotherCommand, "fake")
+	reg.Route("two", "A route").Does(AnotherCommand, "fake")
+	reg.Route("three", "A route").Does(AnotherCommand, "fake")
+	reg.Route("four", "A route").Does(AnotherCommand, "fake")
+	reg.Route("five", "A route").Does(AnotherCommand, "fake")
+
+	names := reg.RouteNames()
+
+	if len(names) != 5 {
+		t.Error("! Expected five routes, found ", len(names))
+	}
+
+	expecting := []string{"one", "two", "three", "four", "five"}
+	for i, k := range expecting {
+		if k != names[i] {
+			t.Error(fmt.Sprintf("Expecting %s at position %d; got %s", k, i, names[i]))
+		}
+	}
+
+}
+
+func TestAddRoutes(t *testing.T) {
+	reg := NewRegistry()
+	err := reg.AddRoutes(
+		Route{
+			Name: "@boot",
+			Does: Tasks{
+				Cmd{Name: "startup"},
+				Cmd{Name: "ready"},
+			},
+		},
+		Route{
+			Name: "Foo",
+			Help: "Bar",
+			Does: Tasks{
+				Cmd{
+					Name: "cmd1",
+					Fn:   AnotherCommand,
+					Using: []Param{
+						{"test", 1, "cxt:test"},
+						{"test2", "foo", "cxt:test2"},
+					},
+				},
+				Cmd{
+					Name: "cmd2",
+				},
+				// This will include all of the commands on route @boot.
+				Include{"@boot"},
+				Cmd{
+					Name: "cmd3",
+				},
+			},
+		},
+		Route{
+			Name: "Another",
+			Does: Tasks{
+				Cmd{
+					Name: "cmd3",
+				},
+				Cmd{
+					Name: "cmd4",
+				},
+				CmdDef{
+					Name: "obj",
+					Def:  &Dossier{},
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec, ok := reg.RouteSpec("Foo")
+	if !ok {
+		t.Error("Expected to find route Foo.")
+	}
+	if spec.Name() != "Foo" {
+		t.Errorf("Expected route named 'Foo', got '%s'", spec.Name())
+	}
+	if spec.Description() != "Bar" {
+		t.Errorf("Expected description 'Bar', got '%s'", spec.Description())
+	}
+
+	if len(spec.commands) != 5 {
+		t.Errorf("Expected exactly 5 commands, got %d", len(spec.commands))
+	}
+
+	// Check that each command is in the order we expect
+	order := []string{"cmd1", "cmd2", "startup", "ready", "cmd3"}
+	for i, c := range spec.commands {
+		if c.name != order[i] {
+			t.Errorf("Expected commnd %d to be %s, got %s", i, order[i], c.name)
+		}
+	}
+
+	cmd := spec.commands[0]
+	if cmd.name != "cmd1" {
+		t.Errorf("Expected command named cmd1, got %s", cmd.name)
+	}
+	if cmd.command == nil {
+		t.Error("Expected AnotherCommand.")
+	}
+	if len(cmd.parameters) != 2 {
+		t.Errorf("Expected 2 paramters, got %d", len(cmd.parameters))
+	}
+	param := cmd.parameters[0]
+	if param.name != "test" {
+		t.Errorf("Expected param named 'test', got '%s'", param.name)
+	}
+	if param.defaultValue.(int) != 1 {
+		t.Error("Expected int 1.")
+	}
+	if param.from != "cxt:test" {
+		t.Error("Expected cxt:test, got %s", param.from)
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/router.go
+++ b/vendor/github.com/Masterminds/cookoo/router.go
@@ -1,0 +1,293 @@
+package cookoo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RequestResolver is the interface for the request resolver.
+// A request resolver is responsible for transforming a request name to
+// a route name. For example, a web-specific resolver may take a URI
+// and return a route name. Or it make take an HTTP verb and return a
+// route name.
+type RequestResolver interface {
+	Init(registry *Registry)
+	Resolve(path string, cxt Context) (string, error)
+}
+
+// Router is the Cookoo router.
+// A Cookoo app works by passing a request into a router, and
+// relying on the router to execute the appropriate chain of
+// commands.
+type Router struct {
+	registry *Registry
+	resolver RequestResolver
+}
+
+// BasicRequestResolver is a basic resolver that assumes that the given request
+// name *is* the route name.
+type BasicRequestResolver struct {
+	registry *Registry
+	resolver RequestResolver
+}
+
+// NewRouter creates a new Router.
+func NewRouter(reg *Registry) *Router {
+	router := new(Router)
+	router.Init(reg)
+	return router
+}
+
+// Init initializes the BasicRequestResolver.
+func (r *BasicRequestResolver) Init(registry *Registry) {
+	r.registry = registry
+}
+
+// Resolve returns the given path.
+// This is a non-transforming resolver.
+func (r *BasicRequestResolver) Resolve(path string, cxt Context) (string, error) {
+	return path, nil
+}
+
+// Init initializes the Router.
+func (r *Router) Init(registry *Registry) *Router {
+	r.registry = registry
+	r.resolver = new(BasicRequestResolver)
+	r.resolver.Init(registry)
+	return r
+}
+
+// SetRegistry sets the registry.
+func (r *Router) SetRegistry(reg *Registry) {
+	r.registry = reg
+}
+
+// SetRequestResolver sets the request resolver.
+// The resolver is responsible for taking an arbitrary string and
+// resolving it to a registry route.
+//
+// Example: Take a URI and translate it to a route.
+func (r *Router) SetRequestResolver(resolver RequestResolver) {
+	r.resolver = resolver
+}
+
+// RequestResolver gets the request resolver.
+func (r *Router) RequestResolver() RequestResolver {
+	return r.resolver
+}
+
+// ResolveRequest resolver a given string into a route name.
+func (r *Router) ResolveRequest(name string, cxt Context) (string, error) {
+	routeName, e := r.resolver.Resolve(name, cxt)
+
+	if e != nil {
+		return routeName, e
+	}
+
+	return routeName, nil
+}
+
+// HandleRequest does a request.
+// This executes a request "named" name (this string is passed through the
+// request resolver.) The context is cloned (shallow copy) and passed in as the
+// base context.
+//
+// If taint is `true`, then no routes that begin with `@` can be executed. Taint
+// should be set to true on anything that relies on a name supplied by an
+// external client.
+//
+// This will do the following:
+// 	- resolve the request name into a route name (using a RequestResolver)
+// 	- look up the route
+// 	- execute each command on the route in order
+//
+// The following context variables are placed into the context during a run:
+//
+// 	route.Name - Processed name of the current route
+// 	route.Description - Description of the current route
+// 	route.RequestName - raw route name as passed by the client
+// 	command.Name - current command name (changed with each command)
+//
+// If an error occurred during processing, an error type is returned.
+func (r *Router) HandleRequest(name string, cxt Context, taint bool) error {
+
+	// Not sure why we were passing a copy of the context?
+	// baseCxt := cxt.Copy()
+	// routeName, e := r.ResolveRequest(name, baseCxt)
+	routeName, e := r.ResolveRequest(name, cxt)
+
+	if e != nil {
+		return e
+	}
+
+	cxt.Put("route.RequestName", name)
+	cxt.Put("route.Name", routeName)
+	if spec, ok := r.registry.RouteSpec(routeName); ok {
+		cxt.Put("route.Description", spec.description)
+	}
+
+	// Let an outer routine call go HandleRequest()
+	//go r.runRoute(routeName, cxt, taint)
+	e = r.runRoute(routeName, cxt, taint)
+
+	return e
+}
+
+// HasRoute checks whether or not the route exists.
+// Note that this does NOT resolve a request name into a route name. This
+// expects a route name.
+func (r *Router) HasRoute(name string) bool {
+	_, ok := r.registry.RouteSpec(name)
+	return ok
+}
+
+// PRIVATE ==========================================================
+
+// Given a router, context, and taint, run the route.
+func (r *Router) runRoute(route string, cxt Context, taint bool) error {
+	if len(route) == 0 {
+		return &RouteError{"Empty route name."}
+	}
+	if taint && route[0] == '@' {
+		return &RouteError{"Route is tainted. Refusing to run."}
+	}
+	spec, ok := r.registry.RouteSpec(route)
+	if !ok {
+		return &RouteError{fmt.Sprintf("Route %s does not exist.", route)}
+	}
+	// fmt.Printf("Running route %s: %s\n", spec.name, spec.description)
+	for _, cmd := range spec.commands {
+		// Provide info for each run.
+		cxt.Put("command.Name", cmd.name)
+
+		// fmt.Printf("Command %d is %s (%T)\n", i, cmd.name, cmd.command)
+		res, irq := r.doCommand(cmd, cxt)
+
+		// This may store a nil.
+		cxt.Put(cmd.name, res)
+
+		// Handle interrupts.
+		if irq != nil {
+			// If this is a reroute, call runRoute() again.
+			reroute, isType := irq.(*Reroute)
+			if isType {
+				routeName, e := r.ResolveRequest(reroute.RouteTo(), cxt)
+				if e != nil {
+					return e
+				}
+				//fmt.Printf("Routing to %s\n", routeName)
+				// MPB: I think re-routes should disable taint mode, since they
+				// are explicitly called from within the code.
+				return r.runRoute(routeName, cxt /*taint*/, false)
+			}
+
+			_, isType = irq.(*Stop)
+			if isType {
+				return nil
+			}
+
+			// If this is a recoverable error, recover and go on.
+			err, isType := irq.(*RecoverableError)
+			// Otherwise, terminate the route.
+			if isType {
+				// Swallow the error.
+				// XXX: Should this be logged?
+				cxt.Logf("warn", "Continuing after Recoverable Error on route %s: %v", route, err)
+			} else {
+				// return irq.(*FatalError)
+				return irq.(error)
+			}
+		}
+	}
+	return nil
+}
+
+// Do an individual command.
+func (r *Router) doCommand(cmd *commandSpec, cxt Context) (interface{}, Interrupt) {
+	params := r.resolveParams(cmd, cxt)
+
+	ret, irq := cmd.command(cxt, params)
+	return ret, irq
+}
+
+// Get the appropriate values for each param.
+func (r *Router) resolveParams(cmd *commandSpec, cxt Context) *Params {
+	parameters := NewParams(len(cmd.parameters))
+	for _, ps := range cmd.parameters {
+		sources := parseFromStatement(ps.from)
+		val := r.defaultFromSources(sources, cxt)
+		if val == nil {
+			parameters.set(ps.name, ps.defaultValue)
+			val = ps.defaultValue
+		}
+		parameters.set(ps.name, val)
+	}
+	return parameters
+}
+
+// Get the values from a source.
+// Returns the value of the first source to return a non-nil value.
+func (r *Router) defaultFromSources(sources []*fromVal, cxt Context) interface{} {
+	for _, src := range sources {
+		switch src.source {
+		case "c", "cxt", "context":
+			val, ok := cxt.Has(src.key)
+			if ok {
+				return val
+			}
+		case "datasource", "ds":
+			ds, ok := cxt.HasDatasource(src.key)
+			if ok {
+				return ds
+			}
+		default:
+			// If we have a datasource, and the datasource
+			// is a KeyValueDatasource, try to return the value.
+			if ds, ok := cxt.HasDatasource(src.source); ok {
+				store, ok := ds.(KeyValueDatasource)
+				if ok {
+					v := store.Value(src.key)
+					if v != nil {
+						return v
+					}
+					//fmt.Printf("V is nil for %v\n", src)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Parse a 'from' statement.
+func parseFromStatement(from string) []*fromVal {
+	toks := strings.Fields(from)
+	ret := make([]*fromVal, len(toks))
+	for i, tok := range toks {
+		ret[i] = parseFromVal(tok)
+	}
+	return ret
+}
+
+// Represents a 'from' value of a 'from' statement.
+type fromVal struct {
+	source, key string
+}
+
+// Parse a FROM string of the form NAME:VALUE
+func parseFromVal(from string) *fromVal {
+	vals := strings.SplitN(strings.TrimSpace(from), ":", 2)
+	if len(vals) == 1 {
+		return &fromVal{vals[0], ""}
+	}
+	return &fromVal{vals[0], vals[1]}
+}
+
+// RouteError indicates that a route cannot be executed successfully.
+type RouteError struct {
+	Message string
+}
+
+// Error returns the error.
+func (e *RouteError) Error() string {
+	return e.Message
+}

--- a/vendor/github.com/Masterminds/cookoo/router_test.go
+++ b/vendor/github.com/Masterminds/cookoo/router_test.go
@@ -1,0 +1,554 @@
+package cookoo
+
+import (
+	"testing"
+)
+
+// Mock resolver
+type FakeRequestResolver struct {
+	BasicRequestResolver
+}
+
+// Always returns FOO.
+func (self *FakeRequestResolver) Resolve(name string, cxt Context) (string, error) {
+	return "FOO", nil
+}
+
+type FakeErrorRequestResolver struct {
+	BasicRequestResolver
+}
+
+func (self *FakeErrorRequestResolver) Resolve(name string, cxt Context) (string, error) {
+	if name == "test" {
+		return "test", nil
+	}
+	return "test2", &RouteError{"Route not resolved."}
+}
+
+type CmdDefStub struct {
+	Name string `coo:"name"`
+	Age  int    `coo:"age"`
+}
+
+func (c *CmdDefStub) Run(cxt Context) (interface{}, Interrupt) {
+	if len(c.Name) == 0 {
+		return false, &FatalError{"Expected a name."}
+	}
+
+	return true, nil
+}
+
+// Test the resolver.
+func TestResolver(t *testing.T) {
+	fakeCxt := new(ExecutionContext)
+	fakeCxt.Init()
+	registry := new(Registry)
+	registry.Init()
+	r := new(Router)
+	r.Init(registry)
+
+	// Canary: Check that resolver is working.
+	if a, _ := r.ResolveRequest("test", fakeCxt); a != "test" {
+		t.Error("Expected path to be 'test'")
+	}
+
+	// Set and get a resolver.
+	resolver := new(FakeRequestResolver)
+	r.SetRequestResolver(resolver)
+	resolver, ok := r.RequestResolver().(*FakeRequestResolver)
+
+	if !ok {
+		t.Error("! Resolver is not a FakeRequestResolver.")
+	}
+
+	// Make sure the new resolver works.
+	path, _ := r.ResolveRequest("test", fakeCxt)
+
+	if path != "FOO" {
+		t.Error("Expected path to be 'test'")
+	}
+
+	// Test errors on a resolver.
+	resolver2 := new(FakeErrorRequestResolver)
+	r.SetRequestResolver(resolver2)
+	resolver2, ok2 := r.RequestResolver().(*FakeErrorRequestResolver)
+
+	if !ok2 {
+		t.Error("! Resolver is not a FakeErrorRequestResolver.")
+	}
+
+	_, e := r.ResolveRequest("test2", fakeCxt)
+	if e == nil {
+		t.Error("! Resolver did not error when it should.")
+	}
+
+	e = r.HandleRequest("test2", fakeCxt, true)
+	if e == nil {
+		t.Error("! HandleRequest did not error when it should.")
+	}
+	// Testing errors on a resolver via a reroute.
+	registry.
+		Route("test", "A test route").
+		Does(RerouteCommand, "fake").
+		Using("route").WithDefault("test2").
+		Route("test2", "a test").
+		Does(AddToContext, "fake2").
+		Using("bar").WithDefault("baz")
+
+	e = r.HandleRequest("test", fakeCxt, true)
+	if e == nil {
+		t.Error("! HandleRequest did not error on a reroute.")
+	}
+
+	if fakeCxt.Get("route.Name", "foo").(string) != "test" {
+		t.Error("! Expected route name to be test.")
+	}
+	if fakeCxt.Get("route.Description", "").(string) != "A test route" {
+		t.Error("! Unexpected route description")
+	}
+	if fakeCxt.Get("route.RequestName", "").(string) != "test" {
+		t.Errorf("Expected raw route name to be test.")
+	}
+	if n := fakeCxt.Get("command.Name", "").(string); n != "fake" {
+		t.Errorf("Expected fake to be the last command run. Got %s", n)
+	}
+
+}
+
+func MockCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	//println("Mock command")
+	return true, nil
+}
+
+func RerouteCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	route := params.Get("route", "default").(string)
+	return nil, &Reroute{route}
+}
+
+func FetchParams(cxt Context, params *Params) (interface{}, Interrupt) {
+	return params, nil
+}
+
+func RecoverableErrorCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	return nil, &RecoverableError{"Blarg"}
+}
+
+func FatalErrorCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	return nil, &FatalError{"Blarg"}
+}
+
+func StopCommand(cxt Context, params *Params) (interface{}, Interrupt) {
+	return nil, &Stop{}
+}
+
+type MockDatasource struct {
+	RetVal string
+}
+
+func (ds *MockDatasource) Value(key string) interface{} {
+	return ds.RetVal
+}
+
+func TestParseFromStatement(t *testing.T) {
+	str := "foo:bar foo:baz blarg:urg"
+	res := parseFromStatement(str)
+	if len(res) != 3 {
+		t.Error("! Expected length 3, got ", len(res))
+	}
+	exp := res[0]
+	if exp.source != "foo" {
+		t.Error("! Expected foo, got ", exp.source)
+	}
+	if exp.key != "bar" {
+		t.Error("! Expected bar, got ", exp.source)
+	}
+
+	exp = res[1]
+	if exp.source != "foo" {
+		t.Error("! Expected foo, got ", exp.source)
+	}
+	if exp.key != "baz" {
+		t.Error("! Expected baz, got ", exp.source)
+	}
+
+	exp = res[2]
+	if exp.source != "blarg" {
+		t.Error("! Expected blarg, got ", exp.source)
+	}
+	if exp.key != "urg" {
+		t.Error("! Expected urg, got ", exp.source)
+	}
+}
+
+func TestParseFromVal(t *testing.T) {
+	fr := "test:foo"
+
+	r := parseFromVal(fr)
+	name := r.source
+	val := r.key
+	if name != "test" {
+		t.Error("Expected 'test', got ", name)
+	}
+	if val != "foo" {
+		t.Error("Expected 'foo', got ", val)
+	}
+
+	fr = "test"
+	r = parseFromVal(fr)
+	name = r.source
+	val = r.key
+	if name != "test" {
+		t.Error("Expected 'test', got ", name)
+	}
+	if val != "" {
+		t.Error("Expected an empty string, got ", val)
+	}
+
+	fr = "test:"
+	r = parseFromVal(fr)
+	name = r.source
+	val = r.key
+	if name != "test" {
+		t.Error("Expected 'test', got ", name)
+	}
+	if val != "" {
+		t.Error("Expected an empty string, got ", val)
+	}
+
+	fr = "test:foo:bar:baz"
+	r = parseFromVal(fr)
+	name = r.source
+	val = r.key
+	if name != "test" {
+		t.Error("Expected 'test', got ", name)
+	}
+	if val != "foo:bar:baz" {
+		t.Error("Expected 'foo:bar:baz' string, got ", val)
+	}
+
+	fr = ""
+	r = parseFromVal(fr)
+	name = r.source
+	val = r.key
+	if name != "" {
+		t.Error("Expected empty string, got ", name)
+	}
+	if val != "" {
+		t.Error("Expected an empty string string, got ", val)
+	}
+}
+
+func TestRouterSetRegistry(t *testing.T) {
+	reg, router, cxt := Cookoo()
+	reg2 := NewRegistry()
+
+	reg.Route("mock", "a test").
+		Does(AddToContext, "fake").
+		Using("foo").WithDefault("bar")
+
+	reg2.Route("foo", "a test").
+		Does(AddToContext, "fake2").
+		Using("bar").WithDefault("baz")
+
+	router.SetRegistry(reg2)
+
+	e := router.HandleRequest("mock", cxt, true)
+	if e == nil {
+		t.Error("! Router should have been set to one that does not handle request.")
+	}
+}
+
+func TestFromValues(t *testing.T) {
+	reg, router, cxt := Cookoo()
+
+	cxt.Put("test1", 1234)
+	cxt.AddDatasource("test2", "foo")
+
+	ds := new(MockDatasource)
+	ds.RetVal = "1234"
+	cxt.AddDatasource("foo", ds)
+
+	reg.AddRoute(Route{
+		Name: "mock",
+		Help: "Test from.",
+		Does: Tasks{
+			Cmd{
+				Name: "first",
+				Fn:   FetchParams,
+				Using: []Param{
+					{Name: "test1", From: "cxt:test1"},
+					{Name: "test2", From: "datasource:test2"},
+					{Name: "test3", From: "foo:test3"},
+					{Name: "test4", From: "NONE:none", DefaultValue: "test4"},
+					{Name: "test5", From: "NONE:none foo:test3 cxt:test1", DefaultValue: "Z"},
+					{Name: "test6", From: "None:none"},
+				},
+			},
+		},
+	})
+
+	e := router.HandleRequest("mock", cxt, true)
+	if e != nil {
+		t.Error("Unexpected: ", e.Error())
+	}
+
+	params, ok := cxt.Get("first", nil).(*Params)
+	if !ok {
+		t.Error("! Expected a Params object.")
+	}
+
+	test1, ok := params.Has("test1")
+	if !ok {
+		t.Error("! Expected a value in cxt:test1")
+	}
+	if test1.(int) != 1234 {
+		t.Error("! Expected test1 to return 1234. Got ", test1)
+	}
+
+	test2, ok := params.Has("test2")
+	if !ok {
+		t.Error("! Expected a value in cxt:test1")
+	}
+	if test2.(string) != "foo" {
+		t.Error("! Expected test2 to return 'foo'. Got ", test2)
+	}
+
+	test3, ok := params.Has("test3")
+	if !ok {
+		t.Error("! Expected default value")
+	}
+	if test3.(string) != "1234" {
+		t.Error("! Expected test4 to return '1234'. Got ", test3)
+	}
+
+	test4, ok := params.Has("test4")
+	if !ok {
+		t.Error("! Expected default value")
+	}
+	if test4.(string) != "test4" {
+		t.Error("! Expected test4 to return 'test4'. Got ", test4)
+	}
+
+	// We expect that in this case the first match in the From clause
+	// will be returned, which is the value of foo:test3.
+	test5, ok := params.Has("test3")
+	if !ok {
+		t.Error("! Expected default value")
+	}
+	if test5.(string) != "1234" {
+		t.Error("! Expected test5 to return '1234'. Got ", test5)
+	}
+
+	param, ok := params.Has("test6")
+	// This expectation has changed. A nil value must be treated
+	// as a non-existing param. Otherwise there is no way to
+	// trigger defaults when no default is set on the chain itself.
+	//if !ok {
+	//	t.Error("! Expected a *Param with a nil value")
+	//}
+	if param != nil {
+		t.Error("! Expected nil value")
+	}
+}
+
+func TestHandleRequest(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.
+		Route("TEST", "A test route").Does(MockCommand, "fake").
+		Route("@tainted", "Tainted route").Does(MockCommand, "fake2").
+		Route("Several", "Test multiple.").
+		Does(MockCommand, "first").
+		Does(MockCommand, "second").
+		Does(MockCommand, "third")
+
+	e := router.HandleRequest("TEST", context, true)
+	if e != nil {
+		t.Error("Unexpected: ", e.Error())
+	}
+
+	e = router.HandleRequest("@tainted", context, true)
+	if e == nil {
+		t.Error("Expected tainted route to not run protected name.")
+	}
+	if e.Error() != "Route is tainted. Refusing to run." {
+		t.Error("Expected RouteError to be a tainted one.")
+	}
+
+	e = router.HandleRequest("@tainted", context, false)
+	if e != nil {
+		t.Error("Unexpected: ", e.Error())
+	}
+
+	router.HandleRequest("NO Such Route", context, false)
+
+	context = NewContext()
+	router.HandleRequest("Several", context, false)
+	if context.Len() != 7 {
+		t.Errorf("! Expected three items in the context, got %d", context.Len())
+	}
+
+	e = router.HandleRequest("", context, true)
+	if e == nil {
+		t.Error("Expected empty route to give error.")
+	}
+	if e.Error() != "Empty route name." {
+		t.Error("Expected RouteError to be a empty route error.")
+	}
+}
+
+func TestHandleRequestCmdDef(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.AddRoutes(Route{
+		Name: "TEST",
+		Help: "A test route",
+		Does: Tasks{
+			Cmd{
+				Name: "fake",
+				Fn:   MockCommand,
+			},
+		},
+	},
+		Route{
+			Name: "@tainted",
+			Help: "Tainted route",
+			Does: Tasks{
+				Cmd{Name: "fake", Fn: MockCommand},
+			},
+		},
+		Route{
+			Name: "Several",
+			Help: "Test multiple",
+			Does: Tasks{
+				Cmd{Name: "first", Fn: MockCommand},
+				Cmd{Name: "second", Fn: MockCommand},
+				Cmd{Name: "third", Fn: MockCommand},
+			},
+		},
+		Route{
+			Name: "CmdDef",
+			Help: "Test command defs.",
+			Does: Tasks{
+				CmdDef{
+					Name: "test",
+					Def:  &CmdDefStub{},
+					Using: []Param{
+						{Name: "name", DefaultValue: "test"},
+						{Name: "age", DefaultValue: 5},
+					},
+				},
+			},
+		})
+
+	e := router.HandleRequest("TEST", context, true)
+	if e != nil {
+		t.Error("Unexpected: ", e.Error())
+	}
+
+	e = router.HandleRequest("@tainted", context, true)
+	if e == nil {
+		t.Error("Expected tainted route to not run protected name.")
+	}
+	if e.Error() != "Route is tainted. Refusing to run." {
+		t.Error("Expected RouteError to be a tainted one.")
+	}
+
+	e = router.HandleRequest("@tainted", context, false)
+	if e != nil {
+		t.Error("Unexpected: ", e.Error())
+	}
+
+	router.HandleRequest("NO Such Route", context, false)
+
+	context = NewContext()
+	router.HandleRequest("Several", context, false)
+	if context.Len() != 7 {
+		t.Errorf("! Expected three items in the context, got %d", context.Len())
+	}
+
+	e = router.HandleRequest("", context, true)
+	if e == nil {
+		t.Error("Expected empty route to give error.")
+	}
+	if e.Error() != "Empty route name." {
+		t.Error("Expected RouteError to be a empty route error.")
+	}
+
+	// Test command def
+	if e = router.HandleRequest("CmdDef", context, true); e != nil {
+		t.Error(e)
+	}
+}
+
+func TestReroute(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.
+		Route("TEST", "A test route").Does(RerouteCommand, "fake").
+		Using("route").WithDefault("TEST2").
+		Route("TEST2", "Tainted route").Does(FetchParams, "fake2").Using("foo").WithDefault("bar")
+	e := router.HandleRequest("TEST", context, false)
+	if e != nil {
+		t.Error("! Unexpected error executing TEST")
+	}
+
+	p := context.Get("fake2", nil)
+	if p == nil {
+		t.Error("! Expected data in fake2.")
+	}
+}
+
+func TestRecoverableError(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.
+		Route("TEST", "A test route").
+		Does(RecoverableErrorCommand, "fake").
+		Does(FetchParams, "fake2").Using("foo").WithDefault("bar")
+
+	e := router.HandleRequest("TEST", context, false)
+	if e != nil {
+		t.Error("! Unexpected error executing TEST")
+	}
+
+	p := context.Get("fake2", nil)
+	if p == nil {
+		t.Error("! Expected data in fake2.")
+	}
+}
+
+func TestFatalError(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.
+		Route("TEST", "A test route").
+		Does(FatalErrorCommand, "fake").
+		Does(FetchParams, "fake2").Using("foo").WithDefault("bar")
+
+	e := router.HandleRequest("TEST", context, false)
+	if e == nil {
+		t.Error("! Expected error executing TEST")
+	}
+	if e.Error() != "Blarg" {
+		t.Error("! Message from FatalError is incorrect.")
+	}
+
+	p := context.Get("fake2", nil)
+	if p != nil {
+		t.Error("! Expected fake2 to not get executed.")
+	}
+}
+
+func TestStop(t *testing.T) {
+	reg, router, context := Cookoo()
+	reg.
+		Route("TEST", "A test route").
+		Does(StopCommand, "fake").
+		Does(FetchParams, "fake2").Using("foo").WithDefault("bar")
+
+	e := router.HandleRequest("TEST", context, false)
+	if e != nil {
+		t.Error("! Unexpected error executing TEST")
+	}
+
+	p := context.Get("fake2", nil)
+	if p != nil {
+		t.Error("! Expected fake2 to not get executed.")
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/safely/README.md
+++ b/vendor/github.com/Masterminds/cookoo/safely/README.md
@@ -1,0 +1,15 @@
+# Safely: Do scary things safely in Go.
+
+This is a small utility library for doing things safely.
+
+## Go Routine Wrappers
+
+Don't let a panic in a `goroutine` take down your entire program.
+
+```go
+import "github.com/Masterminds/safely"
+
+func main() {
+  safely.Go(func() { panic("Oops!") })
+}
+```

--- a/vendor/github.com/Masterminds/cookoo/safely/safely.go
+++ b/vendor/github.com/Masterminds/cookoo/safely/safely.go
@@ -1,0 +1,88 @@
+/* Safely is a package for providing safety wrappers around commonly used features.
+
+You might have at one point done this:
+
+	go myFunc()
+
+But what happens if myFunc panics? It will terminate the program with a panic.
+
+Safely provides a panic-trapping goroutine runner:
+
+	safely.Go(myFunc)
+
+If `myFunc` panics, Safely will capture the panic and log the error message.
+*/
+package safely
+
+import (
+	"log"
+)
+
+// GoDoer is a function that `safely.Go` can execute.
+type GoDoer func()
+
+// SafelyLogger is used to log messages when a failure occurs
+type SafelyLogger interface {
+	Printf(string, ...interface{})
+}
+
+// Captures the log portion of a cookoo.Context.
+type Logger interface {
+	Logf(string, string, ...interface{})
+}
+
+// Go executes a function as a goroutine, but recovers from any panics.
+//
+// Normally, if a GoRoutine panics, it will stop execution on the current
+// program, which ain't always good.
+//
+// safely.Go handles this by trapping the panic and writing it to the default
+// logger.
+//
+// To use your own logger, use safely.GoLog.
+func Go(todo GoDoer) {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				// Seems like there should be a way to get the default logger
+				// and then pass this into GoLog.
+				log.Printf("Panic in safely.Go: %s", err)
+			}
+		}()
+		todo()
+	}()
+}
+
+// GoDo runs a Goroutine, traps panics, and logs panics to a safely.Logger.
+//
+// Example:
+//
+// 	_, _, cxt := cookoo.Cookoo()
+// 	safely.GoDo(cxt, func(){})
+//
+//
+func GoDo(cxt Logger, todo GoDoer) {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				cxt.Logf("error", "Panic in safely.Go: %s", err)
+			}
+		}()
+		todo()
+	}()
+}
+
+
+// GoLog executes a function as a goroutine, but traps any panics.
+//
+// If a panic is encountered, it is logged to the given logger.
+func GoLog(logger SafelyLogger, todo GoDoer) {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				logger.Printf("Panic in safely.Go: %s", err)
+			}
+		}()
+		todo()
+	}()
+}

--- a/vendor/github.com/Masterminds/cookoo/safely/safely_test.go
+++ b/vendor/github.com/Masterminds/cookoo/safely/safely_test.go
@@ -1,0 +1,27 @@
+package safely
+
+import (
+	"testing"
+	"bytes"
+	"log"
+	"time"
+)
+
+func TestGo( t *testing.T) {
+	f := func() {
+		panic("OUCH!")
+	}
+	Go(f)
+}
+
+func TestGoLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	GoLog(logger, func() {
+		panic("OUCH")
+	})
+	time.Sleep(time.Second)
+	if !bytes.Contains(buf.Bytes(), []byte("OUCH")) {
+		t.Errorf("Expected to find 'OUCH' in %s.", buf.String())
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/sync_context.go
+++ b/vendor/github.com/Masterminds/cookoo/sync_context.go
@@ -1,0 +1,165 @@
+package cookoo
+
+import (
+	"sync"
+	"io"
+)
+
+// SyncContext wraps a context, syncronizing access to it.
+//
+// This uses a read/write mutex which allows multiple reads at a time, but
+// locks both reading and writing for writes.
+//
+// To avoid really nefarious bugs, the same mutex locks context values and
+// datasource values (since there is no guarantee that one is not backed by
+// the other).
+func SyncContext(cxt Context) Context {
+	var mutex sync.RWMutex
+	return &synchronizedContext{mutex: mutex, cxt: cxt}
+}
+
+type synchronizedContext struct {
+	mutex sync.RWMutex
+	cxt Context
+}
+
+// Add is deprecated. Use Put instead.
+func (s *synchronizedContext) Add(key string, val ContextValue) {
+	s.Put(key, val)
+}
+
+// Put locks the context and then inserts the key/value pair.
+func (s *synchronizedContext) Put (key string, val ContextValue) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cxt.Put(key, val)
+}
+
+// Get pulls a readlock, and then returns the associated value (or default
+// if no suitable value is found).
+func (s *synchronizedContext) Get(key string, def interface{}) ContextValue {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.Get(key, def)
+}
+
+// Has locks the context, and retrieves value and OK.
+//
+// If the key is not found in the context, the ok is set to false.
+func (s *synchronizedContext) Has(key string) (ContextValue, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.Has(key)
+}
+
+// Datasource read-locks the context, and then fetches the named datasource.
+func (s *synchronizedContext) Datasource(key string) Datasource {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.Datasource(key)
+}
+// Datasources read-locks and then returns a copy of a map of datasources.
+//
+// WARNING: As with all datasource operations, it is up to the underlying
+// datasource to handle concurrency issues. This does not deep copy the
+// datasources.
+func (s *synchronizedContext) Datasources() map[string]Datasource {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	// XXX: Is there any reason to copy the map before returning?
+	return s.cxt.Datasources()
+}
+// HasDatasource read-locks the context and then fetches the named datasource.
+//
+// If the datasource is not found, the ok flag will be set to false. This
+// allows you to differentiate between a missing datasource and a nil datasource.
+func (s *synchronizedContext) HasDatasource(key string) (Datasource, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.HasDatasource(key)
+}
+// AddDatasource locks the context and then adds a datasource.
+func (s *synchronizedContext) AddDatasource(key string, ds Datasource) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cxt.AddDatasource(key, ds)
+}
+// RemoveDatasource locks the context and then removes a datasource.
+func (s *synchronizedContext) RemoveDatasource(key string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cxt.RemoveDatasource(key)
+}
+// Len read-locks the context and then finds the length.
+func (s *synchronizedContext) Len() int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.Len()
+}
+
+// Copy makes a shallow copy of the underlying context, and then wraps it in a
+// new synchronizer.
+//
+// Use this with care. Because the copy is shallow, you can expose race
+// conditions when two contexts access the same underlying data. You may
+// want to make your own deep copy of the context. (see `Context.AsMap()`)
+func (s *synchronizedContext) Copy() Context {
+	return SyncContext(s.cxt.Copy())
+}
+// AsMap returns an unsynchronized map of the values in this context.
+//
+// This will give you access to the values, not the datasources or logger.
+//
+// The context is locked while the map is built and returned.
+func (s *synchronizedContext) AsMap() map[string]ContextValue {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.AsMap()
+}
+// Logger locks the context and then gets the logger.
+//
+// This will NOT prevent events from being written to the logger, but
+// it will prevent other changes.
+func (s *synchronizedContext) Logger(name string) (io.Writer, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.cxt.Logger(name)
+}
+
+// AddLogger puts a new logger into the context's logging subsystem.
+//
+// The context is locked during insertion.
+func (s *synchronizedContext) AddLogger(name string, logger io.Writer) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cxt.AddLogger(name, logger)
+}
+// RemoveLogger locks the context and then removes the logger from the context.
+//
+// This does NOT stop events from being logged to the logger, nor does it close
+// the underlying writer. However, once the logger is removed, no further log
+// messages will be written to it.
+func (s *synchronizedContext) RemoveLogger(name string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cxt.RemoveLogger(name)
+}
+
+// Log sends a message to the underlying logger.
+//
+// This method is not synchronized. It is expected that the underlying
+// logger will handle synchronization.
+func (s *synchronizedContext) Log(prefix string, v ...interface{}) {
+	s.cxt.Log(prefix, v...)
+}
+// Logf formats a message and sends it to the logger.
+//
+// This method is not synchronized, as it is assumed that the underlying logger
+// will handle synchronization.
+func (s *synchronizedContext) Logf(prefix, format string, v ...interface{}) {
+	s.cxt.Logf(prefix, format, v...)
+}
+
+
+

--- a/vendor/github.com/Masterminds/cookoo/web/auth/auth_datasource.go
+++ b/vendor/github.com/Masterminds/cookoo/web/auth/auth_datasource.go
@@ -1,0 +1,12 @@
+package auth
+
+// Authenticate a username/password pair.
+//
+// This expects a username and a password as strings.
+// A boolean `true` indicates that the user has been authenticated. A `false`
+// indicates that the user/password combo has failed to auth. This is not
+// necessarily an error. An error should only be returned when an unexpected
+// condition has obtained during authentication.
+type UserDatasource interface {
+	AuthUser(username, password string) (bool, error)
+}

--- a/vendor/github.com/Masterminds/cookoo/web/auth/basic.go
+++ b/vendor/github.com/Masterminds/cookoo/web/auth/basic.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"github.com/Masterminds/cookoo"
+
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"fmt"
+)
+
+/**
+ * Perform authentication.
+ *
+ * Params:
+ * 	- realm (string): The name of the realm. (Default: "web")
+ * 	- datasource (string): The name of the datasource that should be used to authenticate.
+ * 	  This datasource must be an `auth.UserDatasource`. (Default: "auth.UserDatasource")
+ *
+ * Context:
+ * 	- http.Request (*http.Request): The HTTP request. This is usually placed into the
+ * 	context for you.
+ * 	- http.ResponseWriter (http.ResponseWriter): The response. This is usually placed
+ * 	 into the context for you.
+ *
+ * Datasource:
+ * 	- An auth.UserDatasource. By default, this will look for a datasource named
+ * 	  "auth.UserDatasource". This can be overridden by the `datasource` param.
+ *
+ * Returns:
+ * 	- True if the user authenticated. If not, this will send a 401 and then stop
+ * 	  the current chain.
+ */
+func Basic(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	realm := p.Get("realm", "web").(string)
+	dsName := p.Get("datasource", "auth.UserDatasource").(string)
+
+	req := c.Get("http.Request", nil).(*http.Request)
+	res := c.Get("http.ResponseWriter", nil).(http.ResponseWriter)
+
+	ds := c.Datasource(dsName).(UserDatasource)
+
+	authz := strings.TrimSpace(req.Header.Get("Authorization"));
+	if len(authz) == 0 || !strings.Contains(authz, "Basic ") {
+		return sendUnauthorized(realm, res)
+	}
+
+	user, pass, err := parseBasicString(authz)
+	if err != nil {
+		c.Logf("info", "Basic authentication parsing failed: %s", err)
+		return sendUnauthorized(realm, res)
+	}
+
+	ok, err := ds.AuthUser(user, pass)
+	if !ok {
+		if err != nil {
+			c.Logf("info", "Basic authentication caused an error: %s", err)
+		}
+		return sendUnauthorized(realm, res)
+	}
+
+	return ok, err
+}
+
+func parseBasicString(header string) (user, pass string, err error) {
+	parts := strings.Split(header, " ")
+	user = ""
+	pass = ""
+	if len(parts) < 2 {
+		err = &cookoo.RecoverableError{"No auth string found."}
+		return
+	}
+
+	full, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return
+	}
+
+	parts = strings.SplitN(string(full), ":", 2)
+	user = parts[0]
+	if len(parts) > 0 {
+		pass = parts[1]
+	}
+	return
+}
+
+func sendUnauthorized(realm string, res http.ResponseWriter) (interface{}, cookoo.Interrupt) {
+	// Send a 403
+	res.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=\"%s\"", realm))
+	http.Error(res, "Authentication Required", http.StatusUnauthorized)
+
+	// We've already notified the client. Issue a stop.
+	return nil, &cookoo.Stop{}	
+}
+

--- a/vendor/github.com/Masterminds/cookoo/web/commands.go
+++ b/vendor/github.com/Masterminds/cookoo/web/commands.go
@@ -1,0 +1,282 @@
+package web
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/Masterminds/cookoo"
+	"html/template"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+)
+
+// Common web-oriented commands
+
+// Flush sends content to output.
+//
+// If no writer is specified, this will attempt to write to whatever is in the
+// Context with the key "http.ResponseWriter". If no suitable writer is found, it will
+// not write to anything at all.
+//
+// Params:
+// 	- writer: A Writer of some sort. This will try to write to the HTTP response if no writer
+// 	is specified.
+// 	- content: The content to write as a body. If this is a byte[], it is sent unchanged. Otherwise.
+// 	we first try to convert to a string, then pass it into a writer.
+// 	- contentType: The content type header (e.g. text/html). Default is text/plain
+// 	- responseCode: Integer HTTP Response Code: Default is `http.StatusOK`.
+// 	- headers: a map[string]string of HTTP headers. The keys will be run through
+// 	 http.CannonicalHeaderKey()
+//
+// Note that this is optimized for writing from strings or arrays, not Readers. For larger
+// objects, you may find it more efficient to use a different command.
+//
+// Context:
+// - If this finds `web.ContentEncoding`, it will set a content-encoding header.
+//
+// Returns
+//
+// 	- boolean true
+func Flush(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+
+	// Make sure we have a place to write this stuff.
+	writer, ok := params.Has("writer")
+	if writer == nil {
+		writer, ok = cxt.Has("http.ResponseWriter")
+		if !ok {
+			return false, nil
+		}
+	}
+	out := writer.(http.ResponseWriter)
+
+	// Get the rest of the info.
+	code := params.Get("responseCode", http.StatusOK).(int)
+	header := out.Header()
+	contentType := params.Get("contentType", "text/plain; charset=utf-8").(string)
+
+	// Prepare the content.
+	var content []byte
+	rawContent, ok := params.Has("content")
+	if !ok {
+		// No content. Send nothing in the body.
+		content = []byte("")
+	} else if byteContent, ok := rawContent.([]byte); ok {
+		// Got a byte[]; add it as is.
+		content = byteContent
+	} else {
+		// Use the formatter to convert to a string, and then
+		// cast it to bytes.
+		content = []byte(fmt.Sprintf("%v", rawContent))
+	}
+
+	// Add headers:
+	header.Set(http.CanonicalHeaderKey("content-type"), contentType)
+
+	te := cxt.Get(ContentEncoding, "").(string)
+	if len(te) > 0 {
+		header.Set(http.CanonicalHeaderKey("transfer-encoding"), te)
+	}
+
+	headerO, ok := params.Has("headers")
+	if ok {
+		headers := headerO.(map[string]string)
+		for k, v := range headers {
+			header.Add(http.CanonicalHeaderKey(k), v)
+		}
+	}
+
+	// Send the headers.
+	out.WriteHeader(code)
+
+	//io.WriteString(out, content)
+	out.Write(content)
+
+	return true, nil
+}
+
+// RenderHTML renders an HTML template.
+//
+// This uses the `html/template` system built into Go to render data into a writer.
+//
+// Params:
+// 	- template (required): An html/templates.Template object.
+// 	- templateName (required): The name of the template to render.
+// 	- values: An interface{} with the values to be passed to the template. If
+// 	  this is not specified, the contents of the Context are passed as a map[string]interface{}.
+// 	  Note that datasources, in this model, are not accessible to the template.
+// 	- writer: The writer that data should be sent to. By default, this will create a new
+// 	  Buffer and put it into the context. (If no Writer was passed in, the returned writer
+// 	  is actually a bytes.Buffer.) To flush the contents directly to the client, you can
+// 	  use `.Using('writer').From('http.ResponseWriter')`.
+//
+// Returns
+// 	- An io.Writer. The template's contents have already been written into the writer.
+//
+// Example:
+//
+//	reg.Route("GET /html", "Test HTML").
+//		Does(cookoo.AddToContext, "_").
+//			Using("Title").WithDefault("Hello World").
+//			Using("Body").WithDefault("This is the body.").
+//		Does(web.RenderHTML, "render").
+//			Using("template").From('cxt:templateCache').
+//			Using("templateName").WithDefault("index.html").
+//		Does(web.Flush, "_").
+//			Using("contentType").WithDefault("text/html").
+//			Using("content").From("cxt:render")
+//
+// In the example above, we do three things:
+// 	- Add Title and Body to the context. For the template rendered, it will see these as
+// 	  {{.Title}} and {{.Body}}.
+// 	- Render the template located in a local file called "index.html". It is recommended that
+// 	  a template.Template object be created at startup. This way, all of the templates can
+// 	  be cached immediately and shared throughout processing.
+// 	- Flush the result out to the client. This gives you a chance to add any additional headers.
+func RenderHTML(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	ok, missing := params.Requires("template", "templateName")
+	if !ok {
+		return nil, &cookoo.FatalError{"Missing params: " + strings.Join(missing, ", ")}
+	}
+
+	var buf bytes.Buffer
+	out := params.Get("writer", &buf).(io.Writer)
+	tplName := params.Get("templateName", nil).(string)
+	tpl := params.Get("template", nil).(*template.Template)
+	vals := params.Get("values", cxt.AsMap())
+
+	err := tpl.ExecuteTemplate(out, tplName, vals)
+	if err != nil {
+		log.Printf("Recoverable error parsing template: %s", err)
+		// XXX: This outputs partially completed templates. Is this what we want?
+		io.WriteString(out, "Template error. The error has been logged.")
+		return out, &cookoo.RecoverableError{"Template failed to completely render."}
+	}
+	return out, nil
+}
+
+// ServerInfo gets the server info for this request.
+//
+// This assumes that `http.Request` and `http.ResponseWriter` are in the context, which
+// they are by default.
+//
+// Returns:
+// 	- boolean true
+func ServerInfo(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	req := cxt.Get("http.Request", nil).(*http.Request)
+	out := cxt.Get("http.ResponseWriter", nil).(http.ResponseWriter)
+
+	out.Header().Add("X-Foo", "Bar")
+	out.Header().Add("Content-type", "text/plain; charset=utf-8")
+
+	fmt.Fprintf(out, "Request:\n %+v\n", req)
+	fmt.Fprintf(out, "\n\n\nResponse:\n%+v\n", out)
+	return true, nil
+}
+
+const ContentEncoding = "web.ContentEncoding"
+
+// GuessContentType guesses the MIME type of a given name.
+//
+// Name should be a path-like thing with an extension. E.g. foo.html,
+// foo/bar/baz.css
+//
+// If this detects a file with extensions like gz, zip, or Z, it will also
+// set the context `web.ContentEncoding` to the appropriate encoding.
+//
+// Params:
+//	- name (string): The filename-like thing to use to guess the content type.
+// Returns:
+//	string content-type
+func GuessContentType(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
+	n := p.Get("name", "").(string)
+
+	ext := strings.ToLower(path.Ext(n))
+	switch ext {
+	case ".Z":
+		c.Put(ContentEncoding, "compress")
+	case ".gz", ".gzip", ".tgz":
+		c.Put(ContentEncoding, "gzip")
+		if ext == "tgz" {
+			ext = "tar"
+		}
+	case ".bz2", ".bzip2", ".tbz2":
+		c.Put(ContentEncoding, "bzip2")
+		if ext == "tbz2" {
+			ext = "tar"
+		}
+	}
+
+	return mime.TypeByExtension(ext), nil
+}
+
+// ServeFiles is a cookoo command to serve files from a set of filesystem directories.
+//
+// If no writer is specified, this will attempt to write to whatever is in the
+// Context with the key "http.ResponseWriter". If no suitable writer is found, it will
+// not write to anything at all.
+//
+// Example:
+//
+//     registry.Route("GET /**", "Serve assets").
+//         Does(web.ServeFiles, "fileServer").
+//            Using("directory").WithDefault("static")
+//
+// Example 2:
+//
+//     registry.Route("GET /foo/**", "Serve assets").
+//         Does(web.ServeFiles, "fileServer").
+//             Using("directory").WithDefault("static").
+//             Using("removePrefix").WithDefault("/foo")
+//
+// Params:
+// 	- directory: A directory to serve files from.
+// 	- removePrefix: A prefix to remove from the url before looking for it on the filesystem.
+// 	- writer: A Writer of some sort. This will try to write to the HTTP response if no writer
+// 	  is specified.
+// 	- request: A request of some sort. This will try to use the HTTP request if no request
+// 	  is specified.
+func ServeFiles(cxt cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt) {
+
+	writer, ok := params.Has("writer")
+	if writer == nil {
+		writer, ok = cxt.Has("http.ResponseWriter")
+		if !ok {
+			return nil, &cookoo.Reroute{"@404"}
+		}
+	}
+	out := writer.(http.ResponseWriter)
+
+	req, ok := params.Has("request")
+	if req == nil {
+		req, ok = cxt.Has("http.Request")
+		if !ok {
+			return nil, &cookoo.Reroute{"@404"}
+		}
+	}
+
+	in := req.(*http.Request)
+
+	directory := params.Get("directory", nil)
+	if directory == nil {
+		return nil, &cookoo.Reroute{"@404"}
+	}
+
+	prefix := params.Get("removePrefix", "").(string)
+	urlPath := strings.TrimPrefix(in.URL.Path, prefix)
+	staticFile := path.Join(directory.(string), urlPath)
+
+	info, err := os.Stat(staticFile)
+	if err != nil {
+		return nil, &cookoo.Reroute{"@404"}
+	}
+
+	if info.IsDir() == false {
+		http.ServeFile(out, in, staticFile)
+		return true, nil
+	}
+	return nil, &cookoo.Reroute{"@404"}
+}

--- a/vendor/github.com/Masterminds/cookoo/web/datasources.go
+++ b/vendor/github.com/Masterminds/cookoo/web/datasources.go
@@ -1,0 +1,192 @@
+// Extra datasources for Web servers.
+package web
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Get the query parameters by name.
+type QueryParameterDatasource struct {
+	Parameters url.Values
+}
+
+// The datasource for URLs.
+// This datasource knows the following items:
+// - url: the URL struct
+// - scheme: The scheme of the URL as a string
+// - opaque: The opaque identifier
+// - user: A *Userinfo
+// - host: The string hostname
+// - path: The entire path
+// - rawquery: The query string, not decoded.
+// - fragment: The fragment string.
+// - query: The array of Query parameters. Usually it is better to use the
+//   'query:foo' syntax.
+type URLDatasource struct {
+	URL *url.URL
+}
+
+type RequestHeaderDatasource struct {
+	req *http.Request
+}
+
+func (r *RequestHeaderDatasource) Init(req *http.Request) *RequestHeaderDatasource {
+	r.req = req
+	return r
+}
+func (r *RequestHeaderDatasource) Value(name string) interface{} {
+	// We return a nil so that the context can substitute in a
+	// default value. Empty string for headers seems to always mean
+	// "No header found". So a default value 'bar' is what is expected when
+	// From("header:foo").WithDefault("bar") and foo is not present.
+	v := r.req.Header.Get(name)
+	if len(v) == 0 {
+		return nil
+	}
+	return v
+}
+
+// Access to name/value pairs in POST/PUT form data from the body.
+// This will attempt to access form data supplied in the HTTP request's body.
+// If the MIME type is not correct or if there is no POST data, no data will
+// be made available.
+//
+// Parsing is lazy: No form data is parsed until it is requested.
+type FormValuesDatasource struct {
+	req *http.Request
+}
+
+func (f *FormValuesDatasource) Init(req *http.Request) *FormValuesDatasource {
+	f.req = req
+	return f
+}
+
+// The return value will always be a string or nil.
+// To match the interface, we use interface{}.
+func (f *FormValuesDatasource) Value(name string) interface{} {
+	return f.req.PostFormValue(name)
+}
+
+func (d *QueryParameterDatasource) Init(vals url.Values) *QueryParameterDatasource {
+	d.Parameters = vals
+	return d
+}
+
+func (d *QueryParameterDatasource) Value(name string) interface{} {
+	v := d.Parameters.Get(name)
+
+	// We need to do this to meet the expectations of the datasource system.
+	if len(v) == 0 {
+		return nil
+	}
+	return v
+}
+
+func (d *URLDatasource) Init(parsedUrl *url.URL) *URLDatasource {
+	d.URL = parsedUrl
+	return d
+}
+
+func (d *URLDatasource) Value(name string) interface{} {
+	switch name {
+	case "host", "Host":
+		return d.URL.Host
+	case "path", "Path":
+		return d.URL.Path
+	case "url", "URL", "Url":
+		return d.URL
+	case "user", "User":
+		return d.URL.User
+	case "scheme", "Scheme":
+		return d.URL.Scheme
+	case "rawquery", "RawQuery":
+		return d.URL.RawQuery
+	case "query", "Query":
+		return d.URL.Query()
+	case "fragment", "Fragment":
+		return d.URL.Fragment
+	case "opaque", "Opaque":
+		return d.URL.Opaque
+	}
+	return nil
+}
+
+type PathDatasource struct {
+	PathParts []string
+}
+
+func (d *PathDatasource) Init(path string) *PathDatasource {
+	d.PathParts = strings.Split(path, "/")[1:]
+	return d
+}
+
+func (d *PathDatasource) Value(name string) interface{} {
+	index, err := strconv.Atoi(name)
+	if err != nil || index > len(d.PathParts) {
+		return nil
+	}
+	return d.PathParts[index]
+}
+
+// This provides a datasource for session data.
+//
+// Sessions differ a little from the other web datasources in that they may
+// need explicit app-controlled initialization.
+type SessionDatasource interface {
+	StartSession(res http.ResponseWriter, req *http.Request) bool
+	ClearSession(res http.ResponseWriter, req *http.Request) bool
+}
+
+/*
+type HTMLTemplateCache struct {
+	//tpls map[string]*templates.Template
+	tpls templates.Template
+}
+
+// Create a new template cache with the associated templates.
+//
+// The array of strings may be either file names or shell glob patterns. In any
+// case, the pattern must match at least one file, or a fatal error will occur.
+func NewHTMLTemplateCache(filenames []string) *HTMLTemplateCache {
+	t := new(HTMLTemplateCache)
+	tpls = templates.New("base")
+	for _, filename := range filenames {
+		_, err := t.ParseGlob(filename)
+		if err != nil {
+			panic("Could not process templates! ", err)
+		}
+	}
+	return t
+}
+
+// Add one or more templates to the cache.
+//
+// filenames may be glob patterns, but at least one file must match.
+//
+// If a template fails to parse, an error will be returned, but this will not
+// cause a panic. Any templates added here will be accessible for anything else
+// that accesses the cache.
+func (c *HTMLTemplateCache) AddTemplates(filenames ...string) error {
+	for _, f := range filenames {
+		_, e := c.tpls.ParseGlob(f)
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// Clone the existing template cache.
+//
+// This is useful if a particular command needs to modify the template cache
+// for it's execution without changing the generally available cache.
+//
+// If the cache cannot be cloned, an error will be returned. This will not
+// cause a panic.
+func (c *HTMLTemplateCache) Clone() (*templates.Template, error) {
+	return c.tpls.Clone()
+}
+*/

--- a/vendor/github.com/Masterminds/cookoo/web/datasources_test.go
+++ b/vendor/github.com/Masterminds/cookoo/web/datasources_test.go
@@ -1,0 +1,126 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestURLDatasource(t *testing.T) {
+	rawurl := "http://user:password@example.com/path?foo=bar#fragment"
+	testUrl, err := url.Parse(rawurl)
+
+	if err != nil {
+		t.Error("! Unexpected error.", err)
+		return
+	}
+	ds := new(URLDatasource)
+	ds.Init(testUrl)
+
+	// Test the string values.
+	arr := map[string]string{
+		"scheme":   "http",
+		"Path":     "/path",
+		"host":     "example.com",
+		"fragment": "fragment",
+	}
+	for key, val := range arr {
+		if ds.Value(key) != val {
+			t.Error(fmt.Sprintf("! Expected '%s', got '%s'", val, ds.Value(key)))
+		}
+	}
+
+	// Test the Query Values object.
+	qvals := ds.Value("Query").(url.Values)
+	if qvals.Get("foo") != "bar" {
+		t.Error("! Expected to find foo=bar query param. Found ", qvals["foo"])
+	}
+
+	// Test the Userinfo object
+	uinfo := ds.Value("User").(*url.Userinfo)
+
+	if uinfo.Username() != "user" {
+		t.Error("! Expected user name 'user', got ", uinfo.Username)
+	}
+}
+
+func TestQueryParameterDatasource(t *testing.T) {
+	testUrl, err := url.ParseRequestURI("/foo?a=b&c=foo+bar&d=1234&d=5678")
+	if err != nil {
+		t.Error("! Unexpected URL parse error.")
+	}
+	ds := new(QueryParameterDatasource).Init(testUrl.Query())
+
+	// Test the string values.
+	arr := map[string]string{
+		"a": "b",
+		"c": "foo bar",
+		// url.Values.Get accesses the first value associated with a key. To get
+		// values after that you need to access the map directly.
+		"d": "1234",
+	}
+	for key, val := range arr {
+		if ds.Value(key) != val {
+			t.Error(fmt.Sprintf("! Expected '%s', got '%s'", val, ds.Value(key)))
+		}
+	}
+
+}
+
+func TestFormValuesDatasource(t *testing.T) {
+	method := "POST"
+	urlString := "http://example.com/form/test"
+	body := strings.NewReader("name=Inigo+Montoya&fingers=6")
+
+	request, err := http.NewRequest(method, urlString, body)
+
+	// Canary
+	if err != nil {
+		t.Error("! Error constructing a request.", err)
+	}
+
+	// For POST requests with a body from a form the Content-Type header needs
+	// to be set or the form body isn't processed.
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
+
+	ds := new(FormValuesDatasource).Init(request)
+
+	if ds.Value("name").(string) != "Inigo Montoya" {
+		t.Error("! Prepare to die.")
+	}
+
+	if ds.Value("fingers") != "6" {
+		t.Error("! Expected six fingers, but got less.")
+	}
+}
+
+func TestPathDatasource(t *testing.T) {
+	ds := new(PathDatasource).Init("/foo/bar")
+	if ds.Value("0") != "foo" {
+		t.Error("! Expected value 0 to be 'foo'. Got ", ds.Value("0"))
+	}
+
+	if ds.Value("1") != "bar" {
+		t.Error("! Expected value 1 to be 'bar'. Got ", ds.Value("1"))
+	}
+
+	ds = new(PathDatasource).Init("POST /foo/bar")
+	if ds.Value("0") != "foo" {
+		t.Error("! Expected value 0 to be 'foo'. Got ", ds.Value("0"))
+	}
+
+	if ds.Value("1") != "bar" {
+		t.Error("! Expected value 1 to be 'bar'. Got ", ds.Value("1"))
+	}
+
+	ds = new(PathDatasource).Init("POST /foo/bar/baz/a/b/c/d/e/f")
+	if ds.Value("0") != "foo" {
+		t.Error("! Expected value 0 to be 'foo'. Got ", ds.Value("0"))
+	}
+
+	if ds.Value("1") != "bar" {
+		t.Error("! Expected value 1 to be 'bar'. Got ", ds.Value("1"))
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/web/server.go
+++ b/vendor/github.com/Masterminds/cookoo/web/server.go
@@ -1,0 +1,271 @@
+package web
+
+import (
+	"github.com/Masterminds/cookoo"
+	"net/http"
+	"runtime"
+
+	"os"
+	"os/signal"
+)
+
+// Serve creates a new Cookoo web server.
+//
+// Important details:
+//
+// 	- A URIPathResolver is used for resolving request names.
+// 	- The following datasources are added to the Context:
+// 	  * url: A URLDatasource (Provides access to parts of the URL)
+// 	  * path: A PathDatasource (Provides access to parts of a path. E.g. "/foo/bar")
+// 	  * query: A QueryParameterDatasource (Provides access to URL query parameters.)
+// 	  * post: A FormValuesDatasource (Provides access to form data or the body of a request.)
+// 	- The following context variables are set:
+// 	  * http.Request: A pointer to the http.Request object
+// 	  * http.ResponseWriter: The response writer.
+// 	  * server.Address: The server's address and port (NOT ALWAYS PRESENT)
+// 	- The handler includes logic to redirect "not found" errors to a path named "@404" if present.
+//
+// Context Params:
+//
+// 	- server.Address: If this key exists in the context, it will be used to determine the host/port the
+//   server runes on. EXPERIMENTAL. Default is ":8080".
+//
+// Example:
+//
+//    package main
+//
+//    import (
+//      //This is the path to Cookoo
+//      "github.com/Masterminds/cookoo"
+//      "github.com/Masterminds/cookoo/web"
+//      "fmt"
+//    )
+//
+//    func main() {
+//      // Build a new Cookoo app.
+//      registry, router, context := cookoo.Cookoo()
+//
+//      // Fill the registry.
+//      registry.Route("GET /", "The index").Does(web.Flush, "example").
+//        Using("content").WithDefault("Hello World")
+//
+//      // Create a server
+//      web.Serve(reg, router, cookoo.SyncContext(cxt))
+//    }
+//
+// Note that we synchronize the context before passing it into Serve(). This
+// is optional because each handler gets its own copy of the context already.
+// However, if commands pass the context to goroutines, the context ought to be
+// synchronized to avoid race conditions.
+//
+// Note that copies of the context are not synchronized with each other.
+// So by declaring the context synchronized here, you
+// are not therefore synchronizing across handlers.
+func Serve(reg *cookoo.Registry, router *cookoo.Router, cxt cookoo.Context) {
+	addr := cxt.Get("server.Address", ":8080").(string)
+
+	handler := NewCookooHandler(reg, router, cxt)
+
+	// MPB: I dont think there's any real point in having a multiplexer in
+	// this particular case. The Cookoo handler is mux enough.
+	//
+	// Note that we can always use Cookoo with the built-in multiplexer. It
+	// just doesn't make sense if Cookoo's the only handler on the app.
+	//http.Handle("/", handler)
+
+	server := &http.Server{Addr: addr}
+
+	// Instead of mux, set a single default handler.
+	// What we might be losing:
+	// - Handling of non-conforming paths.
+	server.Handler = handler
+
+	go handleSignals(router, cxt, server)
+	err := server.ListenAndServe()
+	//err := http.ListenAndServe(addr, nil)
+	if err != nil {
+		cxt.Logf("error", "Caught error while serving: %s", err)
+		if router.HasRoute("@crash") {
+			router.HandleRequest("@crash", cxt, false)
+		}
+	}
+}
+
+// ServeTLS does the same as Serve, but with SSL support.
+//
+// If `server.Address` is not found in the context, the default address is
+// `:4433`.
+//
+// Neither certFile nor keyFile are stored in the context. These values are
+// considered to be security sensitive.
+func ServeTLS(reg *cookoo.Registry, router *cookoo.Router, cxt cookoo.Context, certFile, keyFile string) {
+	addr := cxt.Get("server.Address", ":4433").(string)
+
+	server := &http.Server{Addr: addr}
+	server.Handler = NewCookooHandler(reg, router, cxt)
+
+	go handleSignals(router, cxt, server)
+	err := server.ListenAndServeTLS(certFile, keyFile)
+	if err != nil {
+		cxt.Logf("error", "Caught error while serving: %s", err)
+		if router.HasRoute("@crash") {
+			router.HandleRequest("@crash", cxt, false)
+		}
+	}
+}
+
+// handleSignals traps kill and interrupt signals and runs shutdown().
+func handleSignals(router *cookoo.Router, cxt cookoo.Context, server *http.Server) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Kill, os.Interrupt)
+
+	s := <-sig
+	cxt.Logf("info", "Received signal %s. Shutting down.", s)
+	// Not particularly useful on its own.
+	// server.SetKeepAlivesEnabled(false)
+	// TODO: Implement graceful shutdowns.
+	shutdown(router, cxt)
+	os.Exit(0)
+
+}
+
+// shutdown runs an @shutdown route if it's found in the router.
+func shutdown(router *cookoo.Router, cxt cookoo.Context) {
+	if router.HasRoute("@shutdown") {
+		cxt.Logf("info", "Executing route @shutdown")
+		router.HandleRequest("@shutdown", cxt, false)
+	}
+}
+
+// The handler for Cookoo.
+// You way use this handler in your own web apps, or you can use
+// the Serve() function to create and manage a handler for you.
+type CookooHandler struct {
+	Registry    *cookoo.Registry
+	Router      *cookoo.Router
+	BaseContext cookoo.Context
+}
+
+// Create a new Cookoo HTTP handler.
+//
+// This will create an HTTP hanlder, but will not automatically attach it to a server. Implementors
+// can take the handler and attach it to an existing HTTP server wiht http.HandleFunc() or
+// http.ListenAndServe().
+//
+// For simple web servers, using this package's Serve() function may be the easier route.
+//
+// Important details:
+//
+// - A URIPathResolver is used for resolving request names.
+// - The following datasources are added to the Context:
+//   * url: A URLDatasource (Provides access to parts of the URL)
+//   * path: A PathDatasource (Provides access to parts of a path. E.g. "/foo/bar")
+//   * query: A QueryParameterDatasource (Provides access to URL query parameters.)
+//   * post: A FormValuesDatasource (Provides access to form data or the body of a request.)
+// - The following context variables are set:
+//   * http.Request: A pointer to the http.Request object
+//   * http.ResponseWriter: The response writer.
+//   * server.Address: The server's address and port (NOT ALWAYS PRESENT)
+func NewCookooHandler(reg *cookoo.Registry, router *cookoo.Router, cxt cookoo.Context) *CookooHandler {
+	handler := new(CookooHandler)
+	handler.Registry = reg
+	handler.Router = router
+	handler.BaseContext = cxt
+
+	// Use the URI oriented request resolver in this package.
+	resolver := new(URIPathResolver)
+	resolver.Init(reg)
+	router.SetRequestResolver(resolver)
+
+	return handler
+}
+
+// Adds the built-in HTTP-specific datasources.
+func (h *CookooHandler) addDatasources(cxt cookoo.Context, req *http.Request) {
+	parsedURL := req.URL
+	urlDS := new(URLDatasource).Init(parsedURL)
+	queryDS := new(QueryParameterDatasource).Init(parsedURL.Query())
+	formDS := new(FormValuesDatasource).Init(req)
+	pathDS := new(PathDatasource).Init(parsedURL.Path)
+	headerDS := new(RequestHeaderDatasource).Init(req)
+
+	cxt.AddDatasource("url", urlDS)
+	cxt.AddDatasource("query", queryDS)
+	// cxt.AddDatasource("q", queryDS)
+	cxt.AddDatasource("post", formDS)
+	cxt.AddDatasource("path", pathDS)
+	cxt.AddDatasource("header", headerDS)
+}
+
+// ServeHTTP is the Cookoo request handling function.
+//
+// This is capable of handling HTTP and HTTPS requests.
+func (h *CookooHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	// First we need to clone the context so we have a mutable copy.
+	cxt := h.BaseContext.Copy()
+	// Trap panics and make them 500 errors:
+	defer func() {
+		// fmt.Printf("Deferred function executed for path %s\n", req.URL.Path)
+		if err := recover(); err != nil {
+			//log.Printf("FOUND ERROR: %v", err)
+			where := cxt.Get("command.Name", "<unknown>").(string)
+			rname := cxt.Get("route.Name", "<unknown>").(string)
+			h.BaseContext.Logf("error", "CookooHandler trapped a panic on route '%s' in command '%s': %v", rname, where, err)
+
+			// Buffer for a stack trace.
+			// This is pretty much always worthless, as the stack has been
+			// unwound up to here.
+			stack := make([]byte, 8192)
+			size := runtime.Stack(stack, false)
+			h.BaseContext.Logf("error", "Stack: %s", stack[:size])
+
+			if size == 8192 {
+				h.BaseContext.Logf("error", "<truncated stack trace at 8192 bytes>")
+			}
+
+			http.Error(res, "An internal error occurred.", http.StatusInternalServerError)
+		}
+	}()
+
+	cxt.Put("http.Request", req)
+	cxt.Put("http.ResponseWriter", res)
+
+	// Next, we add the datasources for URL and Query params.
+	h.addDatasources(cxt, req)
+
+	// Find the route
+	path := req.Method + " " + req.URL.Path
+
+	cxt.Logf("info", "Handling request for %s\n", path)
+
+	// If a route matches, run it.
+	err := h.Router.HandleRequest(path, cxt, true)
+	if err != nil {
+		switch err.(type) {
+
+		// For a 404, we bail.
+		case *cookoo.RouteError:
+			cxt.Logf("info", "(recovering) RouteError on route %s: %s", path, err)
+			if h.Router.HasRoute("@404") {
+				h.Router.HandleRequest("@404", cxt, false)
+			} else {
+				http.NotFound(res, req)
+			}
+			return
+		// For any other, we go to a 500.
+		case *cookoo.FatalError:
+			cxt.Logf("error", "Fatal Error on route '%s': %s", path, err)
+		default:
+			cxt.Logf("error", "Untagged error on route '%s': %v (%T)", path, err, err)
+		}
+
+		if h.Router.HasRoute("@500") {
+			cxt.Put("error", err)
+			h.Router.HandleRequest("@500", cxt, false)
+		} else {
+			// Passing the error back to the client is a bad default.
+			//http.Error(res, err.Error(), http.StatusInternalServerError)
+			http.Error(res, "Internal error processing the request.", http.StatusInternalServerError)
+		}
+	}
+}

--- a/vendor/github.com/Masterminds/cookoo/web/uripathresolver.go
+++ b/vendor/github.com/Masterminds/cookoo/web/uripathresolver.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"github.com/Masterminds/cookoo"
+	"path"
+	"strings"
+)
+
+// Resolver for transforming a URI path into a route.
+//
+// This is a more sophisticated path resolver, aware of
+// heirarchyand wildcards.
+//
+// Examples:
+// - URI path `/foo` matches the entry `/foo`
+// - URI path `/foo/bar` could match entries like `/foo/*`, `/foo/**`, and `/foo/bar`
+// - URI path `/foo/bar/baz` could match `/foo/*/baz` and `/foo/**`
+//
+// HTTP Verbs:
+// This resolver also allows you to specify verbs at the beginning of a path:
+// - "GET /foo" and "POST /foo" are separate (but legal) paths. "* /foo" will allow any verb.
+// - There are no constrainst on verb name. Thus, verbs like WebDAV's PROPSET are fine, too. Or you can
+//   make up your own.
+//
+// IMPORTANT! When it comes to matching route patterns against paths, ORDER IS
+// IMPORTANT. Routes are evaluated in order. So if two rules (/a/b* and /a/bc) are
+// both defined, the incomming request /a/bc will match whichever route is
+// defined first. See the unit tests for examples.
+//
+// The `**` and `/**` Wildcards:
+// =============================
+//
+// In addition to the paths described in the `path` package of Go's core, two
+// extra wildcard sequences are defined:
+//
+// - `**`: Match everything.
+// - `/**`: a suffix that matches any sub-path.
+//
+// The `**` wildcard works in ONLY ONE WAY:  If the path is declared as `**`, with nothing else, 
+// then any path will match.
+//
+// VALID: `**`, `GET /foo/**`, `GET /**`
+// NOT VALID: `GET **`, `**/foo`, `foo/**/bar`
+//
+// The `/**` suffix can only be added to the end of a path, and says "Match
+// anything under this".
+//
+// Examples:
+// - URI paths "/foo", "GET /a/b/c", and "hello" all match "**". (The ** rule
+//   can be very dangerous for this reason.)
+// - URI path "/assets/images/foo/bar/baz.jpg" matches "/assets/**"
+// 
+// The behavior for rules that contain `/**` anywhere other than the end
+// have undefined behavior.
+//
+type URIPathResolver struct {
+	registry *cookoo.Registry
+}
+
+// Creates a new URIPathResolver.
+func NewURIPathResolver(reg *cookoo.Registry) *URIPathResolver {
+	res := new(URIPathResolver)
+	res.Init(reg)
+	return res
+}
+
+func (r *URIPathResolver) Init(registry *cookoo.Registry) {
+	r.registry = registry
+}
+
+// Resolve a path name based using path patterns.
+//
+// This resolver is designed to match path-like strings to path patterns. For example,
+// the path `/foo/bar/baz` may match routes like `/foo/*/baz` or `/foo/bar/*`
+func (r *URIPathResolver) Resolve(pathName string, cxt cookoo.Context) (string, error) {
+	// HTTP verb support naturally falls out of the fact that spaces in paths are legal in UNIXy systems, while
+	// illegal in URI paths. So presently we do no special handling for verbs. Yay for simplicity.
+	for _, pattern := range r.registry.RouteNames() {
+
+		if strings.HasSuffix(pattern, "**") {
+			ok := r.subtreeMatch(cxt, pathName, pattern)
+			if ok {
+				return pattern, nil
+			}
+		}
+
+		if ok, err := path.Match(pattern, pathName); ok && err == nil {
+			return pattern, nil
+		} else if err != nil {
+			// Bad pattern
+			return pathName, err
+		}
+	}
+	return pathName, &cookoo.RouteError{"Could not resolve route " + pathName}
+}
+
+func (r *URIPathResolver) subtreeMatch(c cookoo.Context, pathName, pattern string) bool {
+
+	if pattern == "**" {
+		return true
+	}
+
+	// Find out how many slashes we have.
+	countSlash := strings.Count(pattern, "/")
+
+	// '**' matches anything.
+	if countSlash == 0 {
+		c.Logf("warn", "Illegal pattern: %s", pattern)
+		return false
+	}
+
+	// Add 2 for verb plus trailer.
+	parts := strings.SplitN(pathName, "/", countSlash + 1)
+	prefix := strings.Join(parts[0:countSlash], "/")
+
+	subpattern := strings.Replace(pattern, "/**", "", -1)
+	if ok, err := path.Match(subpattern, prefix); ok && err == nil {
+		return true
+	} else if err != nil {
+		c.Logf("warn", "Parsing path `%s` gave error: %s", err)
+	}
+	return false
+}

--- a/vendor/github.com/Masterminds/cookoo/web/uripathresolver_test.go
+++ b/vendor/github.com/Masterminds/cookoo/web/uripathresolver_test.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"fmt"
+	"github.com/Masterminds/cookoo"
+	"testing"
+)
+
+func TestUriPathResolver(t *testing.T) {
+	reg, router, cxt := cookoo.Cookoo()
+
+	resolver := NewURIPathResolver(reg)
+	router.SetRequestResolver(resolver)
+
+	// ORDER IS IMPORTANT!
+	reg.Route("/foo/bar/baz", "test")
+	reg.Route("/foo/bar/*", "test")
+	reg.Route("/foo/c??/baz", "test")
+	reg.Route("/foo/[cft]ar/baz", "test")
+	reg.Route("/foo/*/baz", "test")
+	reg.Route("/foo/[0-9]*/baz", "test")
+	reg.Route("/*/*/*", "test")
+
+	reg.Route("GET /foo/bar/baz", "Test with verb")
+	reg.Route("POST /foo/bar/baz", "Test with verb")
+	reg.Route("DELETE /foo/bar/baz", "Test with verb")
+	reg.Route("* /foo/bar/baz", "Test with verb")
+	reg.Route("* /foo/last", "Test with verb")
+
+	reg.Route("GET /assets/**", "Test with double wildcard")
+	reg.Route("POST /assets/foo/bar/**", "Test with double wildcard")
+	reg.Route("DELETE /foo/assets/**", "Test with double wildcard")
+	reg.Route("* /foo/**", "Test with double wildcard")
+	reg.Route("GET /**", "Match with double wildcard")
+	reg.Route("PROPFIND /assets/z/*/a/**", "Mixed wildcards")
+
+	reg.Route("**", "Match anything")
+
+	tests := map[string]string{
+		// No Verb
+		"/foo/bar/baz": "/foo/bar/baz",
+		"/foo/bar/blurp": "/foo/bar/*",
+		"/foo/car/baz":  "/foo/c??/baz",
+		"/foo/anything/baz": "/foo/*/baz",
+		"/foo/far/baz": "/foo/[cft]ar/baz",
+
+		// Verb
+		"POST /foo/bar/baz": "POST /foo/bar/baz",
+		"GET /foo/last": "* /foo/last",
+
+		// Special Wildcards
+		"GET /foo/assets/img/foo.jpg": "* /foo/**",
+		"DELETE /foo/assets/img/foo.png": "DELETE /foo/assets/**",
+		"POST /assets/foo/bar/baz/bing/a/b/c/d/e.mov": "POST /assets/foo/bar/**",
+		"GET /assets/a/b/c/d/e/f/g/h/i": "GET /assets/**",
+		"GET /zzzz/a/b/c/d/e/fgh": "GET /**",
+		"PROPFIND /assets/z/foo/a/b/c/d": "PROPFIND /assets/z/*/a/**",
+
+		"STINKY /cheese/is/excellent": "**",
+	}
+
+	for name, expects := range tests {
+		resolved, err := router.ResolveRequest(name, cxt)
+		if err != nil {
+			t.Errorf("Unexpected resolver error: %s", err)
+		}
+		if resolved != expects {
+			t.Error(fmt.Sprintf("! Expected `%s` to match `%s`; got `%s`", name, expects, resolved))
+		}
+	}
+}

--- a/vendor/github.com/Masterminds/semver/.travis.yml
+++ b/vendor/github.com/Masterminds/semver/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+
+# Setting sudo access to false will let Travis CI use containers rather than
+# VMs to run the tests. For more details see:
+# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: false
+
+notifications:
+  irc: "irc.freenode.net#masterminds"

--- a/vendor/github.com/Masterminds/semver/LICENSE.txt
+++ b/vendor/github.com/Masterminds/semver/LICENSE.txt
@@ -1,0 +1,20 @@
+The Masterminds
+Copyright (C) 2014-2015, Matt Butcher and Matt Farina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/semver/README.md
+++ b/vendor/github.com/Masterminds/semver/README.md
@@ -1,0 +1,119 @@
+# SemVer
+
+The `semver` package provides the ability to work with [Semantic Versions](http://semver.org) in Go. Specifically it provides the ability to:
+
+* Parse semantic versions
+* Sort semantic versions
+* Check if a semantic version fits within a set of constraints
+* Optionally work with a `v` prefix
+
+[![Build Status](https://travis-ci.org/Masterminds/semver.svg)](https://travis-ci.org/Masterminds/semver) [![GoDoc](https://godoc.org/github.com/Masterminds/semver?status.png)](https://godoc.org/github.com/Masterminds/semver) [![Go Report Card](http://goreportcard.com/badge/Masterminds/semver)](http://goreportcard.com/report/Masterminds/semver)
+
+## Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the [documentation](https://godoc.org/github.com/Masterminds/semver).
+
+## Sorting Semantic Versions
+
+A set of versions can be sorted using the [`sort`](https://golang.org/pkg/sort/)
+package from the standard library. For example,
+
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+
+## Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+
+## Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+* `=`: equal (aliased to no operator)
+* `!=`: not equal
+* `>`: greater than
+* `<`: less than
+* `>=`: greater than or equal to
+* `<=`: less than or equal to
+
+## Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+* `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+* `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+## Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+* `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `>= 1.2.x` is equivalent to `>= 1.2.0`
+* `<= 2.x` is equivalent to `<= 3`
+* `*` is equivalent to `>= 0.0.0`
+
+## Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+* `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+* `~1` is equivalent to `>= 1, < 2`
+* `~2.3` is equivalent to `>= 2.3, < 2.4`
+* `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `~1.x` is equivalent to `>= 1, < 2`
+
+## Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+* `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+* `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+* `^2.3` is equivalent to `>= 2.3, < 3`
+* `^2.x` is equivalent to `>= 2.0.0, < 3`
+
+# Contribute
+
+If you find an issue or want to contribute please file an [issue](https://github.com/Masterminds/semver/issues)
+or [create a pull request](https://github.com/Masterminds/semver/pulls).

--- a/vendor/github.com/Masterminds/semver/collection.go
+++ b/vendor/github.com/Masterminds/semver/collection.go
@@ -1,0 +1,24 @@
+package semver
+
+// Collection is a collection of Version instances and implements the sort
+// interface. See the sort package for more details.
+// https://golang.org/pkg/sort/
+type Collection []*Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (c Collection) Len() int {
+	return len(c)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (c Collection) Less(i, j int) bool {
+	return c[i].LessThan(c[j])
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (c Collection) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}

--- a/vendor/github.com/Masterminds/semver/collection_test.go
+++ b/vendor/github.com/Masterminds/semver/collection_test.go
@@ -1,0 +1,46 @@
+package semver
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCollection(t *testing.T) {
+	raw := []string{
+		"1.2.3",
+		"1.0",
+		"1.3",
+		"2",
+		"0.4.2",
+	}
+
+	vs := make([]*Version, len(raw))
+	for i, r := range raw {
+		v, err := NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(Collection(vs))
+
+	e := []string{
+		"0.4.2",
+		"1.0.0",
+		"1.2.3",
+		"1.3.0",
+		"2.0.0",
+	}
+
+	a := make([]string, len(vs))
+	for i, v := range vs {
+		a[i] = v.String()
+	}
+
+	if !reflect.DeepEqual(a, e) {
+		t.Error("Sorting Collection failed")
+	}
+}

--- a/vendor/github.com/Masterminds/semver/constraints.go
+++ b/vendor/github.com/Masterminds/semver/constraints.go
@@ -1,0 +1,286 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Constraints is one or more constraint that a semantic version can be
+// checked against.
+type Constraints struct {
+	constraints [][]*constraint
+}
+
+// NewConstraint returns a Constraints instance that a Version instance can
+// be checked against. If there is a parse error it will be returned.
+func NewConstraint(c string) (*Constraints, error) {
+
+	// Rewrite - ranges into a comparison operation.
+	c = rewriteRange(c)
+
+	ors := strings.Split(c, "||")
+	or := make([][]*constraint, len(ors))
+	for k, v := range ors {
+		cs := strings.Split(v, ",")
+		result := make([]*constraint, len(cs))
+		for i, s := range cs {
+			pc, err := parseConstraint(s)
+			if err != nil {
+				return nil, err
+			}
+
+			result[i] = pc
+		}
+		or[k] = result
+	}
+
+	o := &Constraints{constraints: or}
+	return o, nil
+}
+
+// Check tests if a version satisfies the constraints.
+func (cs Constraints) Check(v *Version) bool {
+	// loop over the ORs and check the inner ANDs
+	for _, o := range cs.constraints {
+		joy := true
+		for _, c := range o {
+			if !c.check(v) {
+				joy = false
+				break
+			}
+		}
+
+		if joy {
+			return true
+		}
+	}
+
+	return false
+}
+
+var constraintOps map[string]cfunc
+var constraintRegex *regexp.Regexp
+
+func init() {
+	constraintOps = map[string]cfunc{
+		"":   constraintTildeOrEqual,
+		"=":  constraintTildeOrEqual,
+		"!=": constraintNotEqual,
+		">":  constraintGreaterThan,
+		"<":  constraintLessThan,
+		">=": constraintGreaterThanEqual,
+		"=>": constraintGreaterThanEqual,
+		"<=": constraintLessThanEqual,
+		"=<": constraintLessThanEqual,
+		"~":  constraintTilde,
+		"~>": constraintTilde,
+		"^":  constraintCaret,
+	}
+
+	ops := make([]string, 0, len(constraintOps))
+	for k := range constraintOps {
+		ops = append(ops, regexp.QuoteMeta(k))
+	}
+
+	constraintRegex = regexp.MustCompile(fmt.Sprintf(
+		`^\s*(%s)\s*(%s)\s*$`,
+		strings.Join(ops, "|"),
+		cvRegex))
+
+	constraintRangeRegex = regexp.MustCompile(fmt.Sprintf(
+		`\s*(%s)\s*-\s*(%s)\s*`,
+		cvRegex, cvRegex))
+}
+
+// An individual constraint
+type constraint struct {
+	// The callback function for the restraint. It performs the logic for
+	// the constraint.
+	function cfunc
+
+	// The version used in the constraint check. For example, if a constraint
+	// is '<= 2.0.0' the con a version instance representing 2.0.0.
+	con *Version
+
+	// When an x is used as part of the version (e.g., 1.x)
+	minorDirty bool
+	dirty      bool
+}
+
+// Check if a version meets the constraint
+func (c *constraint) check(v *Version) bool {
+	return c.function(v, c)
+}
+
+type cfunc func(v *Version, c *constraint) bool
+
+func parseConstraint(c string) (*constraint, error) {
+	m := constraintRegex.FindStringSubmatch(c)
+	if m == nil {
+		return nil, fmt.Errorf("improper constraint: %s", c)
+	}
+
+	ver := m[2]
+	minorDirty := false
+	dirty := false
+	if isX(m[3]) {
+		ver = "0.0.0"
+		dirty = true
+	} else if isX(strings.TrimPrefix(m[4], ".")) {
+		minorDirty = true
+		dirty = true
+		ver = fmt.Sprintf("%s.0.0%s", m[3], m[6])
+	} else if isX(strings.TrimPrefix(m[5], ".")) {
+		dirty = true
+		ver = fmt.Sprintf("%s%s.0%s", m[3], m[4], m[6])
+	}
+
+	con, err := NewVersion(ver)
+	if err != nil {
+
+		// The constraintRegex should catch any regex parsing errors. So,
+		// we should never get here.
+		return nil, errors.New("constraint Parser Error")
+	}
+
+	cs := &constraint{
+		function:   constraintOps[m[1]],
+		con:        con,
+		minorDirty: minorDirty,
+		dirty:      dirty,
+	}
+	return cs, nil
+}
+
+// Constraint functions
+func constraintNotEqual(v *Version, c *constraint) bool {
+	if c.dirty {
+		if c.con.Major() != v.Major() {
+			return true
+		}
+		if c.con.Minor() != v.Minor() && !c.minorDirty {
+			return true
+		} else if c.minorDirty {
+			return false
+		}
+
+		return false
+	}
+
+	return !v.Equal(c.con)
+}
+
+func constraintGreaterThan(v *Version, c *constraint) bool {
+	return v.Compare(c.con) == 1
+}
+
+func constraintLessThan(v *Version, c *constraint) bool {
+	if !c.dirty {
+		return v.Compare(c.con) < 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+func constraintGreaterThanEqual(v *Version, c *constraint) bool {
+	return v.Compare(c.con) >= 0
+}
+
+func constraintLessThanEqual(v *Version, c *constraint) bool {
+	if !c.dirty {
+		return v.Compare(c.con) <= 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// ~*, ~>* --> >= 0.0.0 (any)
+// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0, <3.0.0
+// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0, <2.1.0
+// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0, <1.3.0
+// ~1.2.3, ~>1.2.3 --> >=1.2.3, <1.3.0
+// ~1.2.0, ~>1.2.0 --> >=1.2.0, <1.3.0
+func constraintTilde(v *Version, c *constraint) bool {
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	if v.Minor() != c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// When there is a .x (dirty) status it automatically opts in to ~. Otherwise
+// it's a straight =
+func constraintTildeOrEqual(v *Version, c *constraint) bool {
+	if c.dirty {
+		return constraintTilde(v, c)
+	}
+
+	return v.Equal(c.con)
+}
+
+// ^* --> (any)
+// ^2, ^2.x, ^2.x.x --> >=2.0.0, <3.0.0
+// ^2.0, ^2.0.x --> >=2.0.0, <3.0.0
+// ^1.2, ^1.2.x --> >=1.2.0, <2.0.0
+// ^1.2.3 --> >=1.2.3, <2.0.0
+// ^1.2.0 --> >=1.2.0, <2.0.0
+func constraintCaret(v *Version, c *constraint) bool {
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	return true
+}
+
+type rwfunc func(i string) string
+
+var constraintRangeRegex *regexp.Regexp
+
+const cvRegex string = `v?([0-9|x|X|\*]+)(\.[0-9|x|X|\*]+)?(\.[0-9|x|X|\*]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+func isX(x string) bool {
+	l := strings.ToLower(x)
+	return l == "x" || l == "*"
+}
+
+func rewriteRange(i string) string {
+	m := constraintRangeRegex.FindAllStringSubmatch(i, -1)
+	if m == nil {
+		return i
+	}
+	o := i
+	for _, v := range m {
+		t := fmt.Sprintf(">= %s, <= %s", v[1], v[11])
+		o = strings.Replace(o, v[0], t, 1)
+	}
+
+	return o
+}

--- a/vendor/github.com/Masterminds/semver/constraints_test.go
+++ b/vendor/github.com/Masterminds/semver/constraints_test.go
@@ -1,0 +1,260 @@
+package semver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseConstraint(t *testing.T) {
+	tests := []struct {
+		in  string
+		f   cfunc
+		v   string
+		err bool
+	}{
+		{">= 1.2", constraintGreaterThanEqual, "1.2.0", false},
+		{"1.0", constraintTildeOrEqual, "1.0.0", false},
+		{"foo", nil, "", true},
+		{"<= 1.2", constraintLessThanEqual, "1.2.0", false},
+		{"=< 1.2", constraintLessThanEqual, "1.2.0", false},
+		{"=> 1.2", constraintGreaterThanEqual, "1.2.0", false},
+		{"v1.2", constraintTildeOrEqual, "1.2.0", false},
+		{"=1.5", constraintTildeOrEqual, "1.5.0", false},
+		{"> 1.3", constraintGreaterThan, "1.3.0", false},
+		{"< 1.4.1", constraintLessThan, "1.4.1", false},
+	}
+
+	for _, tc := range tests {
+		c, err := parseConstraint(tc.in)
+		if tc.err && err == nil {
+			t.Errorf("Expected error for %s didn't occur", tc.in)
+		} else if !tc.err && err != nil {
+			t.Errorf("Unexpected error for %s", tc.in)
+		}
+
+		// If an error was expected continue the loop and don't try the other
+		// tests as they will cause errors.
+		if tc.err {
+			continue
+		}
+
+		if tc.v != c.con.String() {
+			t.Errorf("Incorrect version found on %s", tc.in)
+		}
+
+		f1 := reflect.ValueOf(tc.f)
+		f2 := reflect.ValueOf(c.function)
+		if f1 != f2 {
+			t.Errorf("Wrong constraint found for %s", tc.in)
+		}
+	}
+}
+
+func TestConstraintCheck(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{"= 2.0", "1.2.3", false},
+		{"= 2.0", "2.0.0", true},
+		{"4.1", "4.1.0", true},
+		{"!=4.1", "4.1.0", false},
+		{"!=4.1", "5.1.0", true},
+		{">1.1", "4.1.0", true},
+		{">1.1", "1.1.0", false},
+		{"<1.1", "0.1.0", true},
+		{"<1.1", "1.1.0", false},
+		{"<1.1", "1.1.1", false},
+		{">=1.1", "4.1.0", true},
+		{">=1.1", "1.1.0", true},
+		{">=1.1", "0.0.9", false},
+		{"<=1.1", "0.1.0", true},
+		{"<=1.1", "1.1.0", true},
+		{"<=1.1", "1.1.1", false},
+	}
+
+	for _, tc := range tests {
+		c, err := parseConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		a := c.check(v)
+		if a != tc.check {
+			t.Errorf("Constraint '%s' failing", tc.constraint)
+		}
+	}
+}
+
+func TestNewConstraint(t *testing.T) {
+	tests := []struct {
+		input string
+		ors   int
+		count int
+		err   bool
+	}{
+		{">= 1.1", 1, 1, false},
+		{"2.0", 1, 1, false},
+		{">= bar", 0, 0, true},
+		{">= 1.2.3, < 2.0", 1, 2, false},
+		{">= 1.2.3, < 2.0 || => 3.0, < 4", 2, 2, false},
+
+		// The 3-4 should be broken into 2 by the range rewriting
+		{"3-4 || => 3.0, < 4", 2, 2, false},
+	}
+
+	for _, tc := range tests {
+		v, err := NewConstraint(tc.input)
+		if tc.err && err == nil {
+			t.Errorf("expected but did not get error for: %s", tc.input)
+			continue
+		} else if !tc.err && err != nil {
+			t.Errorf("unexpectederror for input %s: %s", tc.input, err)
+			continue
+		}
+		if tc.err {
+			continue
+		}
+
+		l := len(v.constraints)
+		if tc.ors != l {
+			t.Errorf("Expected %s to have %d ORs but got %d",
+				tc.input, tc.ors, l)
+		}
+
+		l = len(v.constraints[0])
+		if tc.count != l {
+			t.Errorf("Expected %s to have %d constraints but got %d",
+				tc.input, tc.count, l)
+		}
+	}
+}
+
+func TestConstraintsCheck(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{"= 2.0", "1.2.3", false},
+		{"= 2.0", "2.0.0", true},
+		{"4.1", "4.1.0", true},
+		{"4.1.x", "4.1.3", true},
+		{"1.x", "1.4", true},
+		{"!=4.1", "4.1.0", false},
+		{"!=4.1", "5.1.0", true},
+		{"!=4.x", "5.1.0", true},
+		{"!=4.x", "4.1.0", false},
+		{"!=4.1.x", "4.2.0", true},
+		{"!=4.2.x", "4.2.3", false},
+		{">1.1", "4.1.0", true},
+		{">1.1", "1.1.0", false},
+		{"<1.1", "0.1.0", true},
+		{"<1.1", "1.1.0", false},
+		{"<1.1", "1.1.1", false},
+		{"<1.x", "1.1.1", true},
+		{"<1.x", "2.1.1", false},
+		{"<1.1.x", "1.2.1", false},
+		{"<1.1.x", "1.1.500", true},
+		{"<1.2.x", "1.1.1", true},
+		{">=1.1", "4.1.0", true},
+		{">=1.1", "1.1.0", true},
+		{">=1.1", "0.0.9", false},
+		{"<=1.1", "0.1.0", true},
+		{"<=1.1", "1.1.0", true},
+		{"<=1.x", "1.1.0", true},
+		{"<=2.x", "3.1.0", false},
+		{"<=1.1", "1.1.1", false},
+		{"<=1.1.x", "1.2.500", false},
+		{">1.1, <2", "1.1.1", true},
+		{">1.1, <3", "4.3.2", false},
+		{">=1.1, <2, !=1.2.3", "1.2.3", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.1.2", true},
+		{">=1.1, <2, !=1.2.3 || >= 3", "3.0.0", true},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.0.0", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "1.2.3", false},
+		{"1.1 - 2", "1.1.1", true},
+		{"1.1-3", "4.3.2", false},
+		{"^1.1", "1.1.1", true},
+		{"^1.1", "4.3.2", false},
+		{"^1.x", "1.1.1", true},
+		{"^2.x", "1.1.1", false},
+		{"^1.x", "2.1.1", false},
+		{"~*", "2.1.1", false},
+		{"~1.x", "2.1.1", false},
+		{"~1.x", "1.3.5", true},
+		{"~1.x", "1.4", true},
+		{"~1.1", "1.1.1", true},
+		{"~1.2.3", "1.2.5", true},
+		{"~1.2.3", "1.2.2", false},
+		{"~1.2.3", "1.3.2", false},
+		{"~1.1", "1.2.3", false},
+		{"~1.3", "2.4.5", false},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		a := c.Check(v)
+		if a != tc.check {
+			t.Errorf("Constraint '%s' failing with '%s'", tc.constraint, tc.version)
+		}
+	}
+}
+
+func TestRewriteRange(t *testing.T) {
+	tests := []struct {
+		c  string
+		nc string
+	}{
+		{"2-3", ">= 2, <= 3"},
+		{"2-3, 2-3", ">= 2, <= 3,>= 2, <= 3"},
+		{"2-3, 4.0.0-5.1", ">= 2, <= 3,>= 4.0.0, <= 5.1"},
+	}
+
+	for _, tc := range tests {
+		o := rewriteRange(tc.c)
+
+		if o != tc.nc {
+			t.Errorf("Range %s rewritten incorrectly as '%s'", tc.c, o)
+		}
+	}
+}
+
+func TestIsX(t *testing.T) {
+	tests := []struct {
+		t string
+		c bool
+	}{
+		{"A", false},
+		{"%", false},
+		{"X", true},
+		{"x", true},
+		{"*", true},
+	}
+
+	for _, tc := range tests {
+		a := isX(tc.t)
+		if a != tc.c {
+			t.Errorf("Function isX error on %s", tc.t)
+		}
+	}
+}

--- a/vendor/github.com/Masterminds/semver/doc.go
+++ b/vendor/github.com/Masterminds/semver/doc.go
@@ -1,0 +1,115 @@
+/*
+Package semver provides the ability to work with Semantic Versions (http://semver.org) in Go.
+
+Specifically it provides the ability to:
+
+    * Parse semantic versions
+    * Sort semantic versions
+    * Check if a semantic version fits within a set of constraints
+    * Optionally work with a `v` prefix
+
+Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the documentation at https://godoc.org/github.com/Masterminds/semver.
+
+Sorting Semantic Versions
+
+A set of versions can be sorted using the `sort` package from the standard library.
+For example,
+
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+
+Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+
+Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+    * `=`: equal (aliased to no operator)
+    * `!=`: not equal
+    * `>`: greater than
+    * `<`: less than
+    * `>=`: greater than or equal to
+    * `<=`: less than or equal to
+
+Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+    * `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+    * `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+    * `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `>= 1.2.x` is equivalent to `>= 1.2.0`
+    * `<= 2.x` is equivalent to `<= 3`
+    * `*` is equivalent to `>= 0.0.0`
+
+Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+    * `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+    * `~1` is equivalent to `>= 1, < 2`
+    * `~2.3` is equivalent to `>= 2.3, < 2.4`
+    * `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `~1.x` is equivalent to `>= 1, < 2`
+
+Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+    * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+    * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+    * `^2.3` is equivalent to `>= 2.3, < 3`
+    * `^2.x` is equivalent to `>= 2.0.0, < 3`
+*/
+package semver

--- a/vendor/github.com/Masterminds/semver/version.go
+++ b/vendor/github.com/Masterminds/semver/version.go
@@ -1,0 +1,271 @@
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The compiled version of the regex created at init() is cached here so it
+// only needs to be created once.
+var versionRegex *regexp.Regexp
+
+var (
+	// ErrInvalidSemVer is returned a version is found to be invalid when
+	// being parsed.
+	ErrInvalidSemVer = errors.New("Invalid Semantic Version")
+)
+
+// The regular expression used to parse a semantic version.
+const SemVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+// Version represents a single semantic version.
+type Version struct {
+	major, minor, patch int64
+	pre                 string
+	metadata            string
+	original            string
+}
+
+func init() {
+	versionRegex = regexp.MustCompile("^" + SemVerRegex + "$")
+}
+
+// NewVersion parses a given version and returns an instance of Version or
+// an error if unable to parse the version.
+func NewVersion(v string) (*Version, error) {
+	m := versionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return nil, ErrInvalidSemVer
+	}
+
+	sv := &Version{
+		metadata: m[8],
+		pre:      m[5],
+		original: v,
+	}
+
+	var temp int64
+	temp, err := strconv.ParseInt(m[1], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing version segment: %s", err)
+	}
+	sv.major = temp
+
+	if m[2] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.minor = temp
+	} else {
+		sv.minor = 0
+	}
+
+	if m[3] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.patch = temp
+	} else {
+		sv.patch = 0
+	}
+
+	return sv, nil
+}
+
+// String converts a Version object to a string.
+// Note, if the original version contained a leading v this version will not.
+// See the Original() method to retrieve the original value. Semantic Versions
+// don't contain a leading v per the spec. Instead it's optional on
+// impelementation.
+func (v *Version) String() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
+	if v.pre != "" {
+		fmt.Fprintf(&buf, "-%s", v.pre)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&buf, "+%s", v.metadata)
+	}
+
+	return buf.String()
+}
+
+// Original returns the original value passed in to be parsed.
+func (v *Version) Original() string {
+	return v.original
+}
+
+// Major returns the major version.
+func (v *Version) Major() int64 {
+	return v.major
+}
+
+// Minor returns the minor version.
+func (v *Version) Minor() int64 {
+	return v.minor
+}
+
+// Patch returns the patch version.
+func (v *Version) Patch() int64 {
+	return v.patch
+}
+
+// Prerelease returns the pre-release version.
+func (v *Version) Prerelease() string {
+	return v.pre
+}
+
+// Metadata returns the metadata on the version.
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// LessThan tests if one version is less than another one.
+func (v *Version) LessThan(o *Version) bool {
+	return v.Compare(o) < 0
+}
+
+// GreaterThan tests if one version is greater than another one.
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.Compare(o) > 0
+}
+
+// Equal tests if two versions are equal to each other.
+// Note, versions can be equal with different metadata since metadata
+// is not considered part of the comparable version.
+func (v *Version) Equal(o *Version) bool {
+	return v.Compare(o) == 0
+}
+
+// Compare compares this version to another one. It returns -1, 0, or 1 if
+// the version smaller, equal, or larger than the other version.
+//
+// Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
+// lower than the version without a prerelease.
+func (v *Version) Compare(o *Version) int {
+
+	// Fastpath if both versions are the same.
+	if v.String() == o.String() {
+		return 0
+	}
+
+	// Compare the major, minor, and patch version for differences. If a
+	// difference is found return the comparison.
+	if d := compareSegment(v.Major(), o.Major()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Minor(), o.Minor()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Patch(), o.Patch()); d != 0 {
+		return d
+	}
+
+	// At this point the major, minor, and patch versions are the same.
+	ps := v.pre
+	po := o.Prerelease()
+
+	if ps == "" && po == "" {
+		return 0
+	}
+	if ps == "" {
+		return 1
+	}
+	if po == "" {
+		return -1
+	}
+
+	return comparePrerelease(ps, po)
+}
+
+func compareSegment(v, o int64) int {
+	if v < o {
+		return -1
+	}
+	if v > o {
+		return 1
+	}
+
+	return 0
+}
+
+func comparePrerelease(v, o string) int {
+
+	// split the prelease versions by their part. The seperator, per the spec,
+	// is a .
+	sparts := strings.Split(v, ".")
+	oparts := strings.Split(o, ".")
+
+	// Find the longer length of the parts to know how many loop iterations to
+	// go through.
+	slen := len(sparts)
+	olen := len(oparts)
+
+	l := slen
+	if olen > slen {
+		l = olen
+	}
+
+	// Iterate over each part of the prereleases to compare the differences.
+	for i := 0; i < l; i++ {
+		// Since the lentgh of the parts can be different we need to create
+		// a placeholder. This is to avoid out of bounds issues.
+		stemp := ""
+		if i < slen {
+			stemp = sparts[i]
+		}
+
+		otemp := ""
+		if i < olen {
+			otemp = oparts[i]
+		}
+
+		d := comparePrePart(stemp, otemp)
+		if d != 0 {
+			return d
+		}
+	}
+
+	// Reaching here means two verisons are of equal value but have different
+	// metadata (the part following a +). They are not identical in string form
+	// but the version comparison finds them to be equal.
+	return 0
+}
+
+func comparePrePart(s, o string) int {
+	// Fastpath if they are equal
+	if s == o {
+		return 0
+	}
+
+	// When s or o are empty we can use the other in an attempt to determine
+	// the response.
+	if o == "" {
+		_, n := strconv.ParseInt(s, 10, 64)
+		if n != nil {
+			return -1
+		}
+		return 1
+	}
+	if s == "" {
+		_, n := strconv.ParseInt(o, 10, 64)
+		if n != nil {
+			return 1
+		}
+		return -1
+	}
+
+	if s > o {
+		return 1
+	}
+	return -1
+}

--- a/vendor/github.com/Masterminds/semver/version_test.go
+++ b/vendor/github.com/Masterminds/semver/version_test.go
@@ -1,0 +1,283 @@
+package semver
+
+import (
+	"testing"
+)
+
+func TestNewVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		err     bool
+	}{
+		{"1.2.3", false},
+		{"v1.2.3", false},
+		{"1.0", false},
+		{"v1.0", false},
+		{"1", false},
+		{"v1", false},
+		{"1.2.beta", true},
+		{"v1.2.beta", true},
+		{"foo", true},
+		{"1.2-5", false},
+		{"v1.2-5", false},
+		{"1.2-beta.5", false},
+		{"v1.2-beta.5", false},
+		{"\n1.2", true},
+		{"\nv1.2", true},
+		{"1.2.0-x.Y.0+metadata", false},
+		{"v1.2.0-x.Y.0+metadata", false},
+		{"1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"1.2.3-rc1-with-hypen", false},
+		{"v1.2.3-rc1-with-hypen", false},
+		{"1.2.3.4", true},
+		{"v1.2.3.4", true},
+	}
+
+	for _, tc := range tests {
+		_, err := NewVersion(tc.version)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for version: %s", tc.version)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for version %s: %s", tc.version, err)
+		}
+	}
+}
+
+func TestOriginal(t *testing.T) {
+	tests := []string{
+		"1.2.3",
+		"v1.2.3",
+		"1.0",
+		"v1.0",
+		"1",
+		"v1",
+		"1.2-5",
+		"v1.2-5",
+		"1.2-beta.5",
+		"v1.2-beta.5",
+		"1.2.0-x.Y.0+metadata",
+		"v1.2.0-x.Y.0+metadata",
+		"1.2.0-x.Y.0+metadata-width-hypen",
+		"v1.2.0-x.Y.0+metadata-width-hypen",
+		"1.2.3-rc1-with-hypen",
+		"v1.2.3-rc1-with-hypen",
+	}
+
+	for _, tc := range tests {
+		v, err := NewVersion(tc)
+		if err != nil {
+			t.Errorf("Error parsing version %s", tc)
+		}
+
+		o := v.Original()
+		if o != tc {
+			t.Errorf("Error retrieving originl. Expected '%s' but got '%s'", tc, v)
+		}
+	}
+}
+
+func TestParts(t *testing.T) {
+	v, err := NewVersion("1.2.3-beta.1+build.123")
+	if err != nil {
+		t.Error("Error parsing version 1.2.3-beta.1+build.123")
+	}
+
+	if v.Major() != 1 {
+		t.Error("Major() returning wrong value")
+	}
+	if v.Minor() != 2 {
+		t.Error("Minor() returning wrong value")
+	}
+	if v.Patch() != 3 {
+		t.Error("Patch() returning wrong value")
+	}
+	if v.Prerelease() != "beta.1" {
+		t.Error("Prerelease() returning wrong value")
+	}
+	if v.Metadata() != "build.123" {
+		t.Error("Metadata() returning wrong value")
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2.3", "1.2.3"},
+		{"v1.2.3", "1.2.3"},
+		{"1.0", "1.0.0"},
+		{"v1.0", "1.0.0"},
+		{"1", "1.0.0"},
+		{"v1", "1.0.0"},
+		{"1.2-5", "1.2.0-5"},
+		{"v1.2-5", "1.2.0-5"},
+		{"1.2-beta.5", "1.2.0-beta.5"},
+		{"v1.2-beta.5", "1.2.0-beta.5"},
+		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"v1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
+		{"v1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
+		{"1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
+		{"v1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
+	}
+
+	for _, tc := range tests {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("Error parsing version %s", tc)
+		}
+
+		s := v.String()
+		if s != tc.expected {
+			t.Errorf("Error generating string. Expected '%s' but got '%s'", tc.expected, s)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2.3", "1.5.1", -1},
+		{"2.2.3", "1.5.1", 1},
+		{"2.2.3", "2.2.2", 1},
+		{"3.2-beta", "3.2-beta", 0},
+		{"1.3", "1.1.4", 1},
+		{"4.2", "4.2-beta", 1},
+		{"4.2-beta", "4.2", -1},
+		{"4.2-alpha", "4.2-beta", -1},
+		{"4.2-alpha", "4.2-alpha", 0},
+		{"4.2-beta.2", "4.2-beta.1", 1},
+		{"4.2-beta2", "4.2-beta1", 1},
+		{"4.2-beta", "4.2-beta.2", -1},
+		{"4.2-beta", "4.2-beta.foo", 1},
+		{"4.2-beta.2", "4.2-beta", 1},
+		{"4.2-beta.foo", "4.2-beta", -1},
+		{"1.2+bar", "1.2+baz", 0},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.Compare(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%d', got '%d'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestLessThan(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", true},
+		{"2.2.3", "1.5.1", false},
+		{"3.2-beta", "3.2-beta", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.LessThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestGreaterThan(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", true},
+		{"3.2-beta", "3.2-beta", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.GreaterThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", false},
+		{"3.2-beta", "3.2-beta", true},
+		{"3.2-beta+foo", "3.2-beta+bar", true},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.Equal(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/.gitignore
+++ b/vendor/github.com/Masterminds/vcs/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/Masterminds/vcs/.travis.yml
+++ b/vendor/github.com/Masterminds/vcs/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+
+# Setting sudo access to false will let Travis CI use containers rather than
+# VMs to run the tests. For more details see:
+# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: false
+
+notifications:
+  irc: "irc.freenode.net#masterminds"

--- a/vendor/github.com/Masterminds/vcs/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/vcs/CHANGELOG.md
@@ -1,0 +1,32 @@
+# 1.3.0 (2015-11-09)
+
+- Issue #9: Added Date method to get the date/time of latest commit (thanks kamilchm).
+
+# 1.2.0 (2015-10-29)
+
+- Adding IsDirty method to detect a checkout with uncommitted changes.
+
+# 1.1.4 (2015-10-28)
+
+- Fixed #8: Git IsReference not detecting branches that have not been checked
+  out yet.
+
+# 1.1.3 (2015-10-21)
+
+- Fixing issue where there are multiple go-import statements for go redirects
+
+# 1.1.2 (2015-10-20)
+
+- Fixes #7: hg not checking out code when Get is called
+
+# 1.1.1 (2015-10-20)
+
+- Issue #6: Allow VCS commands to be run concurrently.
+
+# 1.1.0 (2015-10-19)
+
+- #5: Added output of failed command to returned errors.
+
+# 1.0.0 (2015-10-06)
+
+- Initial release.

--- a/vendor/github.com/Masterminds/vcs/LICENSE.txt
+++ b/vendor/github.com/Masterminds/vcs/LICENSE.txt
@@ -1,0 +1,20 @@
+The Masterminds
+Copyright (C) 2014-2015, Matt Butcher and Matt Farina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/vcs/README.md
+++ b/vendor/github.com/Masterminds/vcs/README.md
@@ -1,0 +1,46 @@
+# VCS Repository Management for Go
+
+Manage repos in varying version control systems with ease through a common
+interface.
+
+[![Build Status](https://travis-ci.org/Masterminds/vcs.svg)](https://travis-ci.org/Masterminds/vcs) [![GoDoc](https://godoc.org/github.com/Masterminds/vcs?status.png)](https://godoc.org/github.com/Masterminds/vcs) [![Go Report Card](http://goreportcard.com/badge/Masterminds/vcs)](http://goreportcard.com/report/Masterminds/vcs)
+
+## Quick Usage
+
+Quick usage:
+
+	remote := "https://github.com/Masterminds/vcs"
+    local, _ := ioutil.TempDir("", "go-vcs")
+    repo, err := NewRepo(remote, local)
+
+In this case `NewRepo` will detect the VCS is Git and return a `GitRepo`. All of
+the repos implement the `Repo` interface with a common set of features between
+them.
+
+## Supported VCS
+
+Git, SVN, Bazaar (Bzr), and Mercurial (Hg) are currently supported. They each
+have their own type (e.g., `GitRepo`) that follow a simple naming pattern. Each
+type implements the `Repo` interface and has a constructor (e.g., `NewGitRepo`).
+The constructors have the same signature as `NewRepo`.
+
+## Features
+
+- Clone or checkout a repository depending on the version control system.
+- Pull updates to a repository.
+- Get the currently checked out commit id.
+- Checkout a commit id, branch, or tag (depending on the availability in the VCS).
+- Get a list of tags and branches in the VCS.
+- Check if a string value is a valid reference within the VCS.
+- More...
+
+For more details see [the documentation](https://godoc.org/github.com/Masterminds/vcs).
+
+## Motivation
+
+The package `golang.org/x/tools/go/vcs` provides some valuable functionality
+for working with packages in repositories in varying source control management
+systems. That package, while useful and well tested, is designed with a specific
+purpose in mind. Our uses went beyond the scope of that package. To implement
+our scope we built a package that went beyond the functionality and scope
+of `golang.org/x/tools/go/vcs`.

--- a/vendor/github.com/Masterminds/vcs/bzr.go
+++ b/vendor/github.com/Masterminds/vcs/bzr.go
@@ -1,0 +1,155 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var bzrDetectURL = regexp.MustCompile("parent branch: (?P<foo>.+)\n")
+
+// NewBzrRepo creates a new instance of BzrRepo. The remote and local directories
+// need to be passed in.
+func NewBzrRepo(remote, local string) (*BzrRepo, error) {
+	ltype, err := DetectVcsFromFS(local)
+
+	// Found a VCS other than Bzr. Need to report an error.
+	if err == nil && ltype != Bzr {
+		return nil, ErrWrongVCS
+	}
+
+	r := &BzrRepo{}
+	r.setRemote(remote)
+	r.setLocalPath(local)
+	r.Logger = Logger
+
+	// With the other VCS we can check if the endpoint locally is different
+	// from the one configured internally. But, with Bzr you can't. For example,
+	// if you do `bzr branch https://launchpad.net/govcstestbzrrepo` and then
+	// use `bzr info` to get the parent branch you'll find it set to
+	// http://bazaar.launchpad.net/~mattfarina/govcstestbzrrepo/trunk/. Notice
+	// the change from https to http and the path chance.
+	// Here we set the remote to be the local one if none is passed in.
+	if err == nil && r.CheckLocal() == true && remote == "" {
+		c := exec.Command("bzr", "info")
+		c.Dir = local
+		c.Env = envForDir(c.Dir)
+		out, err := c.CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+		m := bzrDetectURL.FindStringSubmatch(string(out))
+
+		// If no remote was passed in but one is configured for the locally
+		// checked out Bzr repo use that one.
+		if m[1] != "" {
+			r.setRemote(m[1])
+		}
+	}
+
+	return r, nil
+}
+
+// BzrRepo implements the Repo interface for the Bzr source control.
+type BzrRepo struct {
+	base
+}
+
+// Vcs retrieves the underlying VCS being implemented.
+func (s BzrRepo) Vcs() Type {
+	return Bzr
+}
+
+// Get is used to perform an initial clone of a repository.
+func (s *BzrRepo) Get() error {
+	_, err := s.run("bzr", "branch", s.Remote(), s.LocalPath())
+	return err
+}
+
+// Update performs a Bzr pull and update to an existing checkout.
+func (s *BzrRepo) Update() error {
+	_, err := s.runFromDir("bzr", "pull")
+	if err != nil {
+		return err
+	}
+	_, err = s.runFromDir("bzr", "update")
+	return err
+}
+
+// UpdateVersion sets the version of a package currently checked out via Bzr.
+func (s *BzrRepo) UpdateVersion(version string) error {
+	_, err := s.runFromDir("bzr", "update", "-r", version)
+	return err
+}
+
+// Version retrieves the current version.
+func (s *BzrRepo) Version() (string, error) {
+
+	out, err := s.runFromDir("bzr", "revno", "--tree")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Date retrieves the date on the latest commit.
+func (s *BzrRepo) Date() (time.Time, error) {
+	out, err := s.runFromDir("bzr", "version-info", "--custom", "--template={date}")
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := time.Parse(longForm, string(out))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// CheckLocal verifies the local location is a Bzr repo.
+func (s *BzrRepo) CheckLocal() bool {
+	if _, err := os.Stat(s.LocalPath() + "/.bzr"); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// Branches returns a list of available branches on the repository.
+// In Bazaar (Bzr) clones and branches are the same. A different branch will
+// have a different URL location which we cannot detect from the repo. This
+// is a little different from other VCS.
+func (s *BzrRepo) Branches() ([]string, error) {
+	var branches []string
+	return branches, nil
+}
+
+// Tags returns a list of available tags on the repository.
+func (s *BzrRepo) Tags() ([]string, error) {
+	out, err := s.runFromDir("bzr", "tags")
+	if err != nil {
+		return []string{}, err
+	}
+	tags := s.referenceList(string(out), `(?m-s)^(\S+)`)
+	return tags, nil
+}
+
+// IsReference returns if a string is a reference. A reference can be a
+// commit id or tag.
+func (s *BzrRepo) IsReference(r string) bool {
+	_, err := s.runFromDir("bzr", "revno", "-r", r)
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
+// IsDirty returns if the checkout has been modified from the checked
+// out reference.
+func (s *BzrRepo) IsDirty() bool {
+	out, err := s.runFromDir("bzr", "diff")
+	return err != nil || len(out) != 0
+}

--- a/vendor/github.com/Masterminds/vcs/bzr_test.go
+++ b/vendor/github.com/Masterminds/vcs/bzr_test.go
@@ -1,0 +1,172 @@
+package vcs
+
+import (
+	"io/ioutil"
+	//"log"
+	"os"
+	"testing"
+)
+
+// Canary test to ensure BzrRepo implements the Repo interface.
+var _ Repo = &BzrRepo{}
+
+// To verify bzr is working we perform intergration testing
+// with a known bzr service. Due to the long time of repeatedly checking out
+// repos these tests are structured to work together.
+
+func TestBzr(t *testing.T) {
+
+	tempDir, err := ioutil.TempDir("", "go-vcs-bzr-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, err := NewBzrRepo("https://launchpad.net/govcstestbzrrepo", tempDir+"/govcstestbzrrepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if repo.Vcs() != Bzr {
+		t.Error("Bzr is detecting the wrong type")
+	}
+
+	// Check the basic getters.
+	if repo.Remote() != "https://launchpad.net/govcstestbzrrepo" {
+		t.Error("Remote not set properly")
+	}
+	if repo.LocalPath() != tempDir+"/govcstestbzrrepo" {
+		t.Error("Local disk location not set properly")
+	}
+
+	//Logger = log.New(os.Stdout, "", log.LstdFlags)
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Bzr repo. Err was %s", err)
+	}
+
+	// Verify Bzr repo is a Bzr repo
+	if repo.CheckLocal() == false {
+		t.Error("Problem checking out repo or Bzr CheckLocal is not working")
+	}
+
+	// Test internal lookup mechanism used outside of Bzr specific functionality.
+	ltype, err := DetectVcsFromFS(tempDir + "/govcstestbzrrepo")
+	if err != nil {
+		t.Error("detectVcsFromFS unable to Bzr repo")
+	}
+	if ltype != Bzr {
+		t.Errorf("detectVcsFromFS detected %s instead of Bzr type", ltype)
+	}
+
+	// Test NewRepo on existing checkout. This should simply provide a working
+	// instance without error based on looking at the local directory.
+	nrepo, nrerr := NewRepo("https://launchpad.net/govcstestbzrrepo", tempDir+"/govcstestbzrrepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+	// Verify the right oject is returned. It will check the local repo type.
+	if nrepo.CheckLocal() == false {
+		t.Error("Wrong version returned from NewRepo")
+	}
+
+	err = repo.UpdateVersion("2")
+	if err != nil {
+		t.Errorf("Unable to update Bzr repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "2" {
+		t.Error("Error checking checked out Bzr version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Date to verify we are on the right commit.
+	d, err := repo.Date()
+	if d.Format(longForm) != "2015-07-31 09:50:42 -0400" {
+		t.Error("Error checking checked out Bzr commit date")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Perform an update.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, err = repo.Version()
+	if v != "3" {
+		t.Error("Error checking checked out Bzr version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	tags, err := repo.Tags()
+	if err != nil {
+		t.Error(err)
+	}
+	if tags[0] != "1.0.0" {
+		t.Error("Bzr tags is not reporting the correct version")
+	}
+
+	branches, err := repo.Branches()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(branches) != 0 {
+		t.Error("Bzr is incorrectly returning branches")
+	}
+
+	if repo.IsReference("1.0.0") != true {
+		t.Error("Bzr is reporting a reference is not one")
+	}
+
+	if repo.IsReference("foo") == true {
+		t.Error("Bzr is reporting a non-existant reference is one")
+	}
+
+	if repo.IsDirty() == true {
+		t.Error("Bzr incorrectly reporting dirty")
+	}
+
+}
+
+func TestBzrCheckLocal(t *testing.T) {
+	// Verify repo.CheckLocal fails for non-Bzr directories.
+	// TestBzr is already checking on a valid repo
+	tempDir, err := ioutil.TempDir("", "go-vcs-bzr-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, _ := NewBzrRepo("", tempDir)
+	if repo.CheckLocal() == true {
+		t.Error("Bzr CheckLocal does not identify non-Bzr location")
+	}
+
+	// Test NewRepo when there's no local. This should simply provide a working
+	// instance without error based on looking at the remote localtion.
+	_, nrerr := NewRepo("https://launchpad.net/govcstestbzrrepo", tempDir+"/govcstestbzrrepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/git.go
+++ b/vendor/github.com/Masterminds/vcs/git.go
@@ -1,0 +1,188 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// NewGitRepo creates a new instance of GitRepo. The remote and local directories
+// need to be passed in.
+func NewGitRepo(remote, local string) (*GitRepo, error) {
+	ltype, err := DetectVcsFromFS(local)
+
+	// Found a VCS other than Git. Need to report an error.
+	if err == nil && ltype != Git {
+		return nil, ErrWrongVCS
+	}
+
+	r := &GitRepo{}
+	r.setRemote(remote)
+	r.setLocalPath(local)
+	r.RemoteLocation = "origin"
+	r.Logger = Logger
+
+	// Make sure the local Git repo is configured the same as the remote when
+	// A remote value was passed in.
+	if err == nil && r.CheckLocal() == true {
+		c := exec.Command("git", "config", "--get", "remote.origin.url")
+		c.Dir = local
+		c.Env = envForDir(c.Dir)
+		out, err := c.CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+
+		localRemote := strings.TrimSpace(string(out))
+		if remote != "" && localRemote != remote {
+			return nil, ErrWrongRemote
+		}
+
+		// If no remote was passed in but one is configured for the locally
+		// checked out Git repo use that one.
+		if remote == "" && localRemote != "" {
+			r.setRemote(localRemote)
+		}
+	}
+
+	return r, nil
+}
+
+// GitRepo implements the Repo interface for the Git source control.
+type GitRepo struct {
+	base
+	RemoteLocation string
+}
+
+// Vcs retrieves the underlying VCS being implemented.
+func (s GitRepo) Vcs() Type {
+	return Git
+}
+
+// Get is used to perform an initial clone of a repository.
+func (s *GitRepo) Get() error {
+	_, err := s.run("git", "clone", s.Remote(), s.LocalPath())
+	return err
+}
+
+// Update performs an Git fetch and pull to an existing checkout.
+func (s *GitRepo) Update() error {
+	// Perform a fetch to make sure everything is up to date.
+	_, err := s.runFromDir("git", "fetch", s.RemoteLocation)
+	if err != nil {
+		return err
+	}
+
+	// When in a detached head state, such as when an individual commit is checked
+	// out do not attempt a pull. It will cause an error.
+	detached, err := isDetachedHead(s.LocalPath())
+
+	if err != nil {
+		return err
+	}
+
+	if detached == true {
+		return nil
+	}
+
+	_, err = s.runFromDir("git", "pull")
+	return err
+}
+
+// UpdateVersion sets the version of a package currently checked out via Git.
+func (s *GitRepo) UpdateVersion(version string) error {
+	_, err := s.runFromDir("git", "checkout", version)
+	return err
+}
+
+// Version retrieves the current version.
+func (s *GitRepo) Version() (string, error) {
+	out, err := s.runFromDir("git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Date retrieves the date on the latest commit.
+func (s *GitRepo) Date() (time.Time, error) {
+	out, err := s.runFromDir("git", "log", "-1", "--date=iso", "--pretty=format:%cd")
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := time.Parse(longForm, string(out))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// Branches returns a list of available branches on the RemoteLocation
+func (s *GitRepo) Branches() ([]string, error) {
+	out, err := s.runFromDir("git", "show-ref")
+	if err != nil {
+		return []string{}, err
+	}
+	branches := s.referenceList(string(out), `(?m-s)(?:`+s.RemoteLocation+`)/(\S+)$`)
+	return branches, nil
+}
+
+// Tags returns a list of available tags on the RemoteLocation
+func (s *GitRepo) Tags() ([]string, error) {
+	out, err := s.runFromDir("git", "show-ref")
+	if err != nil {
+		return []string{}, err
+	}
+	tags := s.referenceList(string(out), `(?m-s)(?:tags)/(\S+)$`)
+	return tags, nil
+}
+
+// CheckLocal verifies the local location is a Git repo.
+func (s *GitRepo) CheckLocal() bool {
+	if _, err := os.Stat(s.LocalPath() + "/.git"); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// IsReference returns if a string is a reference. A reference can be a
+// commit id, branch, or tag.
+func (s *GitRepo) IsReference(r string) bool {
+	_, err := s.runFromDir("git", "rev-parse", "--verify", r)
+	if err == nil {
+		return true
+	}
+
+	// Some refs will fail rev-parse. For example, a remote branch that has
+	// not been checked out yet. This next step should pickup the other
+	// possible references.
+	_, err = s.runFromDir("git", "show-ref", r)
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
+// IsDirty returns if the checkout has been modified from the checked
+// out reference.
+func (s *GitRepo) IsDirty() bool {
+	out, err := s.runFromDir("git", "diff")
+	return err != nil || len(out) != 0
+}
+
+func isDetachedHead(dir string) (bool, error) {
+	c := exec.Command("git", "status", "-uno")
+	c.Dir = dir
+	c.Env = envForDir(c.Dir)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	detached := strings.Contains(string(out), "HEAD detached at")
+
+	return detached, nil
+}

--- a/vendor/github.com/Masterminds/vcs/git_test.go
+++ b/vendor/github.com/Masterminds/vcs/git_test.go
@@ -1,0 +1,191 @@
+package vcs
+
+import (
+	"io/ioutil"
+	//"log"
+	"os"
+	"testing"
+)
+
+// Canary test to ensure GitRepo implements the Repo interface.
+var _ Repo = &GitRepo{}
+
+// To verify git is working we perform intergration testing
+// with a known git service.
+
+func TestGit(t *testing.T) {
+
+	tempDir, err := ioutil.TempDir("", "go-vcs-git-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, err := NewGitRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if repo.Vcs() != Git {
+		t.Error("Git is detecting the wrong type")
+	}
+
+	// Check the basic getters.
+	if repo.Remote() != "https://github.com/Masterminds/VCSTestRepo" {
+		t.Error("Remote not set properly")
+	}
+	if repo.LocalPath() != tempDir+"/VCSTestRepo" {
+		t.Error("Local disk location not set properly")
+	}
+
+	//Logger = log.New(os.Stdout, "", log.LstdFlags)
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Git repo. Err was %s", err)
+	}
+
+	// Verify Git repo is a Git repo
+	if repo.CheckLocal() == false {
+		t.Error("Problem checking out repo or Git CheckLocal is not working")
+	}
+
+	// Test internal lookup mechanism used outside of Git specific functionality.
+	ltype, err := DetectVcsFromFS(tempDir + "/VCSTestRepo")
+	if err != nil {
+		t.Error("detectVcsFromFS unable to Git repo")
+	}
+	if ltype != Git {
+		t.Errorf("detectVcsFromFS detected %s instead of Git type", ltype)
+	}
+
+	// Test NewRepo on existing checkout. This should simply provide a working
+	// instance without error based on looking at the local directory.
+	nrepo, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+	// Verify the right oject is returned. It will check the local repo type.
+	if nrepo.CheckLocal() == false {
+		t.Error("Wrong version returned from NewRepo")
+	}
+
+	// Perform an update.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Set the version using the short hash.
+	err = repo.UpdateVersion("806b07b")
+	if err != nil {
+		t.Errorf("Unable to update Git repo version. Err was %s", err)
+	}
+
+	// Once a ref has been checked out the repo is in a detached head state.
+	// Trying to pull in an update in this state will cause an error. Update
+	// should cleanly handle this. Pulling on a branch (tested elsewhere) and
+	// skipping that here.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "806b07b08faa21cfbdae93027904f80174679402" {
+		t.Error("Error checking checked out Git version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Date to verify we are on the right commit.
+	d, err := repo.Date()
+	if d.Format(longForm) != "2015-07-29 09:46:39 -0400" {
+		t.Error("Error checking checked out Git commit date")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that we can set the version something other than short hash
+	err = repo.UpdateVersion("master")
+	if err != nil {
+		t.Errorf("Unable to update Git repo version. Err was %s", err)
+	}
+	err = repo.UpdateVersion("806b07b08faa21cfbdae93027904f80174679402")
+	if err != nil {
+		t.Errorf("Unable to update Git repo version. Err was %s", err)
+	}
+	v, err = repo.Version()
+	if v != "806b07b08faa21cfbdae93027904f80174679402" {
+		t.Error("Error checking checked out Git version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	tags, err := repo.Tags()
+	if err != nil {
+		t.Error(err)
+	}
+	if tags[0] != "1.0.0" {
+		t.Error("Git tags is not reporting the correct version")
+	}
+
+	branches, err := repo.Branches()
+	if err != nil {
+		t.Error(err)
+	}
+	// The branches should be HEAD, master, and test.
+	if branches[2] != "test" {
+		t.Error("Git is incorrectly returning branches")
+	}
+
+	if repo.IsReference("1.0.0") != true {
+		t.Error("Git is reporting a reference is not one")
+	}
+
+	if repo.IsReference("foo") == true {
+		t.Error("Git is reporting a non-existant reference is one")
+	}
+
+	if repo.IsDirty() == true {
+		t.Error("Git incorrectly reporting dirty")
+	}
+
+}
+
+func TestGitCheckLocal(t *testing.T) {
+	// Verify repo.CheckLocal fails for non-Git directories.
+	// TestGit is already checking on a valid repo
+	tempDir, err := ioutil.TempDir("", "go-vcs-git-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, _ := NewGitRepo("", tempDir)
+	if repo.CheckLocal() == true {
+		t.Error("Git CheckLocal does not identify non-Git location")
+	}
+
+	// Test NewRepo when there's no local. This should simply provide a working
+	// instance without error based on looking at the remote localtion.
+	_, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/hg.go
+++ b/vendor/github.com/Masterminds/vcs/hg.go
@@ -1,0 +1,162 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var hgDetectURL = regexp.MustCompile("default = (?P<foo>.+)\n")
+
+// NewHgRepo creates a new instance of HgRepo. The remote and local directories
+// need to be passed in.
+func NewHgRepo(remote, local string) (*HgRepo, error) {
+	ltype, err := DetectVcsFromFS(local)
+
+	// Found a VCS other than Hg. Need to report an error.
+	if err == nil && ltype != Hg {
+		return nil, ErrWrongVCS
+	}
+
+	r := &HgRepo{}
+	r.setRemote(remote)
+	r.setLocalPath(local)
+	r.Logger = Logger
+
+	// Make sure the local Hg repo is configured the same as the remote when
+	// A remote value was passed in.
+	if err == nil && r.CheckLocal() == true {
+		// An Hg repo was found so test that the URL there matches
+		// the repo passed in here.
+		c := exec.Command("hg", "paths")
+		c.Dir = local
+		c.Env = envForDir(c.Dir)
+		out, err := c.CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+
+		m := hgDetectURL.FindStringSubmatch(string(out))
+		if m[1] != "" && m[1] != remote {
+			return nil, ErrWrongRemote
+		}
+
+		// If no remote was passed in but one is configured for the locally
+		// checked out Hg repo use that one.
+		if remote == "" && m[1] != "" {
+			r.setRemote(m[1])
+		}
+	}
+
+	return r, nil
+}
+
+// HgRepo implements the Repo interface for the Mercurial source control.
+type HgRepo struct {
+	base
+}
+
+// Vcs retrieves the underlying VCS being implemented.
+func (s HgRepo) Vcs() Type {
+	return Hg
+}
+
+// Get is used to perform an initial clone of a repository.
+func (s *HgRepo) Get() error {
+	_, err := s.run("hg", "clone", s.Remote(), s.LocalPath())
+	return err
+}
+
+// Update performs a Mercurial pull to an existing checkout.
+func (s *HgRepo) Update() error {
+	_, err := s.runFromDir("hg", "update")
+	return err
+}
+
+// UpdateVersion sets the version of a package currently checked out via Hg.
+func (s *HgRepo) UpdateVersion(version string) error {
+	_, err := s.runFromDir("hg", "pull")
+	if err != nil {
+		return err
+	}
+	_, err = s.runFromDir("hg", "update", version)
+	return err
+}
+
+// Version retrieves the current version.
+func (s *HgRepo) Version() (string, error) {
+	out, err := s.runFromDir("hg", "identify")
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.SplitN(string(out), " ", 2)
+	sha := parts[0]
+	return strings.TrimSpace(sha), nil
+}
+
+// Date retrieves the date on the latest commit.
+func (s *HgRepo) Date() (time.Time, error) {
+	version, err := s.Version()
+	if err != nil {
+		return time.Time{}, err
+	}
+	out, err := s.runFromDir("hg", "log", "-r", version, "--template", "{date|isodatesec}")
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := time.Parse(longForm, string(out))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// CheckLocal verifies the local location is a Git repo.
+func (s *HgRepo) CheckLocal() bool {
+	if _, err := os.Stat(s.LocalPath() + "/.hg"); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// Branches returns a list of available branches
+func (s *HgRepo) Branches() ([]string, error) {
+	out, err := s.runFromDir("hg", "branches")
+	if err != nil {
+		return []string{}, err
+	}
+	branches := s.referenceList(string(out), `(?m-s)^(\S+)`)
+	return branches, nil
+}
+
+// Tags returns a list of available tags
+func (s *HgRepo) Tags() ([]string, error) {
+	out, err := s.runFromDir("hg", "tags")
+	if err != nil {
+		return []string{}, err
+	}
+	tags := s.referenceList(string(out), `(?m-s)^(\S+)`)
+	return tags, nil
+}
+
+// IsReference returns if a string is a reference. A reference can be a
+// commit id, branch, or tag.
+func (s *HgRepo) IsReference(r string) bool {
+	_, err := s.runFromDir("hg", "log", "-r", r)
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
+// IsDirty returns if the checkout has been modified from the checked
+// out reference.
+func (s *HgRepo) IsDirty() bool {
+	out, err := s.runFromDir("hg", "diff")
+	return err != nil || len(out) != 0
+}

--- a/vendor/github.com/Masterminds/vcs/hg_test.go
+++ b/vendor/github.com/Masterminds/vcs/hg_test.go
@@ -1,0 +1,177 @@
+package vcs
+
+import (
+	"io/ioutil"
+	//"log"
+	"os"
+	"testing"
+)
+
+// Canary test to ensure HgRepo implements the Repo interface.
+var _ Repo = &HgRepo{}
+
+// To verify hg is working we perform intergration testing
+// with a known hg service.
+
+func TestHg(t *testing.T) {
+
+	tempDir, err := ioutil.TempDir("", "go-vcs-hg-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, err := NewHgRepo("https://bitbucket.org/mattfarina/testhgrepo", tempDir+"/testhgrepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if repo.Vcs() != Hg {
+		t.Error("Hg is detecting the wrong type")
+	}
+
+	// Check the basic getters.
+	if repo.Remote() != "https://bitbucket.org/mattfarina/testhgrepo" {
+		t.Error("Remote not set properly")
+	}
+	if repo.LocalPath() != tempDir+"/testhgrepo" {
+		t.Error("Local disk location not set properly")
+	}
+
+	//Logger = log.New(os.Stdout, "", log.LstdFlags)
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Hg repo. Err was %s", err)
+	}
+
+	// Verify Hg repo is a Hg repo
+	if repo.CheckLocal() == false {
+		t.Error("Problem checking out repo or Hg CheckLocal is not working")
+	}
+
+	// Test internal lookup mechanism used outside of Hg specific functionality.
+	ltype, err := DetectVcsFromFS(tempDir + "/testhgrepo")
+	if err != nil {
+		t.Error("detectVcsFromFS unable to Hg repo")
+	}
+	if ltype != Hg {
+		t.Errorf("detectVcsFromFS detected %s instead of Hg type", ltype)
+	}
+
+	// Test NewRepo on existing checkout. This should simply provide a working
+	// instance without error based on looking at the local directory.
+	nrepo, nrerr := NewRepo("https://bitbucket.org/mattfarina/testhgrepo", tempDir+"/testhgrepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+	// Verify the right oject is returned. It will check the local repo type.
+	if nrepo.CheckLocal() == false {
+		t.Error("Wrong version returned from NewRepo")
+	}
+
+	// Set the version using the short hash.
+	err = repo.UpdateVersion("a5494ba2177f")
+	if err != nil {
+		t.Errorf("Unable to update Hg repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "a5494ba2177f" {
+		t.Error("Error checking checked out Hg version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Date to verify we are on the right commit.
+	d, err := repo.Date()
+	if err != nil {
+		t.Error(err)
+	}
+	if d.Format(longForm) != "2015-07-30 16:14:08 -0400" {
+		t.Error("Error checking checked out Hg commit date. Got wrong date:", d)
+	}
+
+	// Perform an update.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, err = repo.Version()
+	if v != "9c6ccbca73e8" {
+		t.Error("Error checking checked out Hg version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	tags, err := repo.Tags()
+	if err != nil {
+		t.Error(err)
+	}
+	if tags[1] != "1.0.0" {
+		t.Error("Hg tags is not reporting the correct version")
+	}
+
+	branches, err := repo.Branches()
+	if err != nil {
+		t.Error(err)
+	}
+	// The branches should be HEAD, master, and test.
+	if branches[0] != "test" {
+		t.Error("Hg is incorrectly returning branches")
+	}
+
+	if repo.IsReference("1.0.0") != true {
+		t.Error("Hg is reporting a reference is not one")
+	}
+
+	if repo.IsReference("test") != true {
+		t.Error("Hg is reporting a reference is not one")
+	}
+
+	if repo.IsReference("foo") == true {
+		t.Error("Hg is reporting a non-existant reference is one")
+	}
+
+	if repo.IsDirty() == true {
+		t.Error("Hg incorrectly reporting dirty")
+	}
+
+}
+
+func TestHgCheckLocal(t *testing.T) {
+	// Verify repo.CheckLocal fails for non-Hg directories.
+	// TestHg is already checking on a valid repo
+	tempDir, err := ioutil.TempDir("", "go-vcs-hg-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, _ := NewHgRepo("", tempDir)
+	if repo.CheckLocal() == true {
+		t.Error("Hg CheckLocal does not identify non-Hg location")
+	}
+
+	// Test NewRepo when there's no local. This should simply provide a working
+	// instance without error based on looking at the remote localtion.
+	_, nrerr := NewRepo("https://bitbucket.org/mattfarina/testhgrepo", tempDir+"/testhgrepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/repo.go
+++ b/vendor/github.com/Masterminds/vcs/repo.go
@@ -1,0 +1,236 @@
+// Package vcs provides the ability to work with varying version control systems
+// (VCS),  also known as source control systems (SCM) though the same interface.
+//
+// This package includes a function that attempts to detect the repo type from
+// the remote URL and return the proper type. For example,
+//
+//     remote := "https://github.com/Masterminds/vcs"
+//     local, _ := ioutil.TempDir("", "go-vcs")
+//     repo, err := NewRepo(remote, local)
+//
+// In this case repo will be a GitRepo instance. NewRepo can detect the VCS for
+// numerous popular VCS and from the URL. For example, a URL ending in .git
+// that's not from one of the popular VCS will be detected as a Git repo and
+// the correct type will be returned.
+//
+// If you know the repository type and would like to create an instance of a
+// specific type you can use one of constructors for a type. They are NewGitRepo,
+// NewSvnRepo, NewBzrRepo, and NewHgRepo. The definition and usage is the same
+// as NewRepo.
+//
+// Once you have an object implementing the Repo interface the operations are
+// the same no matter which VCS you're using. There are some caveats. For
+// example, each VCS has its own version formats that need to be respected and
+// checkout out branches, if a branch is being worked with, is different in
+// each VCS.
+package vcs
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrWrongVCS is returned when an action is tried on the wrong VCS.
+	ErrWrongVCS = errors.New("Wrong VCS detected")
+
+	// ErrCannotDetectVCS is returned when VCS cannot be detected from URI string.
+	ErrCannotDetectVCS = errors.New("Cannot detect VCS")
+
+	// ErrWrongRemote occurs when the passed in remote does not match the VCS
+	// configured endpoint.
+	ErrWrongRemote = errors.New("The Remote does not match the VCS endpoint")
+)
+
+// Logger is where you can provide a logger, implementing the log.Logger interface,
+// where verbose output from each VCS will be written. The default logger does
+// not log data. To log data supply your own logger or change the output location
+// of the provided logger.
+var Logger *log.Logger
+
+func init() {
+	// Initialize the logger to one that does not actually log anywhere. This is
+	// to be overridden by the package user by setting vcs.Logger to a different
+	// logger.
+	Logger = log.New(ioutil.Discard, "go-vcs", log.LstdFlags)
+}
+
+const longForm = "2006-01-02 15:04:05 -0700"
+
+// Type describes the type of VCS
+type Type string
+
+// VCS types
+const (
+	NoVCS Type = ""
+	Git   Type = "git"
+	Svn   Type = "svn"
+	Bzr   Type = "bzr"
+	Hg    Type = "hg"
+)
+
+// Repo provides an interface to work with repositories using different source
+// control systems such as Git, Bzr, Mercurial, and SVN. For implementations
+// of this interface see BzrRepo, GitRepo, HgRepo, and SvnRepo.
+type Repo interface {
+
+	// Vcs retrieves the underlying VCS being implemented.
+	Vcs() Type
+
+	// Remote retrieves the remote location for a repo.
+	Remote() string
+
+	// LocalPath retrieves the local file system location for a repo.
+	LocalPath() string
+
+	// Get is used to perform an initial clone/checkout of a repository.
+	Get() error
+
+	// Update performs an update to an existing checkout of a repository.
+	Update() error
+
+	// UpdateVersion sets the version of a package of a repository.
+	UpdateVersion(string) error
+
+	// Version retrieves the current version.
+	Version() (string, error)
+
+	// Date retrieves the date on the latest commit.
+	Date() (time.Time, error)
+
+	// CheckLocal verifies the local location is of the correct VCS type
+	CheckLocal() bool
+
+	// Branches returns a list of available branches on the repository.
+	Branches() ([]string, error)
+
+	// Tags returns a list of available tags on the repository.
+	Tags() ([]string, error)
+
+	// TODO: Provide a consistent manner to get reference information across
+	// multiple VCS.
+
+	// IsReference returns if a string is a reference. A reference can be a
+	// commit id, branch, or tag.
+	IsReference(string) bool
+
+	// IsDirty returns if the checkout has been modified from the checked
+	// out reference.
+	IsDirty() bool
+}
+
+// NewRepo returns a Repo based on trying to detect the source control from the
+// remote and local locations. The appropriate implementation will be returned
+// or an ErrCannotDetectVCS if the VCS type cannot be detected.
+// Note, this function may make calls to the Internet to determind help determine
+// the VCS.
+func NewRepo(remote, local string) (Repo, error) {
+	vtype, remote, err := detectVcsFromRemote(remote)
+
+	// From the remote URL the VCS could not be detected. See if the local
+	// repo contains enough information to figure out the VCS. The reason the
+	// local repo is not checked first is because of the potential for VCS type
+	// switches which will be detected in each of the type builders.
+	if err == ErrCannotDetectVCS {
+		vtype, err = DetectVcsFromFS(local)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch vtype {
+	case Git:
+		return NewGitRepo(remote, local)
+	case Svn:
+		return NewSvnRepo(remote, local)
+	case Hg:
+		return NewHgRepo(remote, local)
+	case Bzr:
+		return NewBzrRepo(remote, local)
+	}
+
+	// Should never fall through to here but just in case.
+	return nil, ErrCannotDetectVCS
+}
+
+type base struct {
+	remote, local string
+	Logger        *log.Logger
+}
+
+func (b *base) log(v interface{}) {
+	b.Logger.Printf("%s", v)
+}
+
+// Remote retrieves the remote location for a repo.
+func (b *base) Remote() string {
+	return b.remote
+}
+
+// LocalPath retrieves the local file system location for a repo.
+func (b *base) LocalPath() string {
+	return b.local
+}
+
+func (b *base) setRemote(remote string) {
+	b.remote = remote
+}
+
+func (b *base) setLocalPath(local string) {
+	b.local = local
+}
+
+func (b base) run(cmd string, args ...string) ([]byte, error) {
+	out, err := exec.Command(cmd, args...).CombinedOutput()
+	b.log(out)
+	if err != nil {
+		err = fmt.Errorf("%s: %s", out, err)
+	}
+	return out, err
+}
+
+func (b *base) runFromDir(cmd string, args ...string) ([]byte, error) {
+	c := exec.Command(cmd, args...)
+	c.Dir = b.local
+	c.Env = envForDir(c.Dir)
+	out, err := c.CombinedOutput()
+	return out, err
+}
+
+func (b *base) referenceList(c, r string) []string {
+	var out []string
+	re := regexp.MustCompile(r)
+	for _, m := range re.FindAllStringSubmatch(c, -1) {
+		out = append(out, m[1])
+	}
+
+	return out
+}
+
+func envForDir(dir string) []string {
+	env := os.Environ()
+	return mergeEnvLists([]string{"PWD=" + dir}, env)
+}
+
+func mergeEnvLists(in, out []string) []string {
+NextVar:
+	for _, inkv := range in {
+		k := strings.SplitAfterN(inkv, "=", 2)[0]
+		for i, outkv := range out {
+			if strings.HasPrefix(outkv, k) {
+				out[i] = inkv
+				continue NextVar
+			}
+		}
+		out = append(out, inkv)
+	}
+	return out
+}

--- a/vendor/github.com/Masterminds/vcs/repo_test.go
+++ b/vendor/github.com/Masterminds/vcs/repo_test.go
@@ -1,0 +1,62 @@
+package vcs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func ExampleNewRepo() {
+	remote := "https://github.com/Masterminds/vcs"
+	local, _ := ioutil.TempDir("", "go-vcs")
+	repo, _ := NewRepo(remote, local)
+	// Returns: instance of GitRepo
+
+	repo.Vcs()
+	// Returns Git as this is a Git repo
+
+	err := repo.Get()
+	// Pulls down a repo, or a checkout in the case of SVN, and returns an
+	// error if that didn't happen successfully.
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	err = repo.UpdateVersion("master")
+	// Checkouts out a specific version. In most cases this can be a commit id,
+	// branch, or tag.
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestTypeSwitch(t *testing.T) {
+
+	// To test repo type switching we checkout as SVN and then try to get it as
+	// a git repo afterwards.
+	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, err := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	if err != nil {
+		t.Error(err)
+	}
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to checkout SVN repo for repo switching tests. Err was %s", err)
+	}
+
+	_, err = NewRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
+	if err != ErrWrongVCS {
+		t.Errorf("Not detecting repo switch from SVN to Git")
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/svn.go
+++ b/vendor/github.com/Masterminds/vcs/svn.go
@@ -1,0 +1,166 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var svnDetectURL = regexp.MustCompile("URL: (?P<foo>.+)\n")
+
+// NewSvnRepo creates a new instance of SvnRepo. The remote and local directories
+// need to be passed in. The remote location should include the branch for SVN.
+// For example, if the package is https://github.com/Masterminds/cookoo/ the remote
+// should be https://github.com/Masterminds/cookoo/trunk for the trunk branch.
+func NewSvnRepo(remote, local string) (*SvnRepo, error) {
+	ltype, err := DetectVcsFromFS(local)
+
+	// Found a VCS other than Svn. Need to report an error.
+	if err == nil && ltype != Svn {
+		return nil, ErrWrongVCS
+	}
+
+	r := &SvnRepo{}
+	r.setRemote(remote)
+	r.setLocalPath(local)
+	r.Logger = Logger
+
+	// Make sure the local SVN repo is configured the same as the remote when
+	// A remote value was passed in.
+	if err == nil && r.CheckLocal() == true {
+		// An SVN repo was found so test that the URL there matches
+		// the repo passed in here.
+		out, err := exec.Command("svn", "info", local).CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+
+		m := svnDetectURL.FindStringSubmatch(string(out))
+		if m[1] != "" && m[1] != remote {
+			return nil, ErrWrongRemote
+		}
+
+		// If no remote was passed in but one is configured for the locally
+		// checked out Svn repo use that one.
+		if remote == "" && m[1] != "" {
+			r.setRemote(m[1])
+		}
+	}
+
+	return r, nil
+}
+
+// SvnRepo implements the Repo interface for the Svn source control.
+type SvnRepo struct {
+	base
+}
+
+// Vcs retrieves the underlying VCS being implemented.
+func (s SvnRepo) Vcs() Type {
+	return Svn
+}
+
+// Get is used to perform an initial checkout of a repository.
+// Note, because SVN isn't distributed this is a checkout without
+// a clone.
+func (s *SvnRepo) Get() error {
+	_, err := s.run("svn", "checkout", s.Remote(), s.LocalPath())
+	return err
+}
+
+// Update performs an SVN update to an existing checkout.
+func (s *SvnRepo) Update() error {
+	_, err := s.runFromDir("svn", "update")
+	return err
+}
+
+// UpdateVersion sets the version of a package currently checked out via SVN.
+func (s *SvnRepo) UpdateVersion(version string) error {
+	_, err := s.runFromDir("svn", "update", "-r", version)
+	return err
+}
+
+// Version retrieves the current version.
+func (s *SvnRepo) Version() (string, error) {
+	out, err := s.runFromDir("svnversion", ".")
+	s.log(out)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Date retrieves the date on the latest commit.
+func (s *SvnRepo) Date() (time.Time, error) {
+	version, err := s.Version()
+	if err != nil {
+		return time.Time{}, err
+	}
+	out, err := s.runFromDir("svn", "pget", "svn:date", "--revprop", "-r", version)
+	if err != nil {
+		return time.Time{}, err
+	}
+	const longForm = "2006-01-02T15:04:05.000000Z\n"
+	t, err := time.Parse(longForm, string(out))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// CheckLocal verifies the local location is an SVN repo.
+func (s *SvnRepo) CheckLocal() bool {
+	if _, err := os.Stat(s.LocalPath() + "/.svn"); err == nil {
+		return true
+	}
+
+	return false
+
+}
+
+// Tags returns []string{} as there are no formal tags in SVN. Tags are a
+// convention in SVN. They are typically implemented as a copy of the trunk and
+// placed in the /tags/[tag name] directory. Since this is a convention the
+// expectation is to checkout a tag the correct subdirectory will be used
+// as the path. For more information see:
+// http://svnbook.red-bean.com/en/1.7/svn.branchmerge.tags.html
+func (s *SvnRepo) Tags() ([]string, error) {
+	return []string{}, nil
+}
+
+// Branches returns []string{} as there are no formal branches in SVN. Branches
+// are a convention. They are typically implemented as a copy of the trunk and
+// placed in the /branches/[tag name] directory. Since this is a convention the
+// expectation is to checkout a branch the correct subdirectory will be used
+// as the path. For more information see:
+// http://svnbook.red-bean.com/en/1.7/svn.branchmerge.using.html
+func (s *SvnRepo) Branches() ([]string, error) {
+	return []string{}, nil
+}
+
+// IsReference returns if a string is a reference. A reference is a commit id.
+// Branches and tags are part of the path.
+func (s *SvnRepo) IsReference(r string) bool {
+	out, err := s.runFromDir("svn", "log", "-r", r)
+
+	// This is a complete hack. There must be a better way to do this. Pull
+	// requests welcome. When the reference isn't real you get a line of
+	// repeated - followed by an empty line. If the reference is real there
+	// is commit information in addition to those. So, we look for responses
+	// over 2 lines long.
+	lines := strings.Split(string(out), "\n")
+	if err == nil && len(lines) > 2 {
+		return true
+	}
+
+	return false
+}
+
+// IsDirty returns if the checkout has been modified from the checked
+// out reference.
+func (s *SvnRepo) IsDirty() bool {
+	out, err := s.runFromDir("svn", "diff")
+	return err != nil || len(out) != 0
+}

--- a/vendor/github.com/Masterminds/vcs/svn_test.go
+++ b/vendor/github.com/Masterminds/vcs/svn_test.go
@@ -1,0 +1,182 @@
+package vcs
+
+import (
+	"io/ioutil"
+	//"log"
+	"os"
+	"testing"
+)
+
+// To verify svn is working we perform intergration testing
+// with a known svn service.
+
+// Canary test to ensure SvnRepo implements the Repo interface.
+var _ Repo = &SvnRepo{}
+
+func TestSvn(t *testing.T) {
+
+	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, err := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if repo.Vcs() != Svn {
+		t.Error("Svn is detecting the wrong type")
+	}
+
+	// Check the basic getters.
+	if repo.Remote() != "https://github.com/Masterminds/VCSTestRepo/trunk" {
+		t.Error("Remote not set properly")
+	}
+	if repo.LocalPath() != tempDir+"/VCSTestRepo" {
+		t.Error("Local disk location not set properly")
+	}
+
+	//Logger = log.New(os.Stdout, "", log.LstdFlags)
+
+	// Do an initial checkout.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to checkout SVN repo. Err was %s", err)
+	}
+
+	// Verify SVN repo is a SVN repo
+	if repo.CheckLocal() == false {
+		t.Error("Problem checking out repo or SVN CheckLocal is not working")
+	}
+
+	// Verify an incorrect remote is caught when NewSvnRepo is used on an existing location
+	_, nrerr := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/unknownbranch", tempDir+"/VCSTestRepo")
+	if nrerr != ErrWrongRemote {
+		t.Error("ErrWrongRemote was not triggered for SVN")
+	}
+
+	// Test internal lookup mechanism used outside of Hg specific functionality.
+	ltype, err := DetectVcsFromFS(tempDir + "/VCSTestRepo")
+	if err != nil {
+		t.Error("detectVcsFromFS unable to Svn repo")
+	}
+	if ltype != Svn {
+		t.Errorf("detectVcsFromFS detected %s instead of Svn type", ltype)
+	}
+
+	// Commenting out auto-detection tests for SVN. NewRepo automatically detects
+	// GitHub to be a Git repo and that's an issue for this test. Need an
+	// SVN host that can autodetect from before using this test again.
+	//
+	// Test NewRepo on existing checkout. This should simply provide a working
+	// instance without error based on looking at the local directory.
+	// nrepo, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	// if nrerr != nil {
+	// 	t.Error(nrerr)
+	// }
+	// // Verify the right oject is returned. It will check the local repo type.
+	// if nrepo.CheckLocal() == false {
+	// 	t.Error("Wrong version returned from NewRepo")
+	// }
+
+	// Update the version to a previous version.
+	err = repo.UpdateVersion("r2")
+	if err != nil {
+		t.Errorf("Unable to update SVN repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "2" {
+		t.Error("Error checking checked SVN out version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Perform an update which should take up back to the latest version.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Make sure we are on a newer version because of the update.
+	v, err = repo.Version()
+	if v == "2" {
+		t.Error("Error with version. Still on old version. Update failed")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Date to verify we are on the right commit.
+	d, err := repo.Date()
+	if d.Format(longForm) != "2015-07-29 13:47:03 +0000" {
+		t.Error("Error checking checked out Svn commit date")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	tags, err := repo.Tags()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(tags) != 0 {
+		t.Error("Svn is incorrectly returning tags")
+	}
+
+	branches, err := repo.Branches()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(branches) != 0 {
+		t.Error("Svn is incorrectly returning branches")
+	}
+
+	if repo.IsReference("r4") != true {
+		t.Error("Svn is reporting a reference is not one")
+	}
+
+	if repo.IsReference("55") == true {
+		t.Error("Svn is reporting a non-existant reference is one")
+	}
+
+	if repo.IsDirty() == true {
+		t.Error("Svn incorrectly reporting dirty")
+	}
+}
+
+func TestSvnCheckLocal(t *testing.T) {
+	// Verify repo.CheckLocal fails for non-SVN directories.
+	// TestSvn is already checking on a valid repo
+	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	repo, _ := NewSvnRepo("", tempDir)
+	if repo.CheckLocal() == true {
+		t.Error("SVN CheckLocal does not identify non-SVN location")
+	}
+
+	// Test NewRepo when there's no local. This should simply provide a working
+	// instance without error based on looking at the remote localtion.
+	_, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	if nrerr != nil {
+		t.Error(nrerr)
+	}
+}

--- a/vendor/github.com/Masterminds/vcs/vcs_local_lookup.go
+++ b/vendor/github.com/Masterminds/vcs/vcs_local_lookup.go
@@ -1,0 +1,38 @@
+package vcs
+
+import (
+	"os"
+)
+
+// DetectVcsFromFS detects the type from the local path.
+// Is there a better way to do this?
+func DetectVcsFromFS(vcsPath string) (Type, error) {
+
+	// When the local directory to the package doesn't exist
+	// it's not yet downloaded so we can't detect the type
+	// locally.
+	if _, err := os.Stat(vcsPath); os.IsNotExist(err) {
+		return "", ErrCannotDetectVCS
+	}
+
+	seperator := string(os.PathSeparator)
+
+	// Walk through each of the different VCS types to see if
+	// one can be detected. Do this is order of guessed popularity.
+	if _, err := os.Stat(vcsPath + seperator + ".git"); err == nil {
+		return Git, nil
+	}
+	if _, err := os.Stat(vcsPath + seperator + ".svn"); err == nil {
+		return Svn, nil
+	}
+	if _, err := os.Stat(vcsPath + seperator + ".hg"); err == nil {
+		return Hg, nil
+	}
+	if _, err := os.Stat(vcsPath + seperator + ".bzr"); err == nil {
+		return Bzr, nil
+	}
+
+	// If one was not already detected than we default to not finding it.
+	return "", ErrCannotDetectVCS
+
+}

--- a/vendor/github.com/Masterminds/vcs/vcs_remote_lookup.go
+++ b/vendor/github.com/Masterminds/vcs/vcs_remote_lookup.go
@@ -1,0 +1,335 @@
+package vcs
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type vcsInfo struct {
+	host     string
+	pattern  string
+	vcs      Type
+	addCheck func(m map[string]string) (Type, error)
+	regex    *regexp.Regexp
+}
+
+var vcsList = []*vcsInfo{
+	{
+		host:    "github.com",
+		vcs:     Git,
+		pattern: `^(github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
+	},
+	{
+		host:     "bitbucket.org",
+		pattern:  `^(bitbucket\.org/(?P<name>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		addCheck: checkBitbucket,
+	},
+	{
+		host:    "launchpad.net",
+		pattern: `^(launchpad\.net/(([A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:     Bzr,
+	},
+	{
+		host:    "git.launchpad.net",
+		vcs:     Git,
+		pattern: `^(git\.launchpad\.net/(([A-Za-z0-9_.\-]+)|~[A-Za-z0-9_.\-]+/(\+git|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))$`,
+	},
+	{
+		host:    "go.googlesource.com",
+		vcs:     Git,
+		pattern: `^(go\.googlesource\.com/[A-Za-z0-9_.\-]+/?)$`,
+	},
+	// TODO: Once Google Code becomes fully deprecated this can be removed.
+	{
+		host:     "code.google.com",
+		addCheck: checkGoogle,
+		pattern:  `^(code\.google\.com/[pr]/(?P<project>[a-z0-9\-]+)(\.(?P<repo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`,
+	},
+	// Alternative Google setup. This is the previous structure but it still works... until Google Code goes away.
+	{
+		addCheck: checkURL,
+		pattern:  `^([a-z0-9_\-.]+)\.googlecode\.com/(?P<type>git|hg|svn)(/.*)?$`,
+	},
+	// If none of the previous detect the type they will fall to this looking for the type in a generic sense
+	// by the extension to the path.
+	{
+		addCheck: checkURL,
+		pattern:  `\.(?P<type>git|hg|svn|bzr)$`,
+	},
+}
+
+func init() {
+	// Precompile the regular expressions used to check VCS locations.
+	for _, v := range vcsList {
+		v.regex = regexp.MustCompile(v.pattern)
+	}
+}
+
+// This function is really a hack around Go redirects rather than around
+// something VCS related. Should this be moved to the glide project or a
+// helper function?
+func detectVcsFromRemote(vcsURL string) (Type, string, error) {
+	t, e := detectVcsFromURL(vcsURL)
+	if e == nil {
+		return t, vcsURL, nil
+	}
+
+	// Need to test for vanity or paths like golang.org/x/
+
+	// TODO: Test for 3xx redirect codes and handle appropriately.
+
+	// Pages like https://golang.org/x/net provide an html document with
+	// meta tags containing a location to work with. The go tool uses
+	// a meta tag with the name go-import which is what we use here.
+	// godoc.org also has one call go-source that we do not need to use.
+	// The value of go-import is in the form "prefix vcs repo". The prefix
+	// should match the vcsURL and the repo is a location that can be
+	// checked out. Note, to get the html document you you need to add
+	// ?go-get=1 to the url.
+	u, err := url.Parse(vcsURL)
+	if err != nil {
+		return NoVCS, "", err
+	}
+	if u.RawQuery == "" {
+		u.RawQuery = "go-get=1"
+	} else {
+		u.RawQuery = u.RawQuery + "+go-get=1"
+	}
+	checkURL := u.String()
+	resp, err := http.Get(checkURL)
+	if err != nil {
+		return NoVCS, "", ErrCannotDetectVCS
+	}
+	defer resp.Body.Close()
+
+	t, nu, err := parseImportFromBody(u, resp.Body)
+	if err != nil {
+		return NoVCS, "", err
+	} else if t == "" || nu == "" {
+		return NoVCS, "", ErrCannotDetectVCS
+	}
+
+	return t, nu, nil
+}
+
+// From a remote vcs url attempt to detect the VCS.
+func detectVcsFromURL(vcsURL string) (Type, error) {
+	u, err := url.Parse(vcsURL)
+	if err != nil {
+		return "", err
+	}
+
+	// If there is no host found we cannot detect the VCS from
+	// the url. Note, URIs beginning with git@github using the ssh
+	// syntax fail this check.
+	if u.Host == "" {
+		return "", ErrCannotDetectVCS
+	}
+
+	// Try to detect from known hosts, such as Github
+	for _, v := range vcsList {
+		if v.host != "" && v.host != u.Host {
+			continue
+		}
+
+		// Make sure the pattern matches for an actual repo location. For example,
+		// we should fail if the VCS listed is github.com/masterminds as that's
+		// not actually a repo.
+		uCheck := u.Host + u.Path
+		m := v.regex.FindStringSubmatch(uCheck)
+		if m == nil {
+			if v.host != "" {
+				return "", ErrCannotDetectVCS
+			}
+
+			continue
+		}
+
+		// If we are here the host matches. If the host has a singular
+		// VCS type, such as Github, we can return the type right away.
+		if v.vcs != "" {
+			return v.vcs, nil
+		}
+
+		// Run additional checks to determine try and determine the repo
+		// for the matched service.
+		info := make(map[string]string)
+		for i, name := range v.regex.SubexpNames() {
+			if name != "" {
+				info[name] = m[i]
+			}
+		}
+		t, err := v.addCheck(info)
+		if err != nil {
+			return "", ErrCannotDetectVCS
+		}
+
+		return t, nil
+
+	}
+
+	// Unable to determine the vcs from the url.
+	return "", ErrCannotDetectVCS
+}
+
+// Bitbucket provides an API for checking the VCS.
+func checkBitbucket(i map[string]string) (Type, error) {
+
+	// The part of the response we care about.
+	var response struct {
+		SCM Type `json:"scm"`
+	}
+
+	u := expand(i, "https://api.bitbucket.org/1.0/repositories/{name}")
+	data, err := get(u)
+	if err != nil {
+		return "", err
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return "", fmt.Errorf("Decoding error %s: %v", u, err)
+	}
+
+	return response.SCM, nil
+
+}
+
+// Google supports Git, Hg, and Svn. The SVN style is only
+// supported through their legacy setup at <project>.googlecode.com.
+// I wonder if anyone is actually using SVN support.
+func checkGoogle(i map[string]string) (Type, error) {
+
+	// To figure out which of the VCS types is used in Google Code you need
+	// to parse a web page and find it. Ugh. I mean... ugh.
+	var hack = regexp.MustCompile(`id="checkoutcmd">(hg|git|svn)`)
+
+	d, err := get(expand(i, "https://code.google.com/p/{project}/source/checkout?repo={repo}"))
+	if err != nil {
+		return "", err
+	}
+
+	if m := hack.FindSubmatch(d); m != nil {
+		if vcs := string(m[1]); vcs != "" {
+			if vcs == "svn" {
+				// While Google supports SVN it can only be used with the legacy
+				// urls of <project>.googlecode.com. I considered creating a new
+				// error for this problem but Google Code is going away and there
+				// is support for the legacy structure.
+				return "", ErrCannotDetectVCS
+			}
+
+			return Type(vcs), nil
+		}
+	}
+
+	return "", ErrCannotDetectVCS
+}
+
+// Expect a type key on i with the exact type detected from the regex.
+func checkURL(i map[string]string) (Type, error) {
+	return Type(i["type"]), nil
+}
+
+func get(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", url, err)
+	}
+	return b, nil
+}
+
+func expand(match map[string]string, s string) string {
+	for k, v := range match {
+		s = strings.Replace(s, "{"+k+"}", v, -1)
+	}
+	return s
+}
+
+func parseImportFromBody(ur *url.URL, r io.ReadCloser) (tp Type, u string, err error) {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charsetReader
+	d.Strict = false
+	var t xml.Token
+	for {
+		t, err = d.Token()
+		if err != nil {
+			if err == io.EOF {
+				// When the end is reached it could not detect a VCS if it
+				// got here.
+				err = ErrCannotDetectVCS
+			}
+			return
+		}
+		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			return
+		}
+		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			return
+		}
+		e, ok := t.(xml.StartElement)
+		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
+			continue
+		}
+		if attrValue(e.Attr, "name") != "go-import" {
+			continue
+		}
+		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			// If the prefix supplied by the remote system isn't a prefix to the
+			// url we're fetching continue to look for other imports.
+			// This will work for exact matches and prefixes. For example,
+			// golang.org/x/net as a prefix will match for golang.org/x/net and
+			// golang.org/x/net/context.
+			vcsURL := ur.Host + ur.Path
+			if !strings.HasPrefix(vcsURL, f[0]) {
+				continue
+			} else {
+				switch Type(f[1]) {
+				case Git:
+					tp = Git
+				case Svn:
+					tp = Svn
+				case Bzr:
+					tp = Bzr
+				case Hg:
+					tp = Hg
+				}
+
+				u = f[2]
+				return
+			}
+		}
+	}
+}
+
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "ascii":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("can't decode XML document using charset %q", charset)
+	}
+}
+
+func attrValue(attrs []xml.Attr, name string) string {
+	for _, a := range attrs {
+		if strings.EqualFold(a.Name.Local, name) {
+			return a.Value
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/Masterminds/vcs/vcs_remote_lookup_test.go
+++ b/vendor/github.com/Masterminds/vcs/vcs_remote_lookup_test.go
@@ -1,0 +1,52 @@
+package vcs
+
+import (
+	"testing"
+)
+
+func TestVCSLookup(t *testing.T) {
+	// TODO: Expand to make sure it detected the right vcs.
+	urlList := map[string]struct {
+		work bool
+		t    Type
+	}{
+		"https://github.com/masterminds":                                   {work: false, t: Git},
+		"https://github.com/Masterminds/VCSTestRepo":                       {work: true, t: Git},
+		"https://bitbucket.org/mattfarina/testhgrepo":                      {work: true, t: Hg},
+		"https://launchpad.net/govcstestbzrrepo/trunk":                     {work: true, t: Bzr},
+		"https://launchpad.net/~mattfarina/+junk/mygovcstestbzrrepo":       {work: true, t: Bzr},
+		"https://launchpad.net/~mattfarina/+junk/mygovcstestbzrrepo/trunk": {work: true, t: Bzr},
+		"https://git.launchpad.net/govcstestgitrepo":                       {work: true, t: Git},
+		"https://git.launchpad.net/~mattfarina/+git/mygovcstestgitrepo":    {work: true, t: Git},
+		"http://farbtastic.googlecode.com/svn/":                            {work: true, t: Svn},
+		"http://farbtastic.googlecode.com/svn/trunk":                       {work: true, t: Svn},
+		"https://code.google.com/p/farbtastic":                             {work: false, t: Svn},
+		"https://code.google.com/p/plotinum":                               {work: true, t: Hg},
+		"https://example.com/foo/bar.git":                                  {work: true, t: Git},
+		"https://example.com/foo/bar.svn":                                  {work: true, t: Svn},
+		"https://example.com/foo/bar/baz.bzr":                              {work: true, t: Bzr},
+		"https://example.com/foo/bar/baz.hg":                               {work: true, t: Hg},
+		"https://gopkg.in/tomb.v1":                                         {work: true, t: Git},
+		"https://golang.org/x/net":                                         {work: true, t: Git},
+		"https://speter.net/go/exp/math/dec/inf":                           {work: true, t: Git},
+	}
+
+	for u, c := range urlList {
+		ty, _, err := detectVcsFromRemote(u)
+		if err == nil && c.work == false {
+			t.Errorf("Error detecting VCS from URL(%s)", u)
+		}
+
+		if err == ErrCannotDetectVCS && c.work == true {
+			t.Errorf("Error detecting VCS from URL(%s)", u)
+		}
+
+		if err != nil && c.work == true {
+			t.Errorf("Error detecting VCS from URL(%s): %s", u, err)
+		}
+
+		if c.work == true && ty != c.t {
+			t.Errorf("Incorrect VCS type returned(%s)", u)
+		}
+	}
+}

--- a/vendor/github.com/codegangsta/cli/.travis.yml
+++ b/vendor/github.com/codegangsta/cli/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+sudo: false
+
+go:
+- 1.0.3
+- 1.1.2
+- 1.2.2
+- 1.3.3
+- 1.4.2
+- 1.5.1
+- tip
+
+matrix:
+  allow_failures:
+    - go: tip
+
+script:
+- go vet ./...
+- go test -v ./...

--- a/vendor/github.com/codegangsta/cli/LICENSE
+++ b/vendor/github.com/codegangsta/cli/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2013 Jeremy Saenz
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/codegangsta/cli/README.md
+++ b/vendor/github.com/codegangsta/cli/README.md
@@ -1,0 +1,341 @@
+[![Coverage](http://gocover.io/_badge/github.com/codegangsta/cli?0)](http://gocover.io/github.com/codegangsta/cli)
+[![Build Status](https://travis-ci.org/codegangsta/cli.png?branch=master)](https://travis-ci.org/codegangsta/cli)
+[![GoDoc](https://godoc.org/github.com/codegangsta/cli?status.svg)](https://godoc.org/github.com/codegangsta/cli)
+
+# cli.go
+`cli.go` is simple, fast, and fun package for building command line apps in Go. The goal is to enable developers to write fast and distributable command line applications in an expressive way.
+
+## Overview
+Command line apps are usually so tiny that there is absolutely no reason why your code should *not* be self-documenting. Things like generating help text and parsing command flags/options should not hinder productivity when writing a command line app.
+
+**This is where `cli.go` comes into play.** `cli.go` makes command line programming fun, organized, and expressive!
+
+## Installation
+Make sure you have a working Go environment (go 1.1+ is *required*). [See the install instructions](http://golang.org/doc/install.html).
+
+To install `cli.go`, simply run:
+```
+$ go get github.com/codegangsta/cli
+```
+
+Make sure your `PATH` includes to the `$GOPATH/bin` directory so your commands can be easily used:
+```
+export PATH=$PATH:$GOPATH/bin
+```
+
+## Getting Started
+One of the philosophies behind `cli.go` is that an API should be playful and full of discovery. So a `cli.go` app can be as little as one line of code in `main()`. 
+
+``` go
+package main
+
+import (
+  "os"
+  "github.com/codegangsta/cli"
+)
+
+func main() {
+  cli.NewApp().Run(os.Args)
+}
+```
+
+This app will run and show help text, but is not very useful. Let's give an action to execute and some help documentation:
+
+``` go
+package main
+
+import (
+  "os"
+  "github.com/codegangsta/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "boom"
+  app.Usage = "make an explosive entrance"
+  app.Action = func(c *cli.Context) {
+    println("boom! I say!")
+  }
+  
+  app.Run(os.Args)
+}
+```
+
+Running this already gives you a ton of functionality, plus support for things like subcommands and flags, which are covered below.
+
+## Example
+
+Being a programmer can be a lonely job. Thankfully by the power of automation that is not the case! Let's create a greeter app to fend off our demons of loneliness!
+
+Start by creating a directory named `greet`, and within it, add a file, `greet.go` with the following code in it:
+
+``` go
+package main
+
+import (
+  "os"
+  "github.com/codegangsta/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "greet"
+  app.Usage = "fight the loneliness!"
+  app.Action = func(c *cli.Context) {
+    println("Hello friend!")
+  }
+
+  app.Run(os.Args)
+}
+```
+
+Install our command to the `$GOPATH/bin` directory:
+
+```
+$ go install
+```
+
+Finally run our new command:
+
+```
+$ greet
+Hello friend!
+```
+
+`cli.go` also generates neat help text:
+
+```
+$ greet help
+NAME:
+    greet - fight the loneliness!
+
+USAGE:
+    greet [global options] command [command options] [arguments...]
+
+VERSION:
+    0.0.0
+
+COMMANDS:
+    help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS
+    --version	Shows version information
+```
+
+### Arguments
+You can lookup arguments by calling the `Args` function on `cli.Context`.
+
+``` go
+...
+app.Action = func(c *cli.Context) {
+  println("Hello", c.Args()[0])
+}
+...
+```
+
+### Flags
+Setting and querying flags is simple.
+``` go
+...
+app.Flags = []cli.Flag {
+  cli.StringFlag{
+    Name: "lang",
+    Value: "english",
+    Usage: "language for the greeting",
+  },
+}
+app.Action = func(c *cli.Context) {
+  name := "someone"
+  if len(c.Args()) > 0 {
+    name = c.Args()[0]
+  }
+  if c.String("lang") == "spanish" {
+    println("Hola", name)
+  } else {
+    println("Hello", name)
+  }
+}
+...
+```
+
+You can also set a destination variable for a flag, to which the content will be scanned.
+``` go
+...
+var language string
+app.Flags = []cli.Flag {
+  cli.StringFlag{
+    Name:        "lang",
+    Value:       "english",
+    Usage:       "language for the greeting",
+    Destination: &language,
+  },
+}
+app.Action = func(c *cli.Context) {
+  name := "someone"
+  if len(c.Args()) > 0 {
+    name = c.Args()[0]
+  }
+  if language == "spanish" {
+    println("Hola", name)
+  } else {
+    println("Hello", name)
+  }
+}
+...
+```
+
+See full list of flags at http://godoc.org/github.com/codegangsta/cli
+
+#### Alternate Names
+
+You can set alternate (or short) names for flags by providing a comma-delimited list for the `Name`. e.g.
+
+``` go
+app.Flags = []cli.Flag {
+  cli.StringFlag{
+    Name: "lang, l",
+    Value: "english",
+    Usage: "language for the greeting",
+  },
+}
+```
+
+That flag can then be set with `--lang spanish` or `-l spanish`. Note that giving two different forms of the same flag in the same command invocation is an error.
+
+#### Values from the Environment
+
+You can also have the default value set from the environment via `EnvVar`.  e.g.
+
+``` go
+app.Flags = []cli.Flag {
+  cli.StringFlag{
+    Name: "lang, l",
+    Value: "english",
+    Usage: "language for the greeting",
+    EnvVar: "APP_LANG",
+  },
+}
+```
+
+The `EnvVar` may also be given as a comma-delimited "cascade", where the first environment variable that resolves is used as the default.
+
+``` go
+app.Flags = []cli.Flag {
+  cli.StringFlag{
+    Name: "lang, l",
+    Value: "english",
+    Usage: "language for the greeting",
+    EnvVar: "LEGACY_COMPAT_LANG,APP_LANG,LANG",
+  },
+}
+```
+
+### Subcommands
+
+Subcommands can be defined for a more git-like command line app.
+```go
+...
+app.Commands = []cli.Command{
+  {
+    Name:      "add",
+    Aliases:     []string{"a"},
+    Usage:     "add a task to the list",
+    Action: func(c *cli.Context) {
+      println("added task: ", c.Args().First())
+    },
+  },
+  {
+    Name:      "complete",
+    Aliases:     []string{"c"},
+    Usage:     "complete a task on the list",
+    Action: func(c *cli.Context) {
+      println("completed task: ", c.Args().First())
+    },
+  },
+  {
+    Name:      "template",
+    Aliases:     []string{"r"},
+    Usage:     "options for task templates",
+    Subcommands: []cli.Command{
+      {
+        Name:  "add",
+        Usage: "add a new template",
+        Action: func(c *cli.Context) {
+            println("new task template: ", c.Args().First())
+        },
+      },
+      {
+        Name:  "remove",
+        Usage: "remove an existing template",
+        Action: func(c *cli.Context) {
+          println("removed task template: ", c.Args().First())
+        },
+      },
+    },
+  },
+}
+...
+```
+
+### Bash Completion
+
+You can enable completion commands by setting the `EnableBashCompletion`
+flag on the `App` object.  By default, this setting will only auto-complete to
+show an app's subcommands, but you can write your own completion methods for
+the App or its subcommands.
+```go
+...
+var tasks = []string{"cook", "clean", "laundry", "eat", "sleep", "code"}
+app := cli.NewApp()
+app.EnableBashCompletion = true
+app.Commands = []cli.Command{
+  {
+    Name:  "complete",
+    Aliases: []string{"c"},
+    Usage: "complete a task on the list",
+    Action: func(c *cli.Context) {
+       println("completed task: ", c.Args().First())
+    },
+    BashComplete: func(c *cli.Context) {
+      // This will complete if no args are passed
+      if len(c.Args()) > 0 {
+        return
+      }
+      for _, t := range tasks {
+        fmt.Println(t)
+      }
+    },
+  }
+}
+...
+```
+
+#### To Enable
+
+Source the `autocomplete/bash_autocomplete` file in your `.bashrc` file while
+setting the `PROG` variable to the name of your program:
+
+`PROG=myprogram source /.../cli/autocomplete/bash_autocomplete`
+
+#### To Distribute
+
+Copy `autocomplete/bash_autocomplete` into `/etc/bash_completion.d/` and rename
+it to the name of the program you wish to add autocomplete support for (or
+automatically install it there if you are distributing a package). Don't forget
+to source the file to make it active in the current shell.
+
+```
+   sudo cp src/bash_autocomplete /etc/bash_completion.d/<myprogram>
+   source /etc/bash_completion.d/<myprogram>
+```
+
+Alternatively, you can just document that users should source the generic
+`autocomplete/bash_autocomplete` in their bash configuration with `$PROG` set
+to the name of their program (as above).
+
+## Contribution Guidelines
+Feel free to put up a pull request to fix a bug or maybe add a feature. I will give it a code review and make sure that it does not break backwards compatibility. If I or any other collaborators agree that it is in line with the vision of the project, we will work with you to get the code into a mergeable state and merge it into the master branch.
+
+If you have contributed something significant to the project, I will most likely add you as a collaborator. As a collaborator you are given the ability to merge others pull requests. It is very important that new code does not break existing code, so be careful about what code you do choose to merge. If you have any questions feel free to link @codegangsta to the issue in question and we can review it together.
+
+If you feel like you have contributed to the project but have not yet been added as a collaborator, I probably forgot to add you. Hit @codegangsta up over email and we will get it figured out.

--- a/vendor/github.com/codegangsta/cli/app.go
+++ b/vendor/github.com/codegangsta/cli/app.go
@@ -1,0 +1,333 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+// App is the main structure of a cli application. It is recomended that
+// an app be created with the cli.NewApp() function
+type App struct {
+	// The name of the program. Defaults to os.Args[0]
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// List of commands to execute
+	Commands []Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+	// Boolean to hide built-in version flag
+	HideVersion bool
+	// An action to execute when the bash-completion flag is set
+	BashComplete func(context *Context)
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before func(context *Context) error
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After func(context *Context) error
+	// The action to execute when no subcommands are specified
+	Action func(context *Context)
+	// Execute this function if the proper command cannot be found
+	CommandNotFound func(context *Context, command string)
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []Author
+	// Copyright of the binary if any
+	Copyright string
+	// Name of Author (Note: Use App.Authors, this is deprecated)
+	Author string
+	// Email of Author (Note: Use App.Authors, this is deprecated)
+	Email string
+	// Writer writer to write output to
+	Writer io.Writer
+}
+
+// Tries to find out when this binary was compiled.
+// Returns the current time if it fails to find it.
+func compileTime() time.Time {
+	info, err := os.Stat(os.Args[0])
+	if err != nil {
+		return time.Now()
+	}
+	return info.ModTime()
+}
+
+// Creates a new cli Application with some reasonable defaults for Name, Usage, Version and Action.
+func NewApp() *App {
+	return &App{
+		Name:         os.Args[0],
+		HelpName:     os.Args[0],
+		Usage:        "A new cli application",
+		Version:      "0.0.0",
+		BashComplete: DefaultAppComplete,
+		Action:       helpCommand.Action,
+		Compiled:     compileTime(),
+		Writer:       os.Stdout,
+	}
+}
+
+// Entry point to the cli app. Parses the arguments slice and routes to the proper flag/args combination
+func (a *App) Run(arguments []string) (err error) {
+	if a.Author != "" || a.Email != "" {
+		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
+	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	// append help to commands
+	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+		a.Commands = append(a.Commands, helpCommand)
+		if (HelpFlag != BoolFlag{}) {
+			a.appendFlag(HelpFlag)
+		}
+	}
+
+	//append version/help flags
+	if a.EnableBashCompletion {
+		a.appendFlag(BashCompletionFlag)
+	}
+
+	if !a.HideVersion {
+		a.appendFlag(VersionFlag)
+	}
+
+	// parse flags
+	set := flagSet(a.Name, a.Flags)
+	set.SetOutput(ioutil.Discard)
+	err = set.Parse(arguments[1:])
+	nerr := normalizeFlags(a.Flags, set)
+	if nerr != nil {
+		fmt.Fprintln(a.Writer, nerr)
+		context := NewContext(a, set, nil)
+		ShowAppHelp(context)
+		return nerr
+	}
+	context := NewContext(a, set, nil)
+
+	if err != nil {
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
+		fmt.Fprintln(a.Writer)
+		ShowAppHelp(context)
+		return err
+	}
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if !a.HideHelp && checkHelp(context) {
+		ShowAppHelp(context)
+		return nil
+	}
+
+	if !a.HideVersion && checkVersion(context) {
+		ShowVersion(context)
+		return nil
+	}
+
+	if a.After != nil {
+		defer func() {
+			afterErr := a.After(context)
+			if afterErr != nil {
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil {
+		err := a.Before(context)
+		if err != nil {
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	// Run default Action
+	a.Action(context)
+	return nil
+}
+
+// Another entry point to the cli app, takes care of passing arguments and error handling
+func (a *App) RunAndExitOnError() {
+	if err := a.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// Invokes the subcommand given the context, parses ctx.Args() to generate command-specific flags
+func (a *App) RunAsSubcommand(ctx *Context) (err error) {
+	// append help to commands
+	if len(a.Commands) > 0 {
+		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+			a.Commands = append(a.Commands, helpCommand)
+			if (HelpFlag != BoolFlag{}) {
+				a.appendFlag(HelpFlag)
+			}
+		}
+	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	// append flags
+	if a.EnableBashCompletion {
+		a.appendFlag(BashCompletionFlag)
+	}
+
+	// parse flags
+	set := flagSet(a.Name, a.Flags)
+	set.SetOutput(ioutil.Discard)
+	err = set.Parse(ctx.Args().Tail())
+	nerr := normalizeFlags(a.Flags, set)
+	context := NewContext(a, set, ctx)
+
+	if nerr != nil {
+		fmt.Fprintln(a.Writer, nerr)
+		fmt.Fprintln(a.Writer)
+		if len(a.Commands) > 0 {
+			ShowSubcommandHelp(context)
+		} else {
+			ShowCommandHelp(ctx, context.Args().First())
+		}
+		return nerr
+	}
+
+	if err != nil {
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
+		fmt.Fprintln(a.Writer)
+		ShowSubcommandHelp(context)
+		return err
+	}
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if len(a.Commands) > 0 {
+		if checkSubcommandHelp(context) {
+			return nil
+		}
+	} else {
+		if checkCommandHelp(ctx, context.Args().First()) {
+			return nil
+		}
+	}
+
+	if a.After != nil {
+		defer func() {
+			afterErr := a.After(context)
+			if afterErr != nil {
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil {
+		err := a.Before(context)
+		if err != nil {
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	// Run default Action
+	a.Action(context)
+
+	return nil
+}
+
+// Returns the named command on App. Returns nil if the command does not exist
+func (a *App) Command(name string) *Command {
+	for _, c := range a.Commands {
+		if c.HasName(name) {
+			return &c
+		}
+	}
+
+	return nil
+}
+
+func (a *App) hasFlag(flag Flag) bool {
+	for _, f := range a.Flags {
+		if flag == f {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *App) appendFlag(flag Flag) {
+	if !a.hasFlag(flag) {
+		a.Flags = append(a.Flags, flag)
+	}
+}
+
+// Author represents someone who has contributed to a cli project.
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+
+// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
+func (a Author) String() string {
+	e := ""
+	if a.Email != "" {
+		e = "<" + a.Email + "> "
+	}
+
+	return fmt.Sprintf("%v %v", a.Name, e)
+}

--- a/vendor/github.com/codegangsta/cli/app_test.go
+++ b/vendor/github.com/codegangsta/cli/app_test.go
@@ -1,0 +1,960 @@
+package cli
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func ExampleApp_Run() {
+	// set args for examples sake
+	os.Args = []string{"greet", "--name", "Jeremy"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.Flags = []Flag{
+		StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
+	}
+	app.Action = func(c *Context) {
+		fmt.Printf("Hello %v\n", c.String("name"))
+	}
+	app.Author = "Harrison"
+	app.Email = "harrison@lolwut.com"
+	app.Authors = []Author{Author{Name: "Oliver Allen", Email: "oliver@toyshop.com"}}
+	app.Run(os.Args)
+	// Output:
+	// Hello Jeremy
+}
+
+func ExampleApp_Run_subcommand() {
+	// set args for examples sake
+	os.Args = []string{"say", "hi", "english", "--name", "Jeremy"}
+	app := NewApp()
+	app.Name = "say"
+	app.Commands = []Command{
+		{
+			Name:        "hello",
+			Aliases:     []string{"hi"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe hello the function",
+			Subcommands: []Command{
+				{
+					Name:        "english",
+					Aliases:     []string{"en"},
+					Usage:       "sends a greeting in english",
+					Description: "greets someone in english",
+					Flags: []Flag{
+						StringFlag{
+							Name:  "name",
+							Value: "Bob",
+							Usage: "Name of the person to greet",
+						},
+					},
+					Action: func(c *Context) {
+						fmt.Println("Hello,", c.String("name"))
+					},
+				},
+			},
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// Hello, Jeremy
+}
+
+func ExampleApp_Run_help() {
+	// set args for examples sake
+	os.Args = []string{"greet", "h", "describeit"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.Flags = []Flag{
+		StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
+	}
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+			Action: func(c *Context) {
+				fmt.Printf("i like to describe things")
+			},
+		},
+	}
+	app.Run(os.Args)
+	// Output:
+	// NAME:
+	//    greet describeit - use it to see a description
+	//
+	// USAGE:
+	//    greet describeit [arguments...]
+	//
+	// DESCRIPTION:
+	//    This is how we describe describeit the function
+}
+
+func ExampleApp_Run_bashComplete() {
+	// set args for examples sake
+	os.Args = []string{"greet", "--generate-bash-completion"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.EnableBashCompletion = true
+	app.Commands = []Command{
+		{
+			Name:        "describeit",
+			Aliases:     []string{"d"},
+			Usage:       "use it to see a description",
+			Description: "This is how we describe describeit the function",
+			Action: func(c *Context) {
+				fmt.Printf("i like to describe things")
+			},
+		}, {
+			Name:        "next",
+			Usage:       "next example",
+			Description: "more stuff to see when generating bash completion",
+			Action: func(c *Context) {
+				fmt.Printf("the next example")
+			},
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// describeit
+	// d
+	// next
+	// help
+	// h
+}
+
+func TestApp_Run(t *testing.T) {
+	s := ""
+
+	app := NewApp()
+	app.Action = func(c *Context) {
+		s = s + c.Args().First()
+	}
+
+	err := app.Run([]string{"command", "foo"})
+	expect(t, err, nil)
+	err = app.Run([]string{"command", "bar"})
+	expect(t, err, nil)
+	expect(t, s, "foobar")
+}
+
+var commandAppTests = []struct {
+	name     string
+	expected bool
+}{
+	{"foobar", true},
+	{"batbaz", true},
+	{"b", true},
+	{"f", true},
+	{"bat", false},
+	{"nothing", false},
+}
+
+func TestApp_Command(t *testing.T) {
+	app := NewApp()
+	fooCommand := Command{Name: "foobar", Aliases: []string{"f"}}
+	batCommand := Command{Name: "batbaz", Aliases: []string{"b"}}
+	app.Commands = []Command{
+		fooCommand,
+		batCommand,
+	}
+
+	for _, test := range commandAppTests {
+		expect(t, app.Command(test.name) != nil, test.expected)
+	}
+}
+
+func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
+	var parsedOption, firstArg string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "option", Value: "", Usage: "some option"},
+		},
+		Action: func(c *Context) {
+			parsedOption = c.String("option")
+			firstArg = c.Args().First()
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--option", "my-option"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, firstArg, "my-arg")
+}
+
+func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
+	var context *Context
+
+	a := NewApp()
+	a.Commands = []Command{
+		{
+			Name: "foo",
+			Action: func(c *Context) {
+				context = c
+			},
+			Flags: []Flag{
+				StringFlag{
+					Name:  "lang",
+					Value: "english",
+					Usage: "language for the greeting",
+				},
+			},
+			Before: func(_ *Context) error { return nil },
+		},
+	}
+	a.Run([]string{"", "foo", "--lang", "spanish", "abcd"})
+
+	expect(t, context.Args().Get(0), "abcd")
+	expect(t, context.String("lang"), "spanish")
+}
+
+func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
+	var parsedOption string
+	var args []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "option", Value: "", Usage: "some option"},
+		},
+		Action: func(c *Context) {
+			parsedOption = c.String("option")
+			args = c.Args()
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--option", "my-option", "--", "--notARealFlag"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, args[0], "my-arg")
+	expect(t, args[1], "--")
+	expect(t, args[2], "--notARealFlag")
+}
+
+func TestApp_CommandWithNoFlagBeforeTerminator(t *testing.T) {
+	var args []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Action: func(c *Context) {
+			args = c.Args()
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--", "notAFlagAtAll"})
+
+	expect(t, args[0], "my-arg")
+	expect(t, args[1], "--")
+	expect(t, args[2], "notAFlagAtAll")
+}
+
+func TestApp_Float64Flag(t *testing.T) {
+	var meters float64
+
+	app := NewApp()
+	app.Flags = []Flag{
+		Float64Flag{Name: "height", Value: 1.5, Usage: "Set the height, in meters"},
+	}
+	app.Action = func(c *Context) {
+		meters = c.Float64("height")
+	}
+
+	app.Run([]string{"", "--height", "1.93"})
+	expect(t, meters, 1.93)
+}
+
+func TestApp_ParseSliceFlags(t *testing.T) {
+	var parsedOption, firstArg string
+	var parsedIntSlice []int
+	var parsedStringSlice []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			IntSliceFlag{Name: "p", Value: &IntSlice{}, Usage: "set one or more ip addr"},
+			StringSliceFlag{Name: "ip", Value: &StringSlice{}, Usage: "set one or more ports to open"},
+		},
+		Action: func(c *Context) {
+			parsedIntSlice = c.IntSlice("p")
+			parsedStringSlice = c.StringSlice("ip")
+			parsedOption = c.String("option")
+			firstArg = c.Args().First()
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-p", "22", "-p", "80", "-ip", "8.8.8.8", "-ip", "8.8.4.4"})
+
+	IntsEquals := func(a, b []int) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	StrsEquals := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	var expectedIntSlice = []int{22, 80}
+	var expectedStringSlice = []string{"8.8.8.8", "8.8.4.4"}
+
+	if !IntsEquals(parsedIntSlice, expectedIntSlice) {
+		t.Errorf("%v does not match %v", parsedIntSlice, expectedIntSlice)
+	}
+
+	if !StrsEquals(parsedStringSlice, expectedStringSlice) {
+		t.Errorf("%v does not match %v", parsedStringSlice, expectedStringSlice)
+	}
+}
+
+func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
+	var parsedIntSlice []int
+	var parsedStringSlice []string
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			IntSliceFlag{Name: "a", Usage: "set numbers"},
+			StringSliceFlag{Name: "str", Usage: "set strings"},
+		},
+		Action: func(c *Context) {
+			parsedIntSlice = c.IntSlice("a")
+			parsedStringSlice = c.StringSlice("str")
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-a", "2", "-str", "A"})
+
+	var expectedIntSlice = []int{2}
+	var expectedStringSlice = []string{"A"}
+
+	if parsedIntSlice[0] != expectedIntSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+
+	if parsedStringSlice[0] != expectedStringSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+}
+
+func TestApp_DefaultStdout(t *testing.T) {
+	app := NewApp()
+
+	if app.Writer != os.Stdout {
+		t.Error("Default output writer not set.")
+	}
+}
+
+type mockWriter struct {
+	written []byte
+}
+
+func (fw *mockWriter) Write(p []byte) (n int, err error) {
+	if fw.written == nil {
+		fw.written = p
+	} else {
+		fw.written = append(fw.written, p...)
+	}
+
+	return len(p), nil
+}
+
+func (fw *mockWriter) GetWritten() (b []byte) {
+	return fw.written
+}
+
+func TestApp_SetStdout(t *testing.T) {
+	w := &mockWriter{}
+
+	app := NewApp()
+	app.Name = "test"
+	app.Writer = w
+
+	err := app.Run([]string{"help"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if len(w.written) == 0 {
+		t.Error("App did not write output to desired writer.")
+	}
+}
+
+func TestApp_BeforeFunc(t *testing.T) {
+	beforeRun, subcommandRun := false, false
+	beforeError := fmt.Errorf("fail")
+	var err error
+
+	app := NewApp()
+
+	app.Before = func(c *Context) error {
+		beforeRun = true
+		s := c.String("opt")
+		if s == "fail" {
+			return beforeError
+		}
+
+		return nil
+	}
+
+	app.Commands = []Command{
+		Command{
+			Name: "sub",
+			Action: func(c *Context) {
+				subcommandRun = true
+			},
+		},
+	}
+
+	app.Flags = []Flag{
+		StringFlag{Name: "opt"},
+	}
+
+	// run with the Before() func succeeding
+	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if beforeRun == false {
+		t.Errorf("Before() not executed when expected")
+	}
+
+	if subcommandRun == false {
+		t.Errorf("Subcommand not executed when expected")
+	}
+
+	// reset
+	beforeRun, subcommandRun = false, false
+
+	// run with the Before() func failing
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Before func
+	if err != beforeError {
+		t.Errorf("Run error expected, but not received")
+	}
+
+	if beforeRun == false {
+		t.Errorf("Before() not executed when expected")
+	}
+
+	if subcommandRun == true {
+		t.Errorf("Subcommand executed when NOT expected")
+	}
+
+}
+
+func TestApp_AfterFunc(t *testing.T) {
+	afterRun, subcommandRun := false, false
+	afterError := fmt.Errorf("fail")
+	var err error
+
+	app := NewApp()
+
+	app.After = func(c *Context) error {
+		afterRun = true
+		s := c.String("opt")
+		if s == "fail" {
+			return afterError
+		}
+
+		return nil
+	}
+
+	app.Commands = []Command{
+		Command{
+			Name: "sub",
+			Action: func(c *Context) {
+				subcommandRun = true
+			},
+		},
+	}
+
+	app.Flags = []Flag{
+		StringFlag{Name: "opt"},
+	}
+
+	// run with the After() func succeeding
+	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if afterRun == false {
+		t.Errorf("After() not executed when expected")
+	}
+
+	if subcommandRun == false {
+		t.Errorf("Subcommand not executed when expected")
+	}
+
+	// reset
+	afterRun, subcommandRun = false, false
+
+	// run with the Before() func failing
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Before func
+	if err != afterError {
+		t.Errorf("Run error expected, but not received")
+	}
+
+	if afterRun == false {
+		t.Errorf("After() not executed when expected")
+	}
+
+	if subcommandRun == false {
+		t.Errorf("Subcommand not executed when expected")
+	}
+}
+
+func TestAppNoHelpFlag(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	HelpFlag = BoolFlag{}
+
+	app := NewApp()
+	err := app.Run([]string{"test", "-h"})
+
+	if err != flag.ErrHelp {
+		t.Errorf("expected error about missing help flag, but got: %s (%T)", err, err)
+	}
+}
+
+func TestAppHelpPrinter(t *testing.T) {
+	oldPrinter := HelpPrinter
+	defer func() {
+		HelpPrinter = oldPrinter
+	}()
+
+	var wasCalled = false
+	HelpPrinter = func(w io.Writer, template string, data interface{}) {
+		wasCalled = true
+	}
+
+	app := NewApp()
+	app.Run([]string{"-h"})
+
+	if wasCalled == false {
+		t.Errorf("Help printer expected to be called, but was not")
+	}
+}
+
+func TestAppVersionPrinter(t *testing.T) {
+	oldPrinter := VersionPrinter
+	defer func() {
+		VersionPrinter = oldPrinter
+	}()
+
+	var wasCalled = false
+	VersionPrinter = func(c *Context) {
+		wasCalled = true
+	}
+
+	app := NewApp()
+	ctx := NewContext(app, nil, nil)
+	ShowVersion(ctx)
+
+	if wasCalled == false {
+		t.Errorf("Version printer expected to be called, but was not")
+	}
+}
+
+func TestAppCommandNotFound(t *testing.T) {
+	beforeRun, subcommandRun := false, false
+	app := NewApp()
+
+	app.CommandNotFound = func(c *Context, command string) {
+		beforeRun = true
+	}
+
+	app.Commands = []Command{
+		Command{
+			Name: "bar",
+			Action: func(c *Context) {
+				subcommandRun = true
+			},
+		},
+	}
+
+	app.Run([]string{"command", "foo"})
+
+	expect(t, beforeRun, true)
+	expect(t, subcommandRun, false)
+}
+
+func TestGlobalFlag(t *testing.T) {
+	var globalFlag string
+	var globalFlagSet bool
+	app := NewApp()
+	app.Flags = []Flag{
+		StringFlag{Name: "global, g", Usage: "global"},
+	}
+	app.Action = func(c *Context) {
+		globalFlag = c.GlobalString("global")
+		globalFlagSet = c.GlobalIsSet("global")
+	}
+	app.Run([]string{"command", "-g", "foo"})
+	expect(t, globalFlag, "foo")
+	expect(t, globalFlagSet, true)
+
+}
+
+func TestGlobalFlagsInSubcommands(t *testing.T) {
+	subcommandRun := false
+	parentFlag := false
+	app := NewApp()
+
+	app.Flags = []Flag{
+		BoolFlag{Name: "debug, d", Usage: "Enable debugging"},
+	}
+
+	app.Commands = []Command{
+		Command{
+			Name: "foo",
+			Flags: []Flag{
+				BoolFlag{Name: "parent, p", Usage: "Parent flag"},
+			},
+			Subcommands: []Command{
+				{
+					Name: "bar",
+					Action: func(c *Context) {
+						if c.GlobalBool("debug") {
+							subcommandRun = true
+						}
+						if c.GlobalBool("parent") {
+							parentFlag = true
+						}
+					},
+				},
+			},
+		},
+	}
+
+	app.Run([]string{"command", "-d", "foo", "-p", "bar"})
+
+	expect(t, subcommandRun, true)
+	expect(t, parentFlag, true)
+}
+
+func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
+	var subcommandHelpTopics = [][]string{
+		{"command", "foo", "--help"},
+		{"command", "foo", "-h"},
+		{"command", "foo", "help"},
+	}
+
+	for _, flagSet := range subcommandHelpTopics {
+		t.Logf("==> checking with flags %v", flagSet)
+
+		app := NewApp()
+		buf := new(bytes.Buffer)
+		app.Writer = buf
+
+		subCmdBar := Command{
+			Name:  "bar",
+			Usage: "does bar things",
+		}
+		subCmdBaz := Command{
+			Name:  "baz",
+			Usage: "does baz things",
+		}
+		cmd := Command{
+			Name:        "foo",
+			Description: "descriptive wall of text about how it does foo things",
+			Subcommands: []Command{subCmdBar, subCmdBaz},
+		}
+
+		app.Commands = []Command{cmd}
+		err := app.Run(flagSet)
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if strings.Contains(output, "No help topic for") {
+			t.Errorf("expect a help topic, got none: \n%q", output)
+		}
+
+		for _, shouldContain := range []string{
+			cmd.Name, cmd.Description,
+			subCmdBar.Name, subCmdBar.Usage,
+			subCmdBaz.Name, subCmdBaz.Usage,
+		} {
+			if !strings.Contains(output, shouldContain) {
+				t.Errorf("want help to contain %q, did not: \n%q", shouldContain, output)
+			}
+		}
+	}
+}
+
+func TestApp_Run_SubcommandFullPath(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "command foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_SubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "custom - does bar things") {
+		t.Errorf("expected HelpName for subcommand: %s", output)
+	}
+	if !strings.Contains(output, "custom [arguments...]") {
+		t.Errorf("expected HelpName to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		HelpName:    "custom",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "command foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "base"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "base foo - foo commands") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "base foo command [command options] [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_Help(t *testing.T) {
+	var helpArguments = [][]string{{"boom", "--help"}, {"boom", "-h"}, {"boom", "help"}}
+
+	for _, args := range helpArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Writer = buf
+		app.Action = func(c *Context) {
+			buf.WriteString("boom I say!")
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "boom - make an explosive entrance") {
+			t.Errorf("want help to contain %q, did not: \n%q", "boom - make an explosive entrance", output)
+		}
+	}
+}
+
+func TestApp_Run_Version(t *testing.T) {
+	var versionArguments = [][]string{{"boom", "--version"}, {"boom", "-v"}}
+
+	for _, args := range versionArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Version = "0.1.0"
+		app.Writer = buf
+		app.Action = func(c *Context) {
+			buf.WriteString("boom I say!")
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "0.1.0") {
+			t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
+		}
+	}
+}
+
+func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
+	app := NewApp()
+	app.Action = func(c *Context) {}
+	app.Before = func(c *Context) error { return fmt.Errorf("before error") }
+	app.After = func(c *Context) error { return fmt.Errorf("after error") }
+
+	err := app.Run([]string{"foo"})
+	if err == nil {
+		t.Fatalf("expected to recieve error from Run, got none")
+	}
+
+	if !strings.Contains(err.Error(), "before error") {
+		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if !strings.Contains(err.Error(), "after error") {
+		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+}
+
+func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		Command{
+			Name:   "bar",
+			Before: func(c *Context) error { return fmt.Errorf("before error") },
+			After:  func(c *Context) error { return fmt.Errorf("after error") },
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	if err == nil {
+		t.Fatalf("expected to recieve error from Run, got none")
+	}
+
+	if !strings.Contains(err.Error(), "before error") {
+		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if !strings.Contains(err.Error(), "after error") {
+		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+}

--- a/vendor/github.com/codegangsta/cli/autocomplete/bash_autocomplete
+++ b/vendor/github.com/codegangsta/cli/autocomplete/bash_autocomplete
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+     local cur opts base
+     COMPREPLY=()
+     cur="${COMP_WORDS[COMP_CWORD]}"
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     return 0
+ }
+  
+ complete -F _cli_bash_autocomplete $PROG

--- a/vendor/github.com/codegangsta/cli/autocomplete/zsh_autocomplete
+++ b/vendor/github.com/codegangsta/cli/autocomplete/zsh_autocomplete
@@ -1,0 +1,5 @@
+autoload -U compinit && compinit
+autoload -U bashcompinit && bashcompinit
+
+script_dir=$(dirname $0)
+source ${script_dir}/bash_autocomplete

--- a/vendor/github.com/codegangsta/cli/cli.go
+++ b/vendor/github.com/codegangsta/cli/cli.go
@@ -1,0 +1,40 @@
+// Package cli provides a minimal framework for creating and organizing command line
+// Go applications. cli is designed to be easy to understand and write, the most simple
+// cli application can be written as follows:
+//   func main() {
+//     cli.NewApp().Run(os.Args)
+//   }
+//
+// Of course this application does not do much, so let's make this an actual application:
+//   func main() {
+//     app := cli.NewApp()
+//     app.Name = "greet"
+//     app.Usage = "say a greeting"
+//     app.Action = func(c *cli.Context) {
+//       println("Greetings")
+//     }
+//
+//     app.Run(os.Args)
+//   }
+package cli
+
+import (
+	"strings"
+)
+
+type MultiError struct {
+	Errors []error
+}
+
+func NewMultiError(err ...error) MultiError {
+	return MultiError{Errors: err}
+}
+
+func (m MultiError) Error() string {
+	errs := make([]string, len(m.Errors))
+	for i, err := range m.Errors {
+		errs[i] = err.Error()
+	}
+
+	return strings.Join(errs, "\n")
+}

--- a/vendor/github.com/codegangsta/cli/command.go
+++ b/vendor/github.com/codegangsta/cli/command.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Command is a subcommand for a cli.App.
+type Command struct {
+	// The name of the command
+	Name string
+	// short name of the command. Typically one character (deprecated, use `Aliases`)
+	ShortName string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// A longer explanation of how the command works
+	Description string
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The function to call when checking for bash command completions
+	BashComplete func(context *Context)
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before func(context *Context) error
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After func(context *Context) error
+	// The function to call when this command is invoked
+	Action func(context *Context)
+	// List of child commands
+	Subcommands []Command
+	// List of flags to parse
+	Flags []Flag
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName        string
+	commandNamePath []string
+}
+
+// Returns the full name of the command.
+// For subcommands this ensures that parent commands are part of the command path
+func (c Command) FullName() string {
+	if c.commandNamePath == nil {
+		return c.Name
+	}
+	return strings.Join(c.commandNamePath, " ")
+}
+
+// Invokes the command given the context, parses ctx.Args() to generate command-specific flags
+func (c Command) Run(ctx *Context) error {
+	if len(c.Subcommands) > 0 || c.Before != nil || c.After != nil {
+		return c.startApp(ctx)
+	}
+
+	if !c.HideHelp && (HelpFlag != BoolFlag{}) {
+		// append help to flags
+		c.Flags = append(
+			c.Flags,
+			HelpFlag,
+		)
+	}
+
+	if ctx.App.EnableBashCompletion {
+		c.Flags = append(c.Flags, BashCompletionFlag)
+	}
+
+	set := flagSet(c.Name, c.Flags)
+	set.SetOutput(ioutil.Discard)
+
+	var err error
+	if !c.SkipFlagParsing {
+		firstFlagIndex := -1
+		terminatorIndex := -1
+		for index, arg := range ctx.Args() {
+			if arg == "--" {
+				terminatorIndex = index
+				break
+			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
+				firstFlagIndex = index
+			}
+		}
+
+		if firstFlagIndex > -1 {
+			args := ctx.Args()
+			regularArgs := make([]string, len(args[1:firstFlagIndex]))
+			copy(regularArgs, args[1:firstFlagIndex])
+
+			var flagArgs []string
+			if terminatorIndex > -1 {
+				flagArgs = args[firstFlagIndex:terminatorIndex]
+				regularArgs = append(regularArgs, args[terminatorIndex:]...)
+			} else {
+				flagArgs = args[firstFlagIndex:]
+			}
+
+			err = set.Parse(append(flagArgs, regularArgs...))
+		} else {
+			err = set.Parse(ctx.Args().Tail())
+		}
+	} else {
+		if c.SkipFlagParsing {
+			err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
+		}
+	}
+
+	if err != nil {
+		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage.")
+		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
+		return err
+	}
+
+	nerr := normalizeFlags(c.Flags, set)
+	if nerr != nil {
+		fmt.Fprintln(ctx.App.Writer, nerr)
+		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
+		return nerr
+	}
+	context := NewContext(ctx.App, set, ctx)
+
+	if checkCommandCompletions(context, c.Name) {
+		return nil
+	}
+
+	if checkCommandHelp(context, c.Name) {
+		return nil
+	}
+	context.Command = c
+	c.Action(context)
+	return nil
+}
+
+func (c Command) Names() []string {
+	names := []string{c.Name}
+
+	if c.ShortName != "" {
+		names = append(names, c.ShortName)
+	}
+
+	return append(names, c.Aliases...)
+}
+
+// Returns true if Command.Name or Command.ShortName matches given name
+func (c Command) HasName(name string) bool {
+	for _, n := range c.Names() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Command) startApp(ctx *Context) error {
+	app := NewApp()
+
+	// set the name and usage
+	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	if c.HelpName == "" {
+		app.HelpName = c.HelpName
+	} else {
+		app.HelpName = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	}
+
+	if c.Description != "" {
+		app.Usage = c.Description
+	} else {
+		app.Usage = c.Usage
+	}
+
+	// set CommandNotFound
+	app.CommandNotFound = ctx.App.CommandNotFound
+
+	// set the flags and commands
+	app.Commands = c.Subcommands
+	app.Flags = c.Flags
+	app.HideHelp = c.HideHelp
+
+	app.Version = ctx.App.Version
+	app.HideVersion = ctx.App.HideVersion
+	app.Compiled = ctx.App.Compiled
+	app.Author = ctx.App.Author
+	app.Email = ctx.App.Email
+	app.Writer = ctx.App.Writer
+
+	// bash completion
+	app.EnableBashCompletion = ctx.App.EnableBashCompletion
+	if c.BashComplete != nil {
+		app.BashComplete = c.BashComplete
+	}
+
+	// set the actions
+	app.Before = c.Before
+	app.After = c.After
+	if c.Action != nil {
+		app.Action = c.Action
+	} else {
+		app.Action = helpSubcommand.Action
+	}
+
+	var newCmds []Command
+	for _, cc := range app.Commands {
+		cc.commandNamePath = []string{c.Name, cc.Name}
+		newCmds = append(newCmds, cc)
+	}
+	app.Commands = newCmds
+
+	return app.RunAsSubcommand(ctx)
+}

--- a/vendor/github.com/codegangsta/cli/command_test.go
+++ b/vendor/github.com/codegangsta/cli/command_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"testing"
+)
+
+func TestCommandFlagParsing(t *testing.T) {
+	cases := []struct {
+		testArgs        []string
+		skipFlagParsing bool
+		expectedErr     error
+	}{
+		{[]string{"blah", "blah", "-break"}, false, errors.New("flag provided but not defined: -break")}, // Test normal "not ignoring flags" flow
+		{[]string{"blah", "blah"}, true, nil},                                                            // Test SkipFlagParsing without any args that look like flags
+		{[]string{"blah", "-break"}, true, nil},                                                          // Test SkipFlagParsing with random flag arg
+		{[]string{"blah", "-help"}, true, nil},                                                           // Test SkipFlagParsing with "special" help flag arg
+	}
+
+	for _, c := range cases {
+		app := NewApp()
+		set := flag.NewFlagSet("test", 0)
+		set.Parse(c.testArgs)
+
+		context := NewContext(app, set, nil)
+
+		command := Command{
+			Name:        "test-cmd",
+			Aliases:     []string{"tc"},
+			Usage:       "this is for testing",
+			Description: "testing",
+			Action:      func(_ *Context) {},
+		}
+
+		command.SkipFlagParsing = c.skipFlagParsing
+
+		err := command.Run(context)
+
+		expect(t, err, c.expectedErr)
+		expect(t, []string(context.Args()), c.testArgs)
+	}
+}

--- a/vendor/github.com/codegangsta/cli/context.go
+++ b/vendor/github.com/codegangsta/cli/context.go
@@ -1,0 +1,388 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Context is a type that is passed through to
+// each Handler action in a cli application. Context
+// can be used to retrieve context-specific Args and
+// parsed command-line options.
+type Context struct {
+	App            *App
+	Command        Command
+	flagSet        *flag.FlagSet
+	setFlags       map[string]bool
+	globalSetFlags map[string]bool
+	parentContext  *Context
+}
+
+// Creates a new context. For use in when invoking an App or Command action.
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
+	return &Context{App: app, flagSet: set, parentContext: parentCtx}
+}
+
+// Looks up the value of a local int flag, returns 0 if no int flag exists
+func (c *Context) Int(name string) int {
+	return lookupInt(name, c.flagSet)
+}
+
+// Looks up the value of a local time.Duration flag, returns 0 if no time.Duration flag exists
+func (c *Context) Duration(name string) time.Duration {
+	return lookupDuration(name, c.flagSet)
+}
+
+// Looks up the value of a local float64 flag, returns 0 if no float64 flag exists
+func (c *Context) Float64(name string) float64 {
+	return lookupFloat64(name, c.flagSet)
+}
+
+// Looks up the value of a local bool flag, returns false if no bool flag exists
+func (c *Context) Bool(name string) bool {
+	return lookupBool(name, c.flagSet)
+}
+
+// Looks up the value of a local boolT flag, returns false if no bool flag exists
+func (c *Context) BoolT(name string) bool {
+	return lookupBoolT(name, c.flagSet)
+}
+
+// Looks up the value of a local string flag, returns "" if no string flag exists
+func (c *Context) String(name string) string {
+	return lookupString(name, c.flagSet)
+}
+
+// Looks up the value of a local string slice flag, returns nil if no string slice flag exists
+func (c *Context) StringSlice(name string) []string {
+	return lookupStringSlice(name, c.flagSet)
+}
+
+// Looks up the value of a local int slice flag, returns nil if no int slice flag exists
+func (c *Context) IntSlice(name string) []int {
+	return lookupIntSlice(name, c.flagSet)
+}
+
+// Looks up the value of a local generic flag, returns nil if no generic flag exists
+func (c *Context) Generic(name string) interface{} {
+	return lookupGeneric(name, c.flagSet)
+}
+
+// Looks up the value of a global int flag, returns 0 if no int flag exists
+func (c *Context) GlobalInt(name string) int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt(name, fs)
+	}
+	return 0
+}
+
+// Looks up the value of a global time.Duration flag, returns 0 if no time.Duration flag exists
+func (c *Context) GlobalDuration(name string) time.Duration {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupDuration(name, fs)
+	}
+	return 0
+}
+
+// Looks up the value of a global bool flag, returns false if no bool flag exists
+func (c *Context) GlobalBool(name string) bool {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupBool(name, fs)
+	}
+	return false
+}
+
+// Looks up the value of a global string flag, returns "" if no string flag exists
+func (c *Context) GlobalString(name string) string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupString(name, fs)
+	}
+	return ""
+}
+
+// Looks up the value of a global string slice flag, returns nil if no string slice flag exists
+func (c *Context) GlobalStringSlice(name string) []string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupStringSlice(name, fs)
+	}
+	return nil
+}
+
+// Looks up the value of a global int slice flag, returns nil if no int slice flag exists
+func (c *Context) GlobalIntSlice(name string) []int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupIntSlice(name, fs)
+	}
+	return nil
+}
+
+// Looks up the value of a global generic flag, returns nil if no generic flag exists
+func (c *Context) GlobalGeneric(name string) interface{} {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupGeneric(name, fs)
+	}
+	return nil
+}
+
+// Returns the number of flags set
+func (c *Context) NumFlags() int {
+	return c.flagSet.NFlag()
+}
+
+// Determines if the flag was actually set
+func (c *Context) IsSet(name string) bool {
+	if c.setFlags == nil {
+		c.setFlags = make(map[string]bool)
+		c.flagSet.Visit(func(f *flag.Flag) {
+			c.setFlags[f.Name] = true
+		})
+	}
+	return c.setFlags[name] == true
+}
+
+// Determines if the global flag was actually set
+func (c *Context) GlobalIsSet(name string) bool {
+	if c.globalSetFlags == nil {
+		c.globalSetFlags = make(map[string]bool)
+		ctx := c
+		if ctx.parentContext != nil {
+			ctx = ctx.parentContext
+		}
+		for ; ctx != nil && c.globalSetFlags[name] == false; ctx = ctx.parentContext {
+			ctx.flagSet.Visit(func(f *flag.Flag) {
+				c.globalSetFlags[f.Name] = true
+			})
+		}
+	}
+	return c.globalSetFlags[name]
+}
+
+// Returns a slice of flag names used in this context.
+func (c *Context) FlagNames() (names []string) {
+	for _, flag := range c.Command.Flags {
+		name := strings.Split(flag.getName(), ",")[0]
+		if name == "help" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// Returns a slice of global flag names used by the app.
+func (c *Context) GlobalFlagNames() (names []string) {
+	for _, flag := range c.App.Flags {
+		name := strings.Split(flag.getName(), ",")[0]
+		if name == "help" || name == "version" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// Returns the parent context, if any
+func (c *Context) Parent() *Context {
+	return c.parentContext
+}
+
+type Args []string
+
+// Returns the command line arguments associated with the context.
+func (c *Context) Args() Args {
+	args := Args(c.flagSet.Args())
+	return args
+}
+
+// Returns the nth argument, or else a blank string
+func (a Args) Get(n int) string {
+	if len(a) > n {
+		return a[n]
+	}
+	return ""
+}
+
+// Returns the first argument, or else a blank string
+func (a Args) First() string {
+	return a.Get(0)
+}
+
+// Return the rest of the arguments (not the first one)
+// or else an empty string slice
+func (a Args) Tail() []string {
+	if len(a) >= 2 {
+		return []string(a)[1:]
+	}
+	return []string{}
+}
+
+// Checks if there are any arguments present
+func (a Args) Present() bool {
+	return len(a) != 0
+}
+
+// Swaps arguments at the given indexes
+func (a Args) Swap(from, to int) error {
+	if from >= len(a) || to >= len(a) {
+		return errors.New("index out of range")
+	}
+	a[from], a[to] = a[to], a[from]
+	return nil
+}
+
+func lookupGlobalFlagSet(name string, ctx *Context) *flag.FlagSet {
+	if ctx.parentContext != nil {
+		ctx = ctx.parentContext
+	}
+	for ; ctx != nil; ctx = ctx.parentContext {
+		if f := ctx.flagSet.Lookup(name); f != nil {
+			return ctx.flagSet
+		}
+	}
+	return nil
+}
+
+func lookupInt(name string, set *flag.FlagSet) int {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := strconv.Atoi(f.Value.String())
+		if err != nil {
+			return 0
+		}
+		return val
+	}
+
+	return 0
+}
+
+func lookupDuration(name string, set *flag.FlagSet) time.Duration {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := time.ParseDuration(f.Value.String())
+		if err == nil {
+			return val
+		}
+	}
+
+	return 0
+}
+
+func lookupFloat64(name string, set *flag.FlagSet) float64 {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseFloat(f.Value.String(), 64)
+		if err != nil {
+			return 0
+		}
+		return val
+	}
+
+	return 0
+}
+
+func lookupString(name string, set *flag.FlagSet) string {
+	f := set.Lookup(name)
+	if f != nil {
+		return f.Value.String()
+	}
+
+	return ""
+}
+
+func lookupStringSlice(name string, set *flag.FlagSet) []string {
+	f := set.Lookup(name)
+	if f != nil {
+		return (f.Value.(*StringSlice)).Value()
+
+	}
+
+	return nil
+}
+
+func lookupIntSlice(name string, set *flag.FlagSet) []int {
+	f := set.Lookup(name)
+	if f != nil {
+		return (f.Value.(*IntSlice)).Value()
+
+	}
+
+	return nil
+}
+
+func lookupGeneric(name string, set *flag.FlagSet) interface{} {
+	f := set.Lookup(name)
+	if f != nil {
+		return f.Value
+	}
+	return nil
+}
+
+func lookupBool(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return val
+	}
+
+	return false
+}
+
+func lookupBoolT(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return true
+		}
+		return val
+	}
+
+	return false
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case *StringSlice:
+	default:
+		set.Set(name, ff.Value.String())
+	}
+}
+
+func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := strings.Split(f.getName(), ",")
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/codegangsta/cli/context_test.go
+++ b/vendor/github.com/codegangsta/cli/context_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"flag"
+	"testing"
+	"time"
+)
+
+func TestNewContext(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Int("myflag", 42, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	command := Command{Name: "mycommand"}
+	c := NewContext(nil, set, globalCtx)
+	c.Command = command
+	expect(t, c.Int("myflag"), 12)
+	expect(t, c.GlobalInt("myflag"), 42)
+	expect(t, c.Command.Name, "mycommand")
+}
+
+func TestContext_Int(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Int("myflag"), 12)
+}
+
+func TestContext_Duration(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Duration("myflag", time.Duration(12*time.Second), "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Duration("myflag"), time.Duration(12*time.Second))
+}
+
+func TestContext_String(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.String("myflag", "hello world", "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.String("myflag"), "hello world")
+}
+
+func TestContext_Bool(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.Bool("myflag"), false)
+}
+
+func TestContext_BoolT(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", true, "doc")
+	c := NewContext(nil, set, nil)
+	expect(t, c.BoolT("myflag"), true)
+}
+
+func TestContext_Args(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	expect(t, len(c.Args()), 2)
+	expect(t, c.Bool("myflag"), true)
+}
+
+func TestContext_IsSet(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	globalSet.Parse([]string{"--myflagGlobal", "bat", "baz"})
+	expect(t, c.IsSet("myflag"), true)
+	expect(t, c.IsSet("otherflag"), false)
+	expect(t, c.IsSet("bogusflag"), false)
+	expect(t, c.IsSet("myflagGlobal"), false)
+}
+
+func TestContext_GlobalIsSet(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalSet.Bool("myflagGlobalUnset", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	globalSet.Parse([]string{"--myflagGlobal", "bat", "baz"})
+	expect(t, c.GlobalIsSet("myflag"), false)
+	expect(t, c.GlobalIsSet("otherflag"), false)
+	expect(t, c.GlobalIsSet("bogusflag"), false)
+	expect(t, c.GlobalIsSet("myflagGlobal"), true)
+	expect(t, c.GlobalIsSet("myflagGlobalUnset"), false)
+	expect(t, c.GlobalIsSet("bogusGlobal"), false)
+}
+
+func TestContext_NumFlags(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	globalCtx := NewContext(nil, globalSet, nil)
+	c := NewContext(nil, set, globalCtx)
+	set.Parse([]string{"--myflag", "--otherflag=foo"})
+	globalSet.Parse([]string{"--myflagGlobal"})
+	expect(t, c.NumFlags(), 2)
+}

--- a/vendor/github.com/codegangsta/cli/flag.go
+++ b/vendor/github.com/codegangsta/cli/flag.go
@@ -1,0 +1,527 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This flag enables bash-completion for all commands and subcommands
+var BashCompletionFlag = BoolFlag{
+	Name: "generate-bash-completion",
+}
+
+// This flag prints the version for the application
+var VersionFlag = BoolFlag{
+	Name:  "version, v",
+	Usage: "print the version",
+}
+
+// This flag prints the help for all commands and subcommands
+// Set to the zero value (BoolFlag{}) to disable flag -- keeps subcommand
+// unless HideHelp is set to true)
+var HelpFlag = BoolFlag{
+	Name:  "help, h",
+	Usage: "show help",
+}
+
+// Flag is a common interface related to parsing flags in cli.
+// For more advanced flag parsing techniques, it is recomended that
+// this interface be implemented.
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet)
+	getName() string
+}
+
+func flagSet(name string, flags []Flag) *flag.FlagSet {
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	for _, f := range flags {
+		f.Apply(set)
+	}
+	return set
+}
+
+func eachName(longName string, fn func(string)) {
+	parts := strings.Split(longName, ",")
+	for _, name := range parts {
+		name = strings.Trim(name, " ")
+		fn(name)
+	}
+}
+
+// Generic is a generic parseable type identified by a specific flag
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+
+// GenericFlag is the flag type for types implementing Generic
+type GenericFlag struct {
+	Name   string
+	Value  Generic
+	Usage  string
+	EnvVar string
+}
+
+// String returns the string representation of the generic flag to display the
+// help text to the user (uses the String() method of the generic flag to show
+// the value)
+func (f GenericFlag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s%s \"%v\"\t%v", prefixFor(f.Name), f.Name, f.Value, f.Usage))
+}
+
+// Apply takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+func (f GenericFlag) Apply(set *flag.FlagSet) {
+	val := f.Value
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				val.Set(envVal)
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		set.Var(f.Value, name, f.Usage)
+	})
+}
+
+func (f GenericFlag) getName() string {
+	return f.Name
+}
+
+// StringSlice is an opaque type for []string to satisfy flag.Value
+type StringSlice []string
+
+// Set appends the string value to the list of values
+func (f *StringSlice) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *StringSlice) String() string {
+	return fmt.Sprintf("%s", *f)
+}
+
+// Value returns the slice of strings set by this flag
+func (f *StringSlice) Value() []string {
+	return *f
+}
+
+// StringSlice is a string flag that can be specified multiple times on the
+// command-line
+type StringSliceFlag struct {
+	Name   string
+	Value  *StringSlice
+	Usage  string
+	EnvVar string
+}
+
+// String returns the usage
+func (f StringSliceFlag) String() string {
+	firstName := strings.Trim(strings.Split(f.Name, ",")[0], " ")
+	pref := prefixFor(firstName)
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f StringSliceFlag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				newVal := &StringSlice{}
+				for _, s := range strings.Split(envVal, ",") {
+					s = strings.TrimSpace(s)
+					newVal.Set(s)
+				}
+				f.Value = newVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &StringSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+}
+
+func (f StringSliceFlag) getName() string {
+	return f.Name
+}
+
+// StringSlice is an opaque type for []int to satisfy flag.Value
+type IntSlice []int
+
+// Set parses the value into an integer and appends it to the list of values
+func (f *IntSlice) Set(value string) error {
+	tmp, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	} else {
+		*f = append(*f, tmp)
+	}
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *IntSlice) String() string {
+	return fmt.Sprintf("%d", *f)
+}
+
+// Value returns the slice of ints set by this flag
+func (f *IntSlice) Value() []int {
+	return *f
+}
+
+// IntSliceFlag is an int flag that can be specified multiple times on the
+// command-line
+type IntSliceFlag struct {
+	Name   string
+	Value  *IntSlice
+	Usage  string
+	EnvVar string
+}
+
+// String returns the usage
+func (f IntSliceFlag) String() string {
+	firstName := strings.Trim(strings.Split(f.Name, ",")[0], " ")
+	pref := prefixFor(firstName)
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f IntSliceFlag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				newVal := &IntSlice{}
+				for _, s := range strings.Split(envVal, ",") {
+					s = strings.TrimSpace(s)
+					err := newVal.Set(s)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, err.Error())
+					}
+				}
+				f.Value = newVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &IntSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+}
+
+func (f IntSliceFlag) getName() string {
+	return f.Name
+}
+
+// BoolFlag is a switch that defaults to false
+type BoolFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Destination *bool
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f BoolFlag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s\t%v", prefixedNames(f.Name), f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f BoolFlag) Apply(set *flag.FlagSet) {
+	val := false
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				envValBool, err := strconv.ParseBool(envVal)
+				if err == nil {
+					val = envValBool
+				}
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+}
+
+func (f BoolFlag) getName() string {
+	return f.Name
+}
+
+// BoolTFlag this represents a boolean flag that is true by default, but can
+// still be set to false by --some-flag=false
+type BoolTFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	Destination *bool
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f BoolTFlag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s\t%v", prefixedNames(f.Name), f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f BoolTFlag) Apply(set *flag.FlagSet) {
+	val := true
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				envValBool, err := strconv.ParseBool(envVal)
+				if err == nil {
+					val = envValBool
+					break
+				}
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+}
+
+func (f BoolTFlag) getName() string {
+	return f.Name
+}
+
+// StringFlag represents a flag that takes as string value
+type StringFlag struct {
+	Name        string
+	Value       string
+	Usage       string
+	EnvVar      string
+	Destination *string
+}
+
+// String returns the usage
+func (f StringFlag) String() string {
+	var fmtString string
+	fmtString = "%s %v\t%v"
+
+	if len(f.Value) > 0 {
+		fmtString = "%s \"%v\"\t%v"
+	} else {
+		fmtString = "%s %v\t%v"
+	}
+
+	return withEnvHint(f.EnvVar, fmt.Sprintf(fmtString, prefixedNames(f.Name), f.Value, f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f StringFlag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				f.Value = envVal
+				break
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.StringVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.String(name, f.Value, f.Usage)
+	})
+}
+
+func (f StringFlag) getName() string {
+	return f.Name
+}
+
+// IntFlag is a flag that takes an integer
+// Errors if the value provided cannot be parsed
+type IntFlag struct {
+	Name        string
+	Value       int
+	Usage       string
+	EnvVar      string
+	Destination *int
+}
+
+// String returns the usage
+func (f IntFlag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f IntFlag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				envValInt, err := strconv.ParseInt(envVal, 0, 64)
+				if err == nil {
+					f.Value = int(envValInt)
+					break
+				}
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.IntVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Int(name, f.Value, f.Usage)
+	})
+}
+
+func (f IntFlag) getName() string {
+	return f.Name
+}
+
+// DurationFlag is a flag that takes a duration specified in Go's duration
+// format: https://golang.org/pkg/time/#ParseDuration
+type DurationFlag struct {
+	Name        string
+	Value       time.Duration
+	Usage       string
+	EnvVar      string
+	Destination *time.Duration
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f DurationFlag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f DurationFlag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				envValDuration, err := time.ParseDuration(envVal)
+				if err == nil {
+					f.Value = envValDuration
+					break
+				}
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.DurationVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Duration(name, f.Value, f.Usage)
+	})
+}
+
+func (f DurationFlag) getName() string {
+	return f.Name
+}
+
+// Float64Flag is a flag that takes an float value
+// Errors if the value provided cannot be parsed
+type Float64Flag struct {
+	Name        string
+	Value       float64
+	Usage       string
+	EnvVar      string
+	Destination *float64
+}
+
+// String returns the usage
+func (f Float64Flag) String() string {
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+}
+
+// Apply populates the flag given the flag set and environment
+func (f Float64Flag) Apply(set *flag.FlagSet) {
+	if f.EnvVar != "" {
+		for _, envVar := range strings.Split(f.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				envValFloat, err := strconv.ParseFloat(envVal, 10)
+				if err == nil {
+					f.Value = float64(envValFloat)
+				}
+			}
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Float64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Float64(name, f.Value, f.Usage)
+	})
+}
+
+func (f Float64Flag) getName() string {
+	return f.Name
+}
+
+func prefixFor(name string) (prefix string) {
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
+
+	return
+}
+
+func prefixedNames(fullName string) (prefixed string) {
+	parts := strings.Split(fullName, ",")
+	for i, name := range parts {
+		name = strings.Trim(name, " ")
+		prefixed += prefixFor(name) + name
+		if i < len(parts)-1 {
+			prefixed += ", "
+		}
+	}
+	return
+}
+
+func withEnvHint(envVar, str string) string {
+	envText := ""
+	if envVar != "" {
+		envText = fmt.Sprintf(" [$%s]", strings.Join(strings.Split(envVar, ","), ", $"))
+	}
+	return str + envText
+}

--- a/vendor/github.com/codegangsta/cli/flag_test.go
+++ b/vendor/github.com/codegangsta/cli/flag_test.go
@@ -1,0 +1,830 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var boolFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help\t"},
+	{"h", "-h\t"},
+}
+
+func TestBoolFlagHelpOutput(t *testing.T) {
+
+	for _, test := range boolFlagTests {
+		flag := BoolFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+var stringFlagTests = []struct {
+	name     string
+	value    string
+	expected string
+}{
+	{"help", "", "--help \t"},
+	{"h", "", "-h \t"},
+	{"h", "", "-h \t"},
+	{"test", "Something", "--test \"Something\"\t"},
+}
+
+func TestStringFlagHelpOutput(t *testing.T) {
+
+	for _, test := range stringFlagTests {
+		flag := StringFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestStringFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_FOO", "derp")
+	for _, test := range stringFlagTests {
+		flag := StringFlag{Name: test.name, Value: test.value, EnvVar: "APP_FOO"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_FOO]") {
+			t.Errorf("%s does not end with [$APP_FOO]", output)
+		}
+	}
+}
+
+var stringSliceFlagTests = []struct {
+	name     string
+	value    *StringSlice
+	expected string
+}{
+	{"help", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("")
+		return s
+	}(), "--help [--help option --help option]\t"},
+	{"h", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("")
+		return s
+	}(), "-h [-h option -h option]\t"},
+	{"h", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("")
+		return s
+	}(), "-h [-h option -h option]\t"},
+	{"test", func() *StringSlice {
+		s := &StringSlice{}
+		s.Set("Something")
+		return s
+	}(), "--test [--test option --test option]\t"},
+}
+
+func TestStringSliceFlagHelpOutput(t *testing.T) {
+
+	for _, test := range stringSliceFlagTests {
+		flag := StringSliceFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestStringSliceFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_QWWX", "11,4")
+	for _, test := range stringSliceFlagTests {
+		flag := StringSliceFlag{Name: test.name, Value: test.value, EnvVar: "APP_QWWX"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_QWWX]") {
+			t.Errorf("%q does not end with [$APP_QWWX]", output)
+		}
+	}
+}
+
+var intFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
+}
+
+func TestIntFlagHelpOutput(t *testing.T) {
+
+	for _, test := range intFlagTests {
+		flag := IntFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestIntFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2")
+	for _, test := range intFlagTests {
+		flag := IntFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_BAR]") {
+			t.Errorf("%s does not end with [$APP_BAR]", output)
+		}
+	}
+}
+
+var durationFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
+}
+
+func TestDurationFlagHelpOutput(t *testing.T) {
+
+	for _, test := range durationFlagTests {
+		flag := DurationFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestDurationFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAR", "2h3m6s")
+	for _, test := range durationFlagTests {
+		flag := DurationFlag{Name: test.name, EnvVar: "APP_BAR"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_BAR]") {
+			t.Errorf("%s does not end with [$APP_BAR]", output)
+		}
+	}
+}
+
+var intSliceFlagTests = []struct {
+	name     string
+	value    *IntSlice
+	expected string
+}{
+	{"help", &IntSlice{}, "--help [--help option --help option]\t"},
+	{"h", &IntSlice{}, "-h [-h option -h option]\t"},
+	{"h", &IntSlice{}, "-h [-h option -h option]\t"},
+	{"test", func() *IntSlice {
+		i := &IntSlice{}
+		i.Set("9")
+		return i
+	}(), "--test [--test option --test option]\t"},
+}
+
+func TestIntSliceFlagHelpOutput(t *testing.T) {
+
+	for _, test := range intSliceFlagTests {
+		flag := IntSliceFlag{Name: test.name, Value: test.value}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestIntSliceFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_SMURF", "42,3")
+	for _, test := range intSliceFlagTests {
+		flag := IntSliceFlag{Name: test.name, Value: test.value, EnvVar: "APP_SMURF"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_SMURF]") {
+			t.Errorf("%q does not end with [$APP_SMURF]", output)
+		}
+	}
+}
+
+var float64FlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
+}
+
+func TestFloat64FlagHelpOutput(t *testing.T) {
+
+	for _, test := range float64FlagTests {
+		flag := Float64Flag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+func TestFloat64FlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_BAZ", "99.4")
+	for _, test := range float64FlagTests {
+		flag := Float64Flag{Name: test.name, EnvVar: "APP_BAZ"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_BAZ]") {
+			t.Errorf("%s does not end with [$APP_BAZ]", output)
+		}
+	}
+}
+
+var genericFlagTests = []struct {
+	name     string
+	value    Generic
+	expected string
+}{
+	{"test", &Parser{"abc", "def"}, "--test \"abc,def\"\ttest flag"},
+	{"t", &Parser{"abc", "def"}, "-t \"abc,def\"\ttest flag"},
+}
+
+func TestGenericFlagHelpOutput(t *testing.T) {
+
+	for _, test := range genericFlagTests {
+		flag := GenericFlag{Name: test.name, Value: test.value, Usage: "test flag"}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%q does not match %q", output, test.expected)
+		}
+	}
+}
+
+func TestGenericFlagWithEnvVarHelpOutput(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_ZAP", "3")
+	for _, test := range genericFlagTests {
+		flag := GenericFlag{Name: test.name, EnvVar: "APP_ZAP"}
+		output := flag.String()
+
+		if !strings.HasSuffix(output, " [$APP_ZAP]") {
+			t.Errorf("%s does not end with [$APP_ZAP]", output)
+		}
+	}
+}
+
+func TestParseMultiString(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.String("serve") != "10" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("s") != "10" {
+				t.Errorf("short name not set")
+			}
+		},
+	}).Run([]string{"run", "-s", "10"})
+}
+
+func TestParseDestinationString(t *testing.T) {
+	var dest string
+	a := App{
+		Flags: []Flag{
+			StringFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) {
+			if dest != "10" {
+				t.Errorf("expected destination String 10")
+			}
+		},
+	}
+	a.Run([]string{"run", "--dest", "10"})
+}
+
+func TestParseMultiStringFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_COUNT", "20")
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "count, c", EnvVar: "APP_COUNT"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.String("count") != "20" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("c") != "20" {
+				t.Errorf("short name not set")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_COUNT", "20")
+	(&App{
+		Flags: []Flag{
+			StringFlag{Name: "count, c", EnvVar: "COMPAT_COUNT,APP_COUNT"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.String("count") != "20" {
+				t.Errorf("main name not set")
+			}
+			if ctx.String("c") != "20" {
+				t.Errorf("short name not set")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "serve, s", Value: &StringSlice{}},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("s"), []string{"10", "20"}) {
+				t.Errorf("short name not set")
+			}
+		},
+	}).Run([]string{"run", "-s", "10", "-s", "20"})
+}
+
+func TestParseMultiStringSliceFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringSliceFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiInt(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Int("serve") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("s") != 10 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run", "-s", "10"})
+}
+
+func TestParseDestinationInt(t *testing.T) {
+	var dest int
+	a := App{
+		Flags: []Flag{
+			IntFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) {
+			if dest != 10 {
+				t.Errorf("expected destination Int 10")
+			}
+		},
+	}
+	a.Run([]string{"run", "--dest", "10"})
+}
+
+func TestParseMultiIntFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "10")
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Int("timeout") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("t") != 10 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiIntFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "10")
+	a := App{
+		Flags: []Flag{
+			IntFlag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Int("timeout") != 10 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Int("t") != 10 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiIntSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "serve, s", Value: &IntSlice{}},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("s"), []int{10, 20}) {
+				t.Errorf("short name not set")
+			}
+		},
+	}).Run([]string{"run", "-s", "10", "-s", "20"})
+}
+
+func TestParseMultiIntSliceFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiIntSliceFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_INTERVALS", "20,30,40")
+
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiFloat64(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Float64("serve") != 10.2 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("s") != 10.2 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run", "-s", "10.2"})
+}
+
+func TestParseDestinationFloat64(t *testing.T) {
+	var dest float64
+	a := App{
+		Flags: []Flag{
+			Float64Flag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) {
+			if dest != 10.2 {
+				t.Errorf("expected destination Float64 10.2")
+			}
+		},
+	}
+	a.Run([]string{"run", "--dest", "10.2"})
+}
+
+func TestParseMultiFloat64FromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Float64("timeout") != 15.5 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("t") != 15.5 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiFloat64FromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_TIMEOUT_SECONDS", "15.5")
+	a := App{
+		Flags: []Flag{
+			Float64Flag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Float64("timeout") != 15.5 {
+				t.Errorf("main name not set")
+			}
+			if ctx.Float64("t") != 15.5 {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBool(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("serve") != true {
+				t.Errorf("main name not set")
+			}
+			if ctx.Bool("s") != true {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run", "--serve"})
+}
+
+func TestParseDestinationBool(t *testing.T) {
+	var dest bool
+	a := App{
+		Flags: []Flag{
+			BoolFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) {
+			if dest != true {
+				t.Errorf("expected destination Bool true")
+			}
+		},
+	}
+	a.Run([]string{"run", "--dest"})
+}
+
+func TestParseMultiBoolFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "1")
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("debug") != true {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.Bool("d") != true {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBoolFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "1")
+	a := App{
+		Flags: []Flag{
+			BoolFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("debug") != true {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.Bool("d") != true {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBoolT(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "serve, s"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.BoolT("serve") != true {
+				t.Errorf("main name not set")
+			}
+			if ctx.BoolT("s") != true {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run", "--serve"})
+}
+
+func TestParseDestinationBoolT(t *testing.T) {
+	var dest bool
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{
+				Name:        "dest",
+				Destination: &dest,
+			},
+		},
+		Action: func(ctx *Context) {
+			if dest != true {
+				t.Errorf("expected destination BoolT true")
+			}
+		},
+	}
+	a.Run([]string{"run", "--dest"})
+}
+
+func TestParseMultiBoolTFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "0")
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.BoolT("debug") != false {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.BoolT("d") != false {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseMultiBoolTFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_DEBUG", "0")
+	a := App{
+		Flags: []Flag{
+			BoolTFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.BoolT("debug") != false {
+				t.Errorf("main name not set from env")
+			}
+			if ctx.BoolT("d") != false {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+type Parser [2]string
+
+func (p *Parser) Set(value string) error {
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid format")
+	}
+
+	(*p)[0] = parts[0]
+	(*p)[1] = parts[1]
+
+	return nil
+}
+
+func (p *Parser) String() string {
+	return fmt.Sprintf("%s,%s", p[0], p[1])
+}
+
+func TestParseGeneric(t *testing.T) {
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "serve, s", Value: &Parser{}},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"10", "20"}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"10", "20"}) {
+				t.Errorf("short name not set")
+			}
+		},
+	}
+	a.Run([]string{"run", "-s", "10,20"})
+}
+
+func TestParseGenericFromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_SERVE", "20,30")
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "serve, s", Value: &Parser{}, EnvVar: "APP_SERVE"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"20", "30"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"20", "30"}) {
+				t.Errorf("short name not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}
+
+func TestParseGenericFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("APP_FOO", "99,2000")
+	a := App{
+		Flags: []Flag{
+			GenericFlag{Name: "foos", Value: &Parser{}, EnvVar: "COMPAT_FOO,APP_FOO"},
+		},
+		Action: func(ctx *Context) {
+			if !reflect.DeepEqual(ctx.Generic("foos"), &Parser{"99", "2000"}) {
+				t.Errorf("value not set from env")
+			}
+		},
+	}
+	a.Run([]string{"run"})
+}

--- a/vendor/github.com/codegangsta/cli/help.go
+++ b/vendor/github.com/codegangsta/cli/help.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+)
+
+// The text template for the Default help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var AppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{if .Version}}
+VERSION:
+   {{.Version}}
+   {{end}}{{if len .Authors}}
+AUTHOR(S):
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+COMMANDS:
+   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{end}}{{end}}{{if .Flags}}
+GLOBAL OPTIONS:
+   {{range .Flags}}{{.}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}
+   {{end}}
+`
+
+// The text template for the command help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}}{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if .Flags}}
+
+OPTIONS:
+   {{range .Flags}}{{.}}
+   {{end}}{{ end }}
+`
+
+// The text template for the subcommand help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var SubcommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} command{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+
+COMMANDS:
+   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{end}}{{if .Flags}}
+OPTIONS:
+   {{range .Flags}}{{.}}
+   {{end}}{{end}}
+`
+
+var helpCommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) {
+		args := c.Args()
+		if args.Present() {
+			ShowCommandHelp(c, args.First())
+		} else {
+			ShowAppHelp(c)
+		}
+	},
+}
+
+var helpSubcommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) {
+		args := c.Args()
+		if args.Present() {
+			ShowCommandHelp(c, args.First())
+		} else {
+			ShowSubcommandHelp(c)
+		}
+	},
+}
+
+// Prints help for the App or Command
+type helpPrinter func(w io.Writer, templ string, data interface{})
+
+var HelpPrinter helpPrinter = printHelp
+
+// Prints version for the App
+var VersionPrinter = printVersion
+
+func ShowAppHelp(c *Context) {
+	HelpPrinter(c.App.Writer, AppHelpTemplate, c.App)
+}
+
+// Prints the list of subcommands as the default app completion method
+func DefaultAppComplete(c *Context) {
+	for _, command := range c.App.Commands {
+		for _, name := range command.Names() {
+			fmt.Fprintln(c.App.Writer, name)
+		}
+	}
+}
+
+// Prints help for the given command
+func ShowCommandHelp(ctx *Context, command string) {
+	// show the subcommand help for a command with subcommands
+	if command == "" {
+		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		return
+	}
+
+	for _, c := range ctx.App.Commands {
+		if c.HasName(command) {
+			HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
+			return
+		}
+	}
+
+	if ctx.App.CommandNotFound != nil {
+		ctx.App.CommandNotFound(ctx, command)
+	} else {
+		fmt.Fprintf(ctx.App.Writer, "No help topic for '%v'\n", command)
+	}
+}
+
+// Prints help for the given subcommand
+func ShowSubcommandHelp(c *Context) {
+	ShowCommandHelp(c, c.Command.Name)
+}
+
+// Prints the version number of the App
+func ShowVersion(c *Context) {
+	VersionPrinter(c)
+}
+
+func printVersion(c *Context) {
+	fmt.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version)
+}
+
+// Prints the lists of commands within a given context
+func ShowCompletions(c *Context) {
+	a := c.App
+	if a != nil && a.BashComplete != nil {
+		a.BashComplete(c)
+	}
+}
+
+// Prints the custom completions for a given command
+func ShowCommandCompletions(ctx *Context, command string) {
+	c := ctx.App.Command(command)
+	if c != nil && c.BashComplete != nil {
+		c.BashComplete(ctx)
+	}
+}
+
+func printHelp(out io.Writer, templ string, data interface{}) {
+	funcMap := template.FuncMap{
+		"join": strings.Join,
+	}
+
+	w := tabwriter.NewWriter(out, 0, 8, 1, '\t', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	err := t.Execute(w, data)
+	if err != nil {
+		panic(err)
+	}
+	w.Flush()
+}
+
+func checkVersion(c *Context) bool {
+	found := false
+	if VersionFlag.Name != "" {
+		eachName(VersionFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkHelp(c *Context) bool {
+	found := false
+	if HelpFlag.Name != "" {
+		eachName(HelpFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkCommandHelp(c *Context, name string) bool {
+	if c.Bool("h") || c.Bool("help") {
+		ShowCommandHelp(c, name)
+		return true
+	}
+
+	return false
+}
+
+func checkSubcommandHelp(c *Context) bool {
+	if c.GlobalBool("h") || c.GlobalBool("help") {
+		ShowSubcommandHelp(c)
+		return true
+	}
+
+	return false
+}
+
+func checkCompletions(c *Context) bool {
+	if (c.GlobalBool(BashCompletionFlag.Name) || c.Bool(BashCompletionFlag.Name)) && c.App.EnableBashCompletion {
+		ShowCompletions(c)
+		return true
+	}
+
+	return false
+}
+
+func checkCommandCompletions(c *Context, name string) bool {
+	if c.Bool(BashCompletionFlag.Name) && c.App.EnableBashCompletion {
+		ShowCommandCompletions(c, name)
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/codegangsta/cli/help_test.go
+++ b/vendor/github.com/codegangsta/cli/help_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_ShowAppHelp_NoAuthor(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("AUTHOR(S):")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "AUTHOR(S):")
+	}
+}
+
+func Test_ShowAppHelp_NoVersion(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	app.Version = ""
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("VERSION:")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
+	}
+}
+
+func Test_Help_Custom_Flags(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	HelpFlag = BoolFlag{
+		Name:  "help, x",
+		Usage: "show help",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, h"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("h") != true {
+				t.Errorf("custom help flag not set")
+			}
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-h"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}
+
+func Test_Version_Custom_Flags(t *testing.T) {
+	oldFlag := VersionFlag
+	defer func() {
+		VersionFlag = oldFlag
+	}()
+
+	VersionFlag = BoolFlag{
+		Name:  "version, V",
+		Usage: "show version",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, v"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("v") != true {
+				t.Errorf("custom version flag not set")
+			}
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-v"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}

--- a/vendor/github.com/codegangsta/cli/helpers_test.go
+++ b/vendor/github.com/codegangsta/cli/helpers_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+/* Test Helpers */
+func expect(t *testing.T, a interface{}, b interface{}) {
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}
+
+func refute(t *testing.T, a interface{}, b interface{}) {
+	if reflect.DeepEqual(a, b) {
+		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}

--- a/vendor/gopkg.in/yaml.v2/LICENSE
+++ b/vendor/gopkg.in/yaml.v2/LICENSE
@@ -1,0 +1,188 @@
+
+Copyright (c) 2011-2014 - Canonical Inc.
+
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/vendor/gopkg.in/yaml.v2/LICENSE.libyaml
+++ b/vendor/gopkg.in/yaml.v2/LICENSE.libyaml
@@ -1,0 +1,31 @@
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original copyright and license:
+
+    apic.go
+    emitterc.go
+    parserc.go
+    readerc.go
+    scannerc.go
+    writerc.go
+    yamlh.go
+    yamlprivateh.go
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -1,0 +1,131 @@
+# YAML support for the Go language
+
+Introduction
+------------
+
+The yaml package enables Go programs to comfortably encode and decode YAML
+values. It was developed within [Canonical](https://www.canonical.com) as
+part of the [juju](https://juju.ubuntu.com) project, and is based on a
+pure Go port of the well-known [libyaml](http://pyyaml.org/wiki/LibYAML)
+C library to parse and generate YAML data quickly and reliably.
+
+Compatibility
+-------------
+
+The yaml package supports most of YAML 1.1 and 1.2, including support for
+anchors, tags, map merging, etc. Multi-document unmarshalling is not yet
+implemented, and base-60 floats from YAML 1.1 are purposefully not
+supported since they're a poor design and are gone in YAML 1.2.
+
+Installation and usage
+----------------------
+
+The import path for the package is *gopkg.in/yaml.v2*.
+
+To install it, run:
+
+    go get gopkg.in/yaml.v2
+
+API documentation
+-----------------
+
+If opened in a browser, the import path itself leads to the API documentation:
+
+  * [https://gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)
+
+API stability
+-------------
+
+The package API for yaml v2 will remain stable as described in [gopkg.in](https://gopkg.in).
+
+
+License
+-------
+
+The yaml package is licensed under the LGPL with an exception that allows it to be linked statically. Please see the LICENSE file for details.
+
+
+Example
+-------
+
+```Go
+package main
+
+import (
+        "fmt"
+        "log"
+
+        "gopkg.in/yaml.v2"
+)
+
+var data = `
+a: Easy!
+b:
+  c: 2
+  d: [3, 4]
+`
+
+type T struct {
+        A string
+        B struct {
+                RenamedC int   `yaml:"c"`
+                D        []int `yaml:",flow"`
+        }
+}
+
+func main() {
+        t := T{}
+    
+        err := yaml.Unmarshal([]byte(data), &t)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- t:\n%v\n\n", t)
+    
+        d, err := yaml.Marshal(&t)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- t dump:\n%s\n\n", string(d))
+    
+        m := make(map[interface{}]interface{})
+    
+        err = yaml.Unmarshal([]byte(data), &m)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- m:\n%v\n\n", m)
+    
+        d, err = yaml.Marshal(&m)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- m dump:\n%s\n\n", string(d))
+}
+```
+
+This example will generate the following output:
+
+```
+--- t:
+{Easy! {2 [3 4]}}
+
+--- t dump:
+a: Easy!
+b:
+  c: 2
+  d: [3, 4]
+
+
+--- m:
+map[a:Easy! b:map[c:2 d:[3 4]]]
+
+--- m dump:
+a: Easy!
+b:
+  c: 2
+  d:
+  - 3
+  - 4
+```
+

--- a/vendor/gopkg.in/yaml.v2/apic.go
+++ b/vendor/gopkg.in/yaml.v2/apic.go
@@ -1,0 +1,742 @@
+package yaml
+
+import (
+	"io"
+	"os"
+)
+
+func yaml_insert_token(parser *yaml_parser_t, pos int, token *yaml_token_t) {
+	//fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
+
+	// Check if we can move the queue at the beginning of the buffer.
+	if parser.tokens_head > 0 && len(parser.tokens) == cap(parser.tokens) {
+		if parser.tokens_head != len(parser.tokens) {
+			copy(parser.tokens, parser.tokens[parser.tokens_head:])
+		}
+		parser.tokens = parser.tokens[:len(parser.tokens)-parser.tokens_head]
+		parser.tokens_head = 0
+	}
+	parser.tokens = append(parser.tokens, *token)
+	if pos < 0 {
+		return
+	}
+	copy(parser.tokens[parser.tokens_head+pos+1:], parser.tokens[parser.tokens_head+pos:])
+	parser.tokens[parser.tokens_head+pos] = *token
+}
+
+// Create a new parser object.
+func yaml_parser_initialize(parser *yaml_parser_t) bool {
+	*parser = yaml_parser_t{
+		raw_buffer: make([]byte, 0, input_raw_buffer_size),
+		buffer:     make([]byte, 0, input_buffer_size),
+	}
+	return true
+}
+
+// Destroy a parser object.
+func yaml_parser_delete(parser *yaml_parser_t) {
+	*parser = yaml_parser_t{}
+}
+
+// String read handler.
+func yaml_string_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
+	if parser.input_pos == len(parser.input) {
+		return 0, io.EOF
+	}
+	n = copy(buffer, parser.input[parser.input_pos:])
+	parser.input_pos += n
+	return n, nil
+}
+
+// File read handler.
+func yaml_file_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
+	return parser.input_file.Read(buffer)
+}
+
+// Set a string input.
+func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
+	if parser.read_handler != nil {
+		panic("must set the input source only once")
+	}
+	parser.read_handler = yaml_string_read_handler
+	parser.input = input
+	parser.input_pos = 0
+}
+
+// Set a file input.
+func yaml_parser_set_input_file(parser *yaml_parser_t, file *os.File) {
+	if parser.read_handler != nil {
+		panic("must set the input source only once")
+	}
+	parser.read_handler = yaml_file_read_handler
+	parser.input_file = file
+}
+
+// Set the source encoding.
+func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
+	if parser.encoding != yaml_ANY_ENCODING {
+		panic("must set the encoding only once")
+	}
+	parser.encoding = encoding
+}
+
+// Create a new emitter object.
+func yaml_emitter_initialize(emitter *yaml_emitter_t) bool {
+	*emitter = yaml_emitter_t{
+		buffer:     make([]byte, output_buffer_size),
+		raw_buffer: make([]byte, 0, output_raw_buffer_size),
+		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
+		events:     make([]yaml_event_t, 0, initial_queue_size),
+	}
+	return true
+}
+
+// Destroy an emitter object.
+func yaml_emitter_delete(emitter *yaml_emitter_t) {
+	*emitter = yaml_emitter_t{}
+}
+
+// String write handler.
+func yaml_string_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
+	*emitter.output_buffer = append(*emitter.output_buffer, buffer...)
+	return nil
+}
+
+// File write handler.
+func yaml_file_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
+	_, err := emitter.output_file.Write(buffer)
+	return err
+}
+
+// Set a string output.
+func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]byte) {
+	if emitter.write_handler != nil {
+		panic("must set the output target only once")
+	}
+	emitter.write_handler = yaml_string_write_handler
+	emitter.output_buffer = output_buffer
+}
+
+// Set a file output.
+func yaml_emitter_set_output_file(emitter *yaml_emitter_t, file io.Writer) {
+	if emitter.write_handler != nil {
+		panic("must set the output target only once")
+	}
+	emitter.write_handler = yaml_file_write_handler
+	emitter.output_file = file
+}
+
+// Set the output encoding.
+func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t) {
+	if emitter.encoding != yaml_ANY_ENCODING {
+		panic("must set the output encoding only once")
+	}
+	emitter.encoding = encoding
+}
+
+// Set the canonical output style.
+func yaml_emitter_set_canonical(emitter *yaml_emitter_t, canonical bool) {
+	emitter.canonical = canonical
+}
+
+//// Set the indentation increment.
+func yaml_emitter_set_indent(emitter *yaml_emitter_t, indent int) {
+	if indent < 2 || indent > 9 {
+		indent = 2
+	}
+	emitter.best_indent = indent
+}
+
+// Set the preferred line width.
+func yaml_emitter_set_width(emitter *yaml_emitter_t, width int) {
+	if width < 0 {
+		width = -1
+	}
+	emitter.best_width = width
+}
+
+// Set if unescaped non-ASCII characters are allowed.
+func yaml_emitter_set_unicode(emitter *yaml_emitter_t, unicode bool) {
+	emitter.unicode = unicode
+}
+
+// Set the preferred line break character.
+func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
+	emitter.line_break = line_break
+}
+
+///*
+// * Destroy a token object.
+// */
+//
+//YAML_DECLARE(void)
+//yaml_token_delete(yaml_token_t *token)
+//{
+//    assert(token);  // Non-NULL token object expected.
+//
+//    switch (token.type)
+//    {
+//        case YAML_TAG_DIRECTIVE_TOKEN:
+//            yaml_free(token.data.tag_directive.handle);
+//            yaml_free(token.data.tag_directive.prefix);
+//            break;
+//
+//        case YAML_ALIAS_TOKEN:
+//            yaml_free(token.data.alias.value);
+//            break;
+//
+//        case YAML_ANCHOR_TOKEN:
+//            yaml_free(token.data.anchor.value);
+//            break;
+//
+//        case YAML_TAG_TOKEN:
+//            yaml_free(token.data.tag.handle);
+//            yaml_free(token.data.tag.suffix);
+//            break;
+//
+//        case YAML_SCALAR_TOKEN:
+//            yaml_free(token.data.scalar.value);
+//            break;
+//
+//        default:
+//            break;
+//    }
+//
+//    memset(token, 0, sizeof(yaml_token_t));
+//}
+//
+///*
+// * Check if a string is a valid UTF-8 sequence.
+// *
+// * Check 'reader.c' for more details on UTF-8 encoding.
+// */
+//
+//static int
+//yaml_check_utf8(yaml_char_t *start, size_t length)
+//{
+//    yaml_char_t *end = start+length;
+//    yaml_char_t *pointer = start;
+//
+//    while (pointer < end) {
+//        unsigned char octet;
+//        unsigned int width;
+//        unsigned int value;
+//        size_t k;
+//
+//        octet = pointer[0];
+//        width = (octet & 0x80) == 0x00 ? 1 :
+//                (octet & 0xE0) == 0xC0 ? 2 :
+//                (octet & 0xF0) == 0xE0 ? 3 :
+//                (octet & 0xF8) == 0xF0 ? 4 : 0;
+//        value = (octet & 0x80) == 0x00 ? octet & 0x7F :
+//                (octet & 0xE0) == 0xC0 ? octet & 0x1F :
+//                (octet & 0xF0) == 0xE0 ? octet & 0x0F :
+//                (octet & 0xF8) == 0xF0 ? octet & 0x07 : 0;
+//        if (!width) return 0;
+//        if (pointer+width > end) return 0;
+//        for (k = 1; k < width; k ++) {
+//            octet = pointer[k];
+//            if ((octet & 0xC0) != 0x80) return 0;
+//            value = (value << 6) + (octet & 0x3F);
+//        }
+//        if (!((width == 1) ||
+//            (width == 2 && value >= 0x80) ||
+//            (width == 3 && value >= 0x800) ||
+//            (width == 4 && value >= 0x10000))) return 0;
+//
+//        pointer += width;
+//    }
+//
+//    return 1;
+//}
+//
+
+// Create STREAM-START.
+func yaml_stream_start_event_initialize(event *yaml_event_t, encoding yaml_encoding_t) bool {
+	*event = yaml_event_t{
+		typ:      yaml_STREAM_START_EVENT,
+		encoding: encoding,
+	}
+	return true
+}
+
+// Create STREAM-END.
+func yaml_stream_end_event_initialize(event *yaml_event_t) bool {
+	*event = yaml_event_t{
+		typ: yaml_STREAM_END_EVENT,
+	}
+	return true
+}
+
+// Create DOCUMENT-START.
+func yaml_document_start_event_initialize(event *yaml_event_t, version_directive *yaml_version_directive_t,
+	tag_directives []yaml_tag_directive_t, implicit bool) bool {
+	*event = yaml_event_t{
+		typ:               yaml_DOCUMENT_START_EVENT,
+		version_directive: version_directive,
+		tag_directives:    tag_directives,
+		implicit:          implicit,
+	}
+	return true
+}
+
+// Create DOCUMENT-END.
+func yaml_document_end_event_initialize(event *yaml_event_t, implicit bool) bool {
+	*event = yaml_event_t{
+		typ:      yaml_DOCUMENT_END_EVENT,
+		implicit: implicit,
+	}
+	return true
+}
+
+///*
+// * Create ALIAS.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_alias_event_initialize(event *yaml_event_t, anchor *yaml_char_t)
+//{
+//    mark yaml_mark_t = { 0, 0, 0 }
+//    anchor_copy *yaml_char_t = NULL
+//
+//    assert(event) // Non-NULL event object is expected.
+//    assert(anchor) // Non-NULL anchor is expected.
+//
+//    if (!yaml_check_utf8(anchor, strlen((char *)anchor))) return 0
+//
+//    anchor_copy = yaml_strdup(anchor)
+//    if (!anchor_copy)
+//        return 0
+//
+//    ALIAS_EVENT_INIT(*event, anchor_copy, mark, mark)
+//
+//    return 1
+//}
+
+// Create SCALAR.
+func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yaml_scalar_style_t) bool {
+	*event = yaml_event_t{
+		typ:             yaml_SCALAR_EVENT,
+		anchor:          anchor,
+		tag:             tag,
+		value:           value,
+		implicit:        plain_implicit,
+		quoted_implicit: quoted_implicit,
+		style:           yaml_style_t(style),
+	}
+	return true
+}
+
+// Create SEQUENCE-START.
+func yaml_sequence_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_sequence_style_t) bool {
+	*event = yaml_event_t{
+		typ:      yaml_SEQUENCE_START_EVENT,
+		anchor:   anchor,
+		tag:      tag,
+		implicit: implicit,
+		style:    yaml_style_t(style),
+	}
+	return true
+}
+
+// Create SEQUENCE-END.
+func yaml_sequence_end_event_initialize(event *yaml_event_t) bool {
+	*event = yaml_event_t{
+		typ: yaml_SEQUENCE_END_EVENT,
+	}
+	return true
+}
+
+// Create MAPPING-START.
+func yaml_mapping_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_mapping_style_t) bool {
+	*event = yaml_event_t{
+		typ:      yaml_MAPPING_START_EVENT,
+		anchor:   anchor,
+		tag:      tag,
+		implicit: implicit,
+		style:    yaml_style_t(style),
+	}
+	return true
+}
+
+// Create MAPPING-END.
+func yaml_mapping_end_event_initialize(event *yaml_event_t) bool {
+	*event = yaml_event_t{
+		typ: yaml_MAPPING_END_EVENT,
+	}
+	return true
+}
+
+// Destroy an event object.
+func yaml_event_delete(event *yaml_event_t) {
+	*event = yaml_event_t{}
+}
+
+///*
+// * Create a document object.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_initialize(document *yaml_document_t,
+//        version_directive *yaml_version_directive_t,
+//        tag_directives_start *yaml_tag_directive_t,
+//        tag_directives_end *yaml_tag_directive_t,
+//        start_implicit int, end_implicit int)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//    struct {
+//        start *yaml_node_t
+//        end *yaml_node_t
+//        top *yaml_node_t
+//    } nodes = { NULL, NULL, NULL }
+//    version_directive_copy *yaml_version_directive_t = NULL
+//    struct {
+//        start *yaml_tag_directive_t
+//        end *yaml_tag_directive_t
+//        top *yaml_tag_directive_t
+//    } tag_directives_copy = { NULL, NULL, NULL }
+//    value yaml_tag_directive_t = { NULL, NULL }
+//    mark yaml_mark_t = { 0, 0, 0 }
+//
+//    assert(document) // Non-NULL document object is expected.
+//    assert((tag_directives_start && tag_directives_end) ||
+//            (tag_directives_start == tag_directives_end))
+//                            // Valid tag directives are expected.
+//
+//    if (!STACK_INIT(&context, nodes, INITIAL_STACK_SIZE)) goto error
+//
+//    if (version_directive) {
+//        version_directive_copy = yaml_malloc(sizeof(yaml_version_directive_t))
+//        if (!version_directive_copy) goto error
+//        version_directive_copy.major = version_directive.major
+//        version_directive_copy.minor = version_directive.minor
+//    }
+//
+//    if (tag_directives_start != tag_directives_end) {
+//        tag_directive *yaml_tag_directive_t
+//        if (!STACK_INIT(&context, tag_directives_copy, INITIAL_STACK_SIZE))
+//            goto error
+//        for (tag_directive = tag_directives_start
+//                tag_directive != tag_directives_end; tag_directive ++) {
+//            assert(tag_directive.handle)
+//            assert(tag_directive.prefix)
+//            if (!yaml_check_utf8(tag_directive.handle,
+//                        strlen((char *)tag_directive.handle)))
+//                goto error
+//            if (!yaml_check_utf8(tag_directive.prefix,
+//                        strlen((char *)tag_directive.prefix)))
+//                goto error
+//            value.handle = yaml_strdup(tag_directive.handle)
+//            value.prefix = yaml_strdup(tag_directive.prefix)
+//            if (!value.handle || !value.prefix) goto error
+//            if (!PUSH(&context, tag_directives_copy, value))
+//                goto error
+//            value.handle = NULL
+//            value.prefix = NULL
+//        }
+//    }
+//
+//    DOCUMENT_INIT(*document, nodes.start, nodes.end, version_directive_copy,
+//            tag_directives_copy.start, tag_directives_copy.top,
+//            start_implicit, end_implicit, mark, mark)
+//
+//    return 1
+//
+//error:
+//    STACK_DEL(&context, nodes)
+//    yaml_free(version_directive_copy)
+//    while (!STACK_EMPTY(&context, tag_directives_copy)) {
+//        value yaml_tag_directive_t = POP(&context, tag_directives_copy)
+//        yaml_free(value.handle)
+//        yaml_free(value.prefix)
+//    }
+//    STACK_DEL(&context, tag_directives_copy)
+//    yaml_free(value.handle)
+//    yaml_free(value.prefix)
+//
+//    return 0
+//}
+//
+///*
+// * Destroy a document object.
+// */
+//
+//YAML_DECLARE(void)
+//yaml_document_delete(document *yaml_document_t)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//    tag_directive *yaml_tag_directive_t
+//
+//    context.error = YAML_NO_ERROR // Eliminate a compliler warning.
+//
+//    assert(document) // Non-NULL document object is expected.
+//
+//    while (!STACK_EMPTY(&context, document.nodes)) {
+//        node yaml_node_t = POP(&context, document.nodes)
+//        yaml_free(node.tag)
+//        switch (node.type) {
+//            case YAML_SCALAR_NODE:
+//                yaml_free(node.data.scalar.value)
+//                break
+//            case YAML_SEQUENCE_NODE:
+//                STACK_DEL(&context, node.data.sequence.items)
+//                break
+//            case YAML_MAPPING_NODE:
+//                STACK_DEL(&context, node.data.mapping.pairs)
+//                break
+//            default:
+//                assert(0) // Should not happen.
+//        }
+//    }
+//    STACK_DEL(&context, document.nodes)
+//
+//    yaml_free(document.version_directive)
+//    for (tag_directive = document.tag_directives.start
+//            tag_directive != document.tag_directives.end
+//            tag_directive++) {
+//        yaml_free(tag_directive.handle)
+//        yaml_free(tag_directive.prefix)
+//    }
+//    yaml_free(document.tag_directives.start)
+//
+//    memset(document, 0, sizeof(yaml_document_t))
+//}
+//
+///**
+// * Get a document node.
+// */
+//
+//YAML_DECLARE(yaml_node_t *)
+//yaml_document_get_node(document *yaml_document_t, index int)
+//{
+//    assert(document) // Non-NULL document object is expected.
+//
+//    if (index > 0 && document.nodes.start + index <= document.nodes.top) {
+//        return document.nodes.start + index - 1
+//    }
+//    return NULL
+//}
+//
+///**
+// * Get the root object.
+// */
+//
+//YAML_DECLARE(yaml_node_t *)
+//yaml_document_get_root_node(document *yaml_document_t)
+//{
+//    assert(document) // Non-NULL document object is expected.
+//
+//    if (document.nodes.top != document.nodes.start) {
+//        return document.nodes.start
+//    }
+//    return NULL
+//}
+//
+///*
+// * Add a scalar node to a document.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_add_scalar(document *yaml_document_t,
+//        tag *yaml_char_t, value *yaml_char_t, length int,
+//        style yaml_scalar_style_t)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//    mark yaml_mark_t = { 0, 0, 0 }
+//    tag_copy *yaml_char_t = NULL
+//    value_copy *yaml_char_t = NULL
+//    node yaml_node_t
+//
+//    assert(document) // Non-NULL document object is expected.
+//    assert(value) // Non-NULL value is expected.
+//
+//    if (!tag) {
+//        tag = (yaml_char_t *)YAML_DEFAULT_SCALAR_TAG
+//    }
+//
+//    if (!yaml_check_utf8(tag, strlen((char *)tag))) goto error
+//    tag_copy = yaml_strdup(tag)
+//    if (!tag_copy) goto error
+//
+//    if (length < 0) {
+//        length = strlen((char *)value)
+//    }
+//
+//    if (!yaml_check_utf8(value, length)) goto error
+//    value_copy = yaml_malloc(length+1)
+//    if (!value_copy) goto error
+//    memcpy(value_copy, value, length)
+//    value_copy[length] = '\0'
+//
+//    SCALAR_NODE_INIT(node, tag_copy, value_copy, length, style, mark, mark)
+//    if (!PUSH(&context, document.nodes, node)) goto error
+//
+//    return document.nodes.top - document.nodes.start
+//
+//error:
+//    yaml_free(tag_copy)
+//    yaml_free(value_copy)
+//
+//    return 0
+//}
+//
+///*
+// * Add a sequence node to a document.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_add_sequence(document *yaml_document_t,
+//        tag *yaml_char_t, style yaml_sequence_style_t)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//    mark yaml_mark_t = { 0, 0, 0 }
+//    tag_copy *yaml_char_t = NULL
+//    struct {
+//        start *yaml_node_item_t
+//        end *yaml_node_item_t
+//        top *yaml_node_item_t
+//    } items = { NULL, NULL, NULL }
+//    node yaml_node_t
+//
+//    assert(document) // Non-NULL document object is expected.
+//
+//    if (!tag) {
+//        tag = (yaml_char_t *)YAML_DEFAULT_SEQUENCE_TAG
+//    }
+//
+//    if (!yaml_check_utf8(tag, strlen((char *)tag))) goto error
+//    tag_copy = yaml_strdup(tag)
+//    if (!tag_copy) goto error
+//
+//    if (!STACK_INIT(&context, items, INITIAL_STACK_SIZE)) goto error
+//
+//    SEQUENCE_NODE_INIT(node, tag_copy, items.start, items.end,
+//            style, mark, mark)
+//    if (!PUSH(&context, document.nodes, node)) goto error
+//
+//    return document.nodes.top - document.nodes.start
+//
+//error:
+//    STACK_DEL(&context, items)
+//    yaml_free(tag_copy)
+//
+//    return 0
+//}
+//
+///*
+// * Add a mapping node to a document.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_add_mapping(document *yaml_document_t,
+//        tag *yaml_char_t, style yaml_mapping_style_t)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//    mark yaml_mark_t = { 0, 0, 0 }
+//    tag_copy *yaml_char_t = NULL
+//    struct {
+//        start *yaml_node_pair_t
+//        end *yaml_node_pair_t
+//        top *yaml_node_pair_t
+//    } pairs = { NULL, NULL, NULL }
+//    node yaml_node_t
+//
+//    assert(document) // Non-NULL document object is expected.
+//
+//    if (!tag) {
+//        tag = (yaml_char_t *)YAML_DEFAULT_MAPPING_TAG
+//    }
+//
+//    if (!yaml_check_utf8(tag, strlen((char *)tag))) goto error
+//    tag_copy = yaml_strdup(tag)
+//    if (!tag_copy) goto error
+//
+//    if (!STACK_INIT(&context, pairs, INITIAL_STACK_SIZE)) goto error
+//
+//    MAPPING_NODE_INIT(node, tag_copy, pairs.start, pairs.end,
+//            style, mark, mark)
+//    if (!PUSH(&context, document.nodes, node)) goto error
+//
+//    return document.nodes.top - document.nodes.start
+//
+//error:
+//    STACK_DEL(&context, pairs)
+//    yaml_free(tag_copy)
+//
+//    return 0
+//}
+//
+///*
+// * Append an item to a sequence node.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_append_sequence_item(document *yaml_document_t,
+//        sequence int, item int)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//
+//    assert(document) // Non-NULL document is required.
+//    assert(sequence > 0
+//            && document.nodes.start + sequence <= document.nodes.top)
+//                            // Valid sequence id is required.
+//    assert(document.nodes.start[sequence-1].type == YAML_SEQUENCE_NODE)
+//                            // A sequence node is required.
+//    assert(item > 0 && document.nodes.start + item <= document.nodes.top)
+//                            // Valid item id is required.
+//
+//    if (!PUSH(&context,
+//                document.nodes.start[sequence-1].data.sequence.items, item))
+//        return 0
+//
+//    return 1
+//}
+//
+///*
+// * Append a pair of a key and a value to a mapping node.
+// */
+//
+//YAML_DECLARE(int)
+//yaml_document_append_mapping_pair(document *yaml_document_t,
+//        mapping int, key int, value int)
+//{
+//    struct {
+//        error yaml_error_type_t
+//    } context
+//
+//    pair yaml_node_pair_t
+//
+//    assert(document) // Non-NULL document is required.
+//    assert(mapping > 0
+//            && document.nodes.start + mapping <= document.nodes.top)
+//                            // Valid mapping id is required.
+//    assert(document.nodes.start[mapping-1].type == YAML_MAPPING_NODE)
+//                            // A mapping node is required.
+//    assert(key > 0 && document.nodes.start + key <= document.nodes.top)
+//                            // Valid key id is required.
+//    assert(value > 0 && document.nodes.start + value <= document.nodes.top)
+//                            // Valid value id is required.
+//
+//    pair.key = key
+//    pair.value = value
+//
+//    if (!PUSH(&context,
+//                document.nodes.start[mapping-1].data.mapping.pairs, pair))
+//        return 0
+//
+//    return 1
+//}
+//
+//

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -1,0 +1,683 @@
+package yaml
+
+import (
+	"encoding"
+	"encoding/base64"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+const (
+	documentNode = 1 << iota
+	mappingNode
+	sequenceNode
+	scalarNode
+	aliasNode
+)
+
+type node struct {
+	kind         int
+	line, column int
+	tag          string
+	value        string
+	implicit     bool
+	children     []*node
+	anchors      map[string]*node
+}
+
+// ----------------------------------------------------------------------------
+// Parser, produces a node tree out of a libyaml event stream.
+
+type parser struct {
+	parser yaml_parser_t
+	event  yaml_event_t
+	doc    *node
+}
+
+func newParser(b []byte) *parser {
+	p := parser{}
+	if !yaml_parser_initialize(&p.parser) {
+		panic("failed to initialize YAML emitter")
+	}
+
+	if len(b) == 0 {
+		b = []byte{'\n'}
+	}
+
+	yaml_parser_set_input_string(&p.parser, b)
+
+	p.skip()
+	if p.event.typ != yaml_STREAM_START_EVENT {
+		panic("expected stream start event, got " + strconv.Itoa(int(p.event.typ)))
+	}
+	p.skip()
+	return &p
+}
+
+func (p *parser) destroy() {
+	if p.event.typ != yaml_NO_EVENT {
+		yaml_event_delete(&p.event)
+	}
+	yaml_parser_delete(&p.parser)
+}
+
+func (p *parser) skip() {
+	if p.event.typ != yaml_NO_EVENT {
+		if p.event.typ == yaml_STREAM_END_EVENT {
+			failf("attempted to go past the end of stream; corrupted value?")
+		}
+		yaml_event_delete(&p.event)
+	}
+	if !yaml_parser_parse(&p.parser, &p.event) {
+		p.fail()
+	}
+}
+
+func (p *parser) fail() {
+	var where string
+	var line int
+	if p.parser.problem_mark.line != 0 {
+		line = p.parser.problem_mark.line
+	} else if p.parser.context_mark.line != 0 {
+		line = p.parser.context_mark.line
+	}
+	if line != 0 {
+		where = "line " + strconv.Itoa(line) + ": "
+	}
+	var msg string
+	if len(p.parser.problem) > 0 {
+		msg = p.parser.problem
+	} else {
+		msg = "unknown problem parsing YAML content"
+	}
+	failf("%s%s", where, msg)
+}
+
+func (p *parser) anchor(n *node, anchor []byte) {
+	if anchor != nil {
+		p.doc.anchors[string(anchor)] = n
+	}
+}
+
+func (p *parser) parse() *node {
+	switch p.event.typ {
+	case yaml_SCALAR_EVENT:
+		return p.scalar()
+	case yaml_ALIAS_EVENT:
+		return p.alias()
+	case yaml_MAPPING_START_EVENT:
+		return p.mapping()
+	case yaml_SEQUENCE_START_EVENT:
+		return p.sequence()
+	case yaml_DOCUMENT_START_EVENT:
+		return p.document()
+	case yaml_STREAM_END_EVENT:
+		// Happens when attempting to decode an empty buffer.
+		return nil
+	default:
+		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
+	}
+	panic("unreachable")
+}
+
+func (p *parser) node(kind int) *node {
+	return &node{
+		kind:   kind,
+		line:   p.event.start_mark.line,
+		column: p.event.start_mark.column,
+	}
+}
+
+func (p *parser) document() *node {
+	n := p.node(documentNode)
+	n.anchors = make(map[string]*node)
+	p.doc = n
+	p.skip()
+	n.children = append(n.children, p.parse())
+	if p.event.typ != yaml_DOCUMENT_END_EVENT {
+		panic("expected end of document event but got " + strconv.Itoa(int(p.event.typ)))
+	}
+	p.skip()
+	return n
+}
+
+func (p *parser) alias() *node {
+	n := p.node(aliasNode)
+	n.value = string(p.event.anchor)
+	p.skip()
+	return n
+}
+
+func (p *parser) scalar() *node {
+	n := p.node(scalarNode)
+	n.value = string(p.event.value)
+	n.tag = string(p.event.tag)
+	n.implicit = p.event.implicit
+	p.anchor(n, p.event.anchor)
+	p.skip()
+	return n
+}
+
+func (p *parser) sequence() *node {
+	n := p.node(sequenceNode)
+	p.anchor(n, p.event.anchor)
+	p.skip()
+	for p.event.typ != yaml_SEQUENCE_END_EVENT {
+		n.children = append(n.children, p.parse())
+	}
+	p.skip()
+	return n
+}
+
+func (p *parser) mapping() *node {
+	n := p.node(mappingNode)
+	p.anchor(n, p.event.anchor)
+	p.skip()
+	for p.event.typ != yaml_MAPPING_END_EVENT {
+		n.children = append(n.children, p.parse(), p.parse())
+	}
+	p.skip()
+	return n
+}
+
+// ----------------------------------------------------------------------------
+// Decoder, unmarshals a node into a provided value.
+
+type decoder struct {
+	doc     *node
+	aliases map[string]bool
+	mapType reflect.Type
+	terrors []string
+}
+
+var (
+	mapItemType    = reflect.TypeOf(MapItem{})
+	durationType   = reflect.TypeOf(time.Duration(0))
+	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	ifaceType      = defaultMapType.Elem()
+)
+
+func newDecoder() *decoder {
+	d := &decoder{mapType: defaultMapType}
+	d.aliases = make(map[string]bool)
+	return d
+}
+
+func (d *decoder) terror(n *node, tag string, out reflect.Value) {
+	if n.tag != "" {
+		tag = n.tag
+	}
+	value := n.value
+	if tag != yaml_SEQ_TAG && tag != yaml_MAP_TAG {
+		if len(value) > 10 {
+			value = " `" + value[:7] + "...`"
+		} else {
+			value = " `" + value + "`"
+		}
+	}
+	d.terrors = append(d.terrors, fmt.Sprintf("line %d: cannot unmarshal %s%s into %s", n.line+1, shortTag(tag), value, out.Type()))
+}
+
+func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
+	terrlen := len(d.terrors)
+	err := u.UnmarshalYAML(func(v interface{}) (err error) {
+		defer handleErr(&err)
+		d.unmarshal(n, reflect.ValueOf(v))
+		if len(d.terrors) > terrlen {
+			issues := d.terrors[terrlen:]
+			d.terrors = d.terrors[:terrlen]
+			return &TypeError{issues}
+		}
+		return nil
+	})
+	if e, ok := err.(*TypeError); ok {
+		d.terrors = append(d.terrors, e.Errors...)
+		return false
+	}
+	if err != nil {
+		fail(err)
+	}
+	return true
+}
+
+// d.prepare initializes and dereferences pointers and calls UnmarshalYAML
+// if a value is found to implement it.
+// It returns the initialized and dereferenced out value, whether
+// unmarshalling was already done by UnmarshalYAML, and if so whether
+// its types unmarshalled appropriately.
+//
+// If n holds a null value, prepare returns before doing anything.
+func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "") {
+		return out, false, false
+	}
+	again := true
+	for again {
+		again = false
+		if out.Kind() == reflect.Ptr {
+			if out.IsNil() {
+				out.Set(reflect.New(out.Type().Elem()))
+			}
+			out = out.Elem()
+			again = true
+		}
+		if out.CanAddr() {
+			if u, ok := out.Addr().Interface().(Unmarshaler); ok {
+				good = d.callUnmarshaler(n, u)
+				return out, true, good
+			}
+		}
+	}
+	return out, false, false
+}
+
+func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
+	switch n.kind {
+	case documentNode:
+		return d.document(n, out)
+	case aliasNode:
+		return d.alias(n, out)
+	}
+	out, unmarshaled, good := d.prepare(n, out)
+	if unmarshaled {
+		return good
+	}
+	switch n.kind {
+	case scalarNode:
+		good = d.scalar(n, out)
+	case mappingNode:
+		good = d.mapping(n, out)
+	case sequenceNode:
+		good = d.sequence(n, out)
+	default:
+		panic("internal error: unknown node kind: " + strconv.Itoa(n.kind))
+	}
+	return good
+}
+
+func (d *decoder) document(n *node, out reflect.Value) (good bool) {
+	if len(n.children) == 1 {
+		d.doc = n
+		d.unmarshal(n.children[0], out)
+		return true
+	}
+	return false
+}
+
+func (d *decoder) alias(n *node, out reflect.Value) (good bool) {
+	an, ok := d.doc.anchors[n.value]
+	if !ok {
+		failf("unknown anchor '%s' referenced", n.value)
+	}
+	if d.aliases[n.value] {
+		failf("anchor '%s' value contains itself", n.value)
+	}
+	d.aliases[n.value] = true
+	good = d.unmarshal(an, out)
+	delete(d.aliases, n.value)
+	return good
+}
+
+var zeroValue reflect.Value
+
+func resetMap(out reflect.Value) {
+	for _, k := range out.MapKeys() {
+		out.SetMapIndex(k, zeroValue)
+	}
+}
+
+func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
+	var tag string
+	var resolved interface{}
+	if n.tag == "" && !n.implicit {
+		tag = yaml_STR_TAG
+		resolved = n.value
+	} else {
+		tag, resolved = resolve(n.tag, n.value)
+		if tag == yaml_BINARY_TAG {
+			data, err := base64.StdEncoding.DecodeString(resolved.(string))
+			if err != nil {
+				failf("!!binary value contains invalid base64 data")
+			}
+			resolved = string(data)
+		}
+	}
+	if resolved == nil {
+		if out.Kind() == reflect.Map && !out.CanAddr() {
+			resetMap(out)
+		} else {
+			out.Set(reflect.Zero(out.Type()))
+		}
+		return true
+	}
+	if s, ok := resolved.(string); ok && out.CanAddr() {
+		if u, ok := out.Addr().Interface().(encoding.TextUnmarshaler); ok {
+			err := u.UnmarshalText([]byte(s))
+			if err != nil {
+				fail(err)
+			}
+			return true
+		}
+	}
+	switch out.Kind() {
+	case reflect.String:
+		if tag == yaml_BINARY_TAG {
+			out.SetString(resolved.(string))
+			good = true
+		} else if resolved != nil {
+			out.SetString(n.value)
+			good = true
+		}
+	case reflect.Interface:
+		if resolved == nil {
+			out.Set(reflect.Zero(out.Type()))
+		} else {
+			out.Set(reflect.ValueOf(resolved))
+		}
+		good = true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch resolved := resolved.(type) {
+		case int:
+			if !out.OverflowInt(int64(resolved)) {
+				out.SetInt(int64(resolved))
+				good = true
+			}
+		case int64:
+			if !out.OverflowInt(resolved) {
+				out.SetInt(resolved)
+				good = true
+			}
+		case uint64:
+			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
+				out.SetInt(int64(resolved))
+				good = true
+			}
+		case float64:
+			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
+				out.SetInt(int64(resolved))
+				good = true
+			}
+		case string:
+			if out.Type() == durationType {
+				d, err := time.ParseDuration(resolved)
+				if err == nil {
+					out.SetInt(int64(d))
+					good = true
+				}
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		switch resolved := resolved.(type) {
+		case int:
+			if resolved >= 0 && !out.OverflowUint(uint64(resolved)) {
+				out.SetUint(uint64(resolved))
+				good = true
+			}
+		case int64:
+			if resolved >= 0 && !out.OverflowUint(uint64(resolved)) {
+				out.SetUint(uint64(resolved))
+				good = true
+			}
+		case uint64:
+			if !out.OverflowUint(uint64(resolved)) {
+				out.SetUint(uint64(resolved))
+				good = true
+			}
+		case float64:
+			if resolved <= math.MaxUint64 && !out.OverflowUint(uint64(resolved)) {
+				out.SetUint(uint64(resolved))
+				good = true
+			}
+		}
+	case reflect.Bool:
+		switch resolved := resolved.(type) {
+		case bool:
+			out.SetBool(resolved)
+			good = true
+		}
+	case reflect.Float32, reflect.Float64:
+		switch resolved := resolved.(type) {
+		case int:
+			out.SetFloat(float64(resolved))
+			good = true
+		case int64:
+			out.SetFloat(float64(resolved))
+			good = true
+		case uint64:
+			out.SetFloat(float64(resolved))
+			good = true
+		case float64:
+			out.SetFloat(resolved)
+			good = true
+		}
+	case reflect.Ptr:
+		if out.Type().Elem() == reflect.TypeOf(resolved) {
+			// TODO DOes this make sense? When is out a Ptr except when decoding a nil value?
+			elem := reflect.New(out.Type().Elem())
+			elem.Elem().Set(reflect.ValueOf(resolved))
+			out.Set(elem)
+			good = true
+		}
+	}
+	if !good {
+		d.terror(n, tag, out)
+	}
+	return good
+}
+
+func settableValueOf(i interface{}) reflect.Value {
+	v := reflect.ValueOf(i)
+	sv := reflect.New(v.Type()).Elem()
+	sv.Set(v)
+	return sv
+}
+
+func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
+	l := len(n.children)
+
+	var iface reflect.Value
+	switch out.Kind() {
+	case reflect.Slice:
+		out.Set(reflect.MakeSlice(out.Type(), l, l))
+	case reflect.Interface:
+		// No type hints. Will have to use a generic sequence.
+		iface = out
+		out = settableValueOf(make([]interface{}, l))
+	default:
+		d.terror(n, yaml_SEQ_TAG, out)
+		return false
+	}
+	et := out.Type().Elem()
+
+	j := 0
+	for i := 0; i < l; i++ {
+		e := reflect.New(et).Elem()
+		if ok := d.unmarshal(n.children[i], e); ok {
+			out.Index(j).Set(e)
+			j++
+		}
+	}
+	out.Set(out.Slice(0, j))
+	if iface.IsValid() {
+		iface.Set(out)
+	}
+	return true
+}
+
+func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
+	switch out.Kind() {
+	case reflect.Struct:
+		return d.mappingStruct(n, out)
+	case reflect.Slice:
+		return d.mappingSlice(n, out)
+	case reflect.Map:
+		// okay
+	case reflect.Interface:
+		if d.mapType.Kind() == reflect.Map {
+			iface := out
+			out = reflect.MakeMap(d.mapType)
+			iface.Set(out)
+		} else {
+			slicev := reflect.New(d.mapType).Elem()
+			if !d.mappingSlice(n, slicev) {
+				return false
+			}
+			out.Set(slicev)
+			return true
+		}
+	default:
+		d.terror(n, yaml_MAP_TAG, out)
+		return false
+	}
+	outt := out.Type()
+	kt := outt.Key()
+	et := outt.Elem()
+
+	mapType := d.mapType
+	if outt.Key() == ifaceType && outt.Elem() == ifaceType {
+		d.mapType = outt
+	}
+
+	if out.IsNil() {
+		out.Set(reflect.MakeMap(outt))
+	}
+	l := len(n.children)
+	for i := 0; i < l; i += 2 {
+		if isMerge(n.children[i]) {
+			d.merge(n.children[i+1], out)
+			continue
+		}
+		k := reflect.New(kt).Elem()
+		if d.unmarshal(n.children[i], k) {
+			kkind := k.Kind()
+			if kkind == reflect.Interface {
+				kkind = k.Elem().Kind()
+			}
+			if kkind == reflect.Map || kkind == reflect.Slice {
+				failf("invalid map key: %#v", k.Interface())
+			}
+			e := reflect.New(et).Elem()
+			if d.unmarshal(n.children[i+1], e) {
+				out.SetMapIndex(k, e)
+			}
+		}
+	}
+	d.mapType = mapType
+	return true
+}
+
+func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
+	outt := out.Type()
+	if outt.Elem() != mapItemType {
+		d.terror(n, yaml_MAP_TAG, out)
+		return false
+	}
+
+	mapType := d.mapType
+	d.mapType = outt
+
+	var slice []MapItem
+	var l = len(n.children)
+	for i := 0; i < l; i += 2 {
+		if isMerge(n.children[i]) {
+			d.merge(n.children[i+1], out)
+			continue
+		}
+		item := MapItem{}
+		k := reflect.ValueOf(&item.Key).Elem()
+		if d.unmarshal(n.children[i], k) {
+			v := reflect.ValueOf(&item.Value).Elem()
+			if d.unmarshal(n.children[i+1], v) {
+				slice = append(slice, item)
+			}
+		}
+	}
+	out.Set(reflect.ValueOf(slice))
+	d.mapType = mapType
+	return true
+}
+
+func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
+	sinfo, err := getStructInfo(out.Type())
+	if err != nil {
+		panic(err)
+	}
+	name := settableValueOf("")
+	l := len(n.children)
+
+	var inlineMap reflect.Value
+	var elemType reflect.Type
+	if sinfo.InlineMap != -1 {
+		inlineMap = out.Field(sinfo.InlineMap)
+		inlineMap.Set(reflect.New(inlineMap.Type()).Elem())
+		elemType = inlineMap.Type().Elem()
+	}
+
+	for i := 0; i < l; i += 2 {
+		ni := n.children[i]
+		if isMerge(ni) {
+			d.merge(n.children[i+1], out)
+			continue
+		}
+		if !d.unmarshal(ni, name) {
+			continue
+		}
+		if info, ok := sinfo.FieldsMap[name.String()]; ok {
+			var field reflect.Value
+			if info.Inline == nil {
+				field = out.Field(info.Num)
+			} else {
+				field = out.FieldByIndex(info.Inline)
+			}
+			d.unmarshal(n.children[i+1], field)
+		} else if sinfo.InlineMap != -1 {
+			if inlineMap.IsNil() {
+				inlineMap.Set(reflect.MakeMap(inlineMap.Type()))
+			}
+			value := reflect.New(elemType).Elem()
+			d.unmarshal(n.children[i+1], value)
+			inlineMap.SetMapIndex(name, value)
+		}
+	}
+	return true
+}
+
+func failWantMap() {
+	failf("map merge requires map or sequence of maps as the value")
+}
+
+func (d *decoder) merge(n *node, out reflect.Value) {
+	switch n.kind {
+	case mappingNode:
+		d.unmarshal(n, out)
+	case aliasNode:
+		an, ok := d.doc.anchors[n.value]
+		if ok && an.kind != mappingNode {
+			failWantMap()
+		}
+		d.unmarshal(n, out)
+	case sequenceNode:
+		// Step backwards as earlier nodes take precedence.
+		for i := len(n.children) - 1; i >= 0; i-- {
+			ni := n.children[i]
+			if ni.kind == aliasNode {
+				an, ok := d.doc.anchors[ni.value]
+				if ok && an.kind != mappingNode {
+					failWantMap()
+				}
+			} else if ni.kind != mappingNode {
+				failWantMap()
+			}
+			d.unmarshal(ni, out)
+		}
+	default:
+		failWantMap()
+	}
+}
+
+func isMerge(n *node) bool {
+	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
+}

--- a/vendor/gopkg.in/yaml.v2/decode_test.go
+++ b/vendor/gopkg.in/yaml.v2/decode_test.go
@@ -1,0 +1,966 @@
+package yaml_test
+
+import (
+	"errors"
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+	"math"
+	"net"
+	"reflect"
+	"strings"
+	"time"
+)
+
+var unmarshalIntTest = 123
+
+var unmarshalTests = []struct {
+	data  string
+	value interface{}
+}{
+	{
+		"",
+		&struct{}{},
+	}, {
+		"{}", &struct{}{},
+	}, {
+		"v: hi",
+		map[string]string{"v": "hi"},
+	}, {
+		"v: hi", map[string]interface{}{"v": "hi"},
+	}, {
+		"v: true",
+		map[string]string{"v": "true"},
+	}, {
+		"v: true",
+		map[string]interface{}{"v": true},
+	}, {
+		"v: 10",
+		map[string]interface{}{"v": 10},
+	}, {
+		"v: 0b10",
+		map[string]interface{}{"v": 2},
+	}, {
+		"v: 0xA",
+		map[string]interface{}{"v": 10},
+	}, {
+		"v: 4294967296",
+		map[string]int64{"v": 4294967296},
+	}, {
+		"v: 0.1",
+		map[string]interface{}{"v": 0.1},
+	}, {
+		"v: .1",
+		map[string]interface{}{"v": 0.1},
+	}, {
+		"v: .Inf",
+		map[string]interface{}{"v": math.Inf(+1)},
+	}, {
+		"v: -.Inf",
+		map[string]interface{}{"v": math.Inf(-1)},
+	}, {
+		"v: -10",
+		map[string]interface{}{"v": -10},
+	}, {
+		"v: -.1",
+		map[string]interface{}{"v": -0.1},
+	},
+
+	// Simple values.
+	{
+		"123",
+		&unmarshalIntTest,
+	},
+
+	// Floats from spec
+	{
+		"canonical: 6.8523e+5",
+		map[string]interface{}{"canonical": 6.8523e+5},
+	}, {
+		"expo: 685.230_15e+03",
+		map[string]interface{}{"expo": 685.23015e+03},
+	}, {
+		"fixed: 685_230.15",
+		map[string]interface{}{"fixed": 685230.15},
+	}, {
+		"neginf: -.inf",
+		map[string]interface{}{"neginf": math.Inf(-1)},
+	}, {
+		"fixed: 685_230.15",
+		map[string]float64{"fixed": 685230.15},
+	},
+	//{"sexa: 190:20:30.15", map[string]interface{}{"sexa": 0}}, // Unsupported
+	//{"notanum: .NaN", map[string]interface{}{"notanum": math.NaN()}}, // Equality of NaN fails.
+
+	// Bools from spec
+	{
+		"canonical: y",
+		map[string]interface{}{"canonical": true},
+	}, {
+		"answer: NO",
+		map[string]interface{}{"answer": false},
+	}, {
+		"logical: True",
+		map[string]interface{}{"logical": true},
+	}, {
+		"option: on",
+		map[string]interface{}{"option": true},
+	}, {
+		"option: on",
+		map[string]bool{"option": true},
+	},
+	// Ints from spec
+	{
+		"canonical: 685230",
+		map[string]interface{}{"canonical": 685230},
+	}, {
+		"decimal: +685_230",
+		map[string]interface{}{"decimal": 685230},
+	}, {
+		"octal: 02472256",
+		map[string]interface{}{"octal": 685230},
+	}, {
+		"hexa: 0x_0A_74_AE",
+		map[string]interface{}{"hexa": 685230},
+	}, {
+		"bin: 0b1010_0111_0100_1010_1110",
+		map[string]interface{}{"bin": 685230},
+	}, {
+		"bin: -0b101010",
+		map[string]interface{}{"bin": -42},
+	}, {
+		"decimal: +685_230",
+		map[string]int{"decimal": 685230},
+	},
+
+	//{"sexa: 190:20:30", map[string]interface{}{"sexa": 0}}, // Unsupported
+
+	// Nulls from spec
+	{
+		"empty:",
+		map[string]interface{}{"empty": nil},
+	}, {
+		"canonical: ~",
+		map[string]interface{}{"canonical": nil},
+	}, {
+		"english: null",
+		map[string]interface{}{"english": nil},
+	}, {
+		"~: null key",
+		map[interface{}]string{nil: "null key"},
+	}, {
+		"empty:",
+		map[string]*bool{"empty": nil},
+	},
+
+	// Flow sequence
+	{
+		"seq: [A,B]",
+		map[string]interface{}{"seq": []interface{}{"A", "B"}},
+	}, {
+		"seq: [A,B,C,]",
+		map[string][]string{"seq": []string{"A", "B", "C"}},
+	}, {
+		"seq: [A,1,C]",
+		map[string][]string{"seq": []string{"A", "1", "C"}},
+	}, {
+		"seq: [A,1,C]",
+		map[string][]int{"seq": []int{1}},
+	}, {
+		"seq: [A,1,C]",
+		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
+	},
+	// Block sequence
+	{
+		"seq:\n - A\n - B",
+		map[string]interface{}{"seq": []interface{}{"A", "B"}},
+	}, {
+		"seq:\n - A\n - B\n - C",
+		map[string][]string{"seq": []string{"A", "B", "C"}},
+	}, {
+		"seq:\n - A\n - 1\n - C",
+		map[string][]string{"seq": []string{"A", "1", "C"}},
+	}, {
+		"seq:\n - A\n - 1\n - C",
+		map[string][]int{"seq": []int{1}},
+	}, {
+		"seq:\n - A\n - 1\n - C",
+		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
+	},
+
+	// Literal block scalar
+	{
+		"scalar: | # Comment\n\n literal\n\n \ttext\n\n",
+		map[string]string{"scalar": "\nliteral\n\n\ttext\n"},
+	},
+
+	// Folded block scalar
+	{
+		"scalar: > # Comment\n\n folded\n line\n \n next\n line\n  * one\n  * two\n\n last\n line\n\n",
+		map[string]string{"scalar": "\nfolded line\nnext line\n * one\n * two\n\nlast line\n"},
+	},
+
+	// Map inside interface with no type hints.
+	{
+		"a: {b: c}",
+		map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": "c"}},
+	},
+
+	// Structs and type conversions.
+	{
+		"hello: world",
+		&struct{ Hello string }{"world"},
+	}, {
+		"a: {b: c}",
+		&struct{ A struct{ B string } }{struct{ B string }{"c"}},
+	}, {
+		"a: {b: c}",
+		&struct{ A *struct{ B string } }{&struct{ B string }{"c"}},
+	}, {
+		"a: {b: c}",
+		&struct{ A map[string]string }{map[string]string{"b": "c"}},
+	}, {
+		"a: {b: c}",
+		&struct{ A *map[string]string }{&map[string]string{"b": "c"}},
+	}, {
+		"a:",
+		&struct{ A map[string]string }{},
+	}, {
+		"a: 1",
+		&struct{ A int }{1},
+	}, {
+		"a: 1",
+		&struct{ A float64 }{1},
+	}, {
+		"a: 1.0",
+		&struct{ A int }{1},
+	}, {
+		"a: 1.0",
+		&struct{ A uint }{1},
+	}, {
+		"a: [1, 2]",
+		&struct{ A []int }{[]int{1, 2}},
+	}, {
+		"a: 1",
+		&struct{ B int }{0},
+	}, {
+		"a: 1",
+		&struct {
+			B int "a"
+		}{1},
+	}, {
+		"a: y",
+		&struct{ A bool }{true},
+	},
+
+	// Some cross type conversions
+	{
+		"v: 42",
+		map[string]uint{"v": 42},
+	}, {
+		"v: -42",
+		map[string]uint{},
+	}, {
+		"v: 4294967296",
+		map[string]uint64{"v": 4294967296},
+	}, {
+		"v: -4294967296",
+		map[string]uint64{},
+	},
+
+	// int
+	{
+		"int_max: 2147483647",
+		map[string]int{"int_max": math.MaxInt32},
+	},
+	{
+		"int_min: -2147483648",
+		map[string]int{"int_min": math.MinInt32},
+	},
+	{
+		"int_overflow: 9223372036854775808", // math.MaxInt64 + 1
+		map[string]int{},
+	},
+
+	// int64
+	{
+		"int64_max: 9223372036854775807",
+		map[string]int64{"int64_max": math.MaxInt64},
+	},
+	{
+		"int64_max_base2: 0b111111111111111111111111111111111111111111111111111111111111111",
+		map[string]int64{"int64_max_base2": math.MaxInt64},
+	},
+	{
+		"int64_min: -9223372036854775808",
+		map[string]int64{"int64_min": math.MinInt64},
+	},
+	{
+		"int64_neg_base2: -0b111111111111111111111111111111111111111111111111111111111111111",
+		map[string]int64{"int64_neg_base2": -math.MaxInt64},
+	},
+	{
+		"int64_overflow: 9223372036854775808", // math.MaxInt64 + 1
+		map[string]int64{},
+	},
+
+	// uint
+	{
+		"uint_min: 0",
+		map[string]uint{"uint_min": 0},
+	},
+	{
+		"uint_max: 4294967295",
+		map[string]uint{"uint_max": math.MaxUint32},
+	},
+	{
+		"uint_underflow: -1",
+		map[string]uint{},
+	},
+
+	// uint64
+	{
+		"uint64_min: 0",
+		map[string]uint{"uint64_min": 0},
+	},
+	{
+		"uint64_max: 18446744073709551615",
+		map[string]uint64{"uint64_max": math.MaxUint64},
+	},
+	{
+		"uint64_max_base2: 0b1111111111111111111111111111111111111111111111111111111111111111",
+		map[string]uint64{"uint64_max_base2": math.MaxUint64},
+	},
+	{
+		"uint64_maxint64: 9223372036854775807",
+		map[string]uint64{"uint64_maxint64": math.MaxInt64},
+	},
+	{
+		"uint64_underflow: -1",
+		map[string]uint64{},
+	},
+
+	// float32
+	{
+		"float32_max: 3.40282346638528859811704183484516925440e+38",
+		map[string]float32{"float32_max": math.MaxFloat32},
+	},
+	{
+		"float32_nonzero: 1.401298464324817070923729583289916131280e-45",
+		map[string]float32{"float32_nonzero": math.SmallestNonzeroFloat32},
+	},
+	{
+		"float32_maxuint64: 18446744073709551615",
+		map[string]float32{"float32_maxuint64": float32(math.MaxUint64)},
+	},
+	{
+		"float32_maxuint64+1: 18446744073709551616",
+		map[string]float32{"float32_maxuint64+1": float32(math.MaxUint64 + 1)},
+	},
+
+	// float64
+	{
+		"float64_max: 1.797693134862315708145274237317043567981e+308",
+		map[string]float64{"float64_max": math.MaxFloat64},
+	},
+	{
+		"float64_nonzero: 4.940656458412465441765687928682213723651e-324",
+		map[string]float64{"float64_nonzero": math.SmallestNonzeroFloat64},
+	},
+	{
+		"float64_maxuint64: 18446744073709551615",
+		map[string]float64{"float64_maxuint64": float64(math.MaxUint64)},
+	},
+	{
+		"float64_maxuint64+1: 18446744073709551616",
+		map[string]float64{"float64_maxuint64+1": float64(math.MaxUint64 + 1)},
+	},
+
+	// Overflow cases.
+	{
+		"v: 4294967297",
+		map[string]int32{},
+	}, {
+		"v: 128",
+		map[string]int8{},
+	},
+
+	// Quoted values.
+	{
+		"'1': '\"2\"'",
+		map[interface{}]interface{}{"1": "\"2\""},
+	}, {
+		"v:\n- A\n- 'B\n\n  C'\n",
+		map[string][]string{"v": []string{"A", "B\nC"}},
+	},
+
+	// Explicit tags.
+	{
+		"v: !!float '1.1'",
+		map[string]interface{}{"v": 1.1},
+	}, {
+		"v: !!null ''",
+		map[string]interface{}{"v": nil},
+	}, {
+		"%TAG !y! tag:yaml.org,2002:\n---\nv: !y!int '1'",
+		map[string]interface{}{"v": 1},
+	},
+
+	// Anchors and aliases.
+	{
+		"a: &x 1\nb: &y 2\nc: *x\nd: *y\n",
+		&struct{ A, B, C, D int }{1, 2, 1, 2},
+	}, {
+		"a: &a {c: 1}\nb: *a",
+		&struct {
+			A, B struct {
+				C int
+			}
+		}{struct{ C int }{1}, struct{ C int }{1}},
+	}, {
+		"a: &a [1, 2]\nb: *a",
+		&struct{ B []int }{[]int{1, 2}},
+	}, {
+		"b: *a\na: &a {c: 1}",
+		&struct {
+			A, B struct {
+				C int
+			}
+		}{struct{ C int }{1}, struct{ C int }{1}},
+	},
+
+	// Bug #1133337
+	{
+		"foo: ''",
+		map[string]*string{"foo": new(string)},
+	}, {
+		"foo: null",
+		map[string]string{"foo": ""},
+	}, {
+		"foo: null",
+		map[string]interface{}{"foo": nil},
+	},
+
+	// Ignored field
+	{
+		"a: 1\nb: 2\n",
+		&struct {
+			A int
+			B int "-"
+		}{1, 0},
+	},
+
+	// Bug #1191981
+	{
+		"" +
+			"%YAML 1.1\n" +
+			"--- !!str\n" +
+			`"Generic line break (no glyph)\n\` + "\n" +
+			` Generic line break (glyphed)\n\` + "\n" +
+			` Line separator\u2028\` + "\n" +
+			` Paragraph separator\u2029"` + "\n",
+		"" +
+			"Generic line break (no glyph)\n" +
+			"Generic line break (glyphed)\n" +
+			"Line separator\u2028Paragraph separator\u2029",
+	},
+
+	// Struct inlining
+	{
+		"a: 1\nb: 2\nc: 3\n",
+		&struct {
+			A int
+			C inlineB `yaml:",inline"`
+		}{1, inlineB{2, inlineC{3}}},
+	},
+
+	// Map inlining
+	{
+		"a: 1\nb: 2\nc: 3\n",
+		&struct {
+			A int
+			C map[string]int `yaml:",inline"`
+		}{1, map[string]int{"b": 2, "c": 3}},
+	},
+
+	// bug 1243827
+	{
+		"a: -b_c",
+		map[string]interface{}{"a": "-b_c"},
+	},
+	{
+		"a: +b_c",
+		map[string]interface{}{"a": "+b_c"},
+	},
+	{
+		"a: 50cent_of_dollar",
+		map[string]interface{}{"a": "50cent_of_dollar"},
+	},
+
+	// Duration
+	{
+		"a: 3s",
+		map[string]time.Duration{"a": 3 * time.Second},
+	},
+
+	// Issue #24.
+	{
+		"a: <foo>",
+		map[string]string{"a": "<foo>"},
+	},
+
+	// Base 60 floats are obsolete and unsupported.
+	{
+		"a: 1:1\n",
+		map[string]string{"a": "1:1"},
+	},
+
+	// Binary data.
+	{
+		"a: !!binary gIGC\n",
+		map[string]string{"a": "\x80\x81\x82"},
+	}, {
+		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
+		map[string]string{"a": strings.Repeat("\x90", 54)},
+	}, {
+		"a: !!binary |\n  " + strings.Repeat("A", 70) + "\n  ==\n",
+		map[string]string{"a": strings.Repeat("\x00", 52)},
+	},
+
+	// Ordered maps.
+	{
+		"{b: 2, a: 1, d: 4, c: 3, sub: {e: 5}}",
+		&yaml.MapSlice{{"b", 2}, {"a", 1}, {"d", 4}, {"c", 3}, {"sub", yaml.MapSlice{{"e", 5}}}},
+	},
+
+	// Issue #39.
+	{
+		"a:\n b:\n  c: d\n",
+		map[string]struct{ B interface{} }{"a": {map[interface{}]interface{}{"c": "d"}}},
+	},
+
+	// Custom map type.
+	{
+		"a: {b: c}",
+		M{"a": M{"b": "c"}},
+	},
+
+	// Support encoding.TextUnmarshaler.
+	{
+		"a: 1.2.3.4\n",
+		map[string]net.IP{"a": net.IPv4(1, 2, 3, 4)},
+	},
+	{
+		"a: 2015-02-24T18:19:39Z\n",
+		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+	},
+
+	// Encode empty lists as zero-length slices.
+	{
+		"a: []",
+		&struct{ A []int }{[]int{}},
+	},
+}
+
+type M map[interface{}]interface{}
+
+type inlineB struct {
+	B       int
+	inlineC `yaml:",inline"`
+}
+
+type inlineC struct {
+	C int
+}
+
+func (s *S) TestUnmarshal(c *C) {
+	for _, item := range unmarshalTests {
+		t := reflect.ValueOf(item.value).Type()
+		var value interface{}
+		switch t.Kind() {
+		case reflect.Map:
+			value = reflect.MakeMap(t).Interface()
+		case reflect.String:
+			value = reflect.New(t).Interface()
+		case reflect.Ptr:
+			value = reflect.New(t.Elem()).Interface()
+		default:
+			c.Fatalf("missing case for %s", t)
+		}
+		err := yaml.Unmarshal([]byte(item.data), value)
+		if _, ok := err.(*yaml.TypeError); !ok {
+			c.Assert(err, IsNil)
+		}
+		if t.Kind() == reflect.String {
+			c.Assert(*value.(*string), Equals, item.value)
+		} else {
+			c.Assert(value, DeepEquals, item.value)
+		}
+	}
+}
+
+func (s *S) TestUnmarshalNaN(c *C) {
+	value := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte("notanum: .NaN"), &value)
+	c.Assert(err, IsNil)
+	c.Assert(math.IsNaN(value["notanum"].(float64)), Equals, true)
+}
+
+var unmarshalErrorTests = []struct {
+	data, error string
+}{
+	{"v: !!float 'error'", "yaml: cannot decode !!str `error` as a !!float"},
+	{"v: [A,", "yaml: line 1: did not find expected node content"},
+	{"v:\n- [A,", "yaml: line 2: did not find expected node content"},
+	{"a: *b\n", "yaml: unknown anchor 'b' referenced"},
+	{"a: &a\n  b: *a\n", "yaml: anchor 'a' value contains itself"},
+	{"value: -", "yaml: block sequence entries are not allowed in this context"},
+	{"a: !!binary ==", "yaml: !!binary value contains invalid base64 data"},
+	{"{[.]}", `yaml: invalid map key: \[\]interface \{\}\{"\."\}`},
+	{"{{.}}", `yaml: invalid map key: map\[interface\ \{\}\]interface \{\}\{".":interface \{\}\(nil\)\}`},
+}
+
+func (s *S) TestUnmarshalErrors(c *C) {
+	for _, item := range unmarshalErrorTests {
+		var value interface{}
+		err := yaml.Unmarshal([]byte(item.data), &value)
+		c.Assert(err, ErrorMatches, item.error, Commentf("Partial unmarshal: %#v", value))
+	}
+}
+
+var unmarshalerTests = []struct {
+	data, tag string
+	value     interface{}
+}{
+	{"_: {hi: there}", "!!map", map[interface{}]interface{}{"hi": "there"}},
+	{"_: [1,A]", "!!seq", []interface{}{1, "A"}},
+	{"_: 10", "!!int", 10},
+	{"_: null", "!!null", nil},
+	{`_: BAR!`, "!!str", "BAR!"},
+	{`_: "BAR!"`, "!!str", "BAR!"},
+	{"_: !!foo 'BAR!'", "!!foo", "BAR!"},
+}
+
+var unmarshalerResult = map[int]error{}
+
+type unmarshalerType struct {
+	value interface{}
+}
+
+func (o *unmarshalerType) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	if err := unmarshal(&o.value); err != nil {
+		return err
+	}
+	if i, ok := o.value.(int); ok {
+		if result, ok := unmarshalerResult[i]; ok {
+			return result
+		}
+	}
+	return nil
+}
+
+type unmarshalerPointer struct {
+	Field *unmarshalerType "_"
+}
+
+type unmarshalerValue struct {
+	Field unmarshalerType "_"
+}
+
+func (s *S) TestUnmarshalerPointerField(c *C) {
+	for _, item := range unmarshalerTests {
+		obj := &unmarshalerPointer{}
+		err := yaml.Unmarshal([]byte(item.data), obj)
+		c.Assert(err, IsNil)
+		if item.value == nil {
+			c.Assert(obj.Field, IsNil)
+		} else {
+			c.Assert(obj.Field, NotNil, Commentf("Pointer not initialized (%#v)", item.value))
+			c.Assert(obj.Field.value, DeepEquals, item.value)
+		}
+	}
+}
+
+func (s *S) TestUnmarshalerValueField(c *C) {
+	for _, item := range unmarshalerTests {
+		obj := &unmarshalerValue{}
+		err := yaml.Unmarshal([]byte(item.data), obj)
+		c.Assert(err, IsNil)
+		c.Assert(obj.Field, NotNil, Commentf("Pointer not initialized (%#v)", item.value))
+		c.Assert(obj.Field.value, DeepEquals, item.value)
+	}
+}
+
+func (s *S) TestUnmarshalerWholeDocument(c *C) {
+	obj := &unmarshalerType{}
+	err := yaml.Unmarshal([]byte(unmarshalerTests[0].data), obj)
+	c.Assert(err, IsNil)
+	value, ok := obj.value.(map[interface{}]interface{})
+	c.Assert(ok, Equals, true, Commentf("value: %#v", obj.value))
+	c.Assert(value["_"], DeepEquals, unmarshalerTests[0].value)
+}
+
+func (s *S) TestUnmarshalerTypeError(c *C) {
+	unmarshalerResult[2] = &yaml.TypeError{[]string{"foo"}}
+	unmarshalerResult[4] = &yaml.TypeError{[]string{"bar"}}
+	defer func() {
+		delete(unmarshalerResult, 2)
+		delete(unmarshalerResult, 4)
+	}()
+
+	type T struct {
+		Before int
+		After  int
+		M      map[string]*unmarshalerType
+	}
+	var v T
+	data := `{before: A, m: {abc: 1, def: 2, ghi: 3, jkl: 4}, after: B}`
+	err := yaml.Unmarshal([]byte(data), &v)
+	c.Assert(err, ErrorMatches, ""+
+		"yaml: unmarshal errors:\n"+
+		"  line 1: cannot unmarshal !!str `A` into int\n"+
+		"  foo\n"+
+		"  bar\n"+
+		"  line 1: cannot unmarshal !!str `B` into int")
+	c.Assert(v.M["abc"], NotNil)
+	c.Assert(v.M["def"], IsNil)
+	c.Assert(v.M["ghi"], NotNil)
+	c.Assert(v.M["jkl"], IsNil)
+
+	c.Assert(v.M["abc"].value, Equals, 1)
+	c.Assert(v.M["ghi"].value, Equals, 3)
+}
+
+type proxyTypeError struct{}
+
+func (v *proxyTypeError) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	var a int32
+	var b int64
+	if err := unmarshal(&s); err != nil {
+		panic(err)
+	}
+	if s == "a" {
+		if err := unmarshal(&b); err == nil {
+			panic("should have failed")
+		}
+		return unmarshal(&a)
+	}
+	if err := unmarshal(&a); err == nil {
+		panic("should have failed")
+	}
+	return unmarshal(&b)
+}
+
+func (s *S) TestUnmarshalerTypeErrorProxying(c *C) {
+	type T struct {
+		Before int
+		After  int
+		M      map[string]*proxyTypeError
+	}
+	var v T
+	data := `{before: A, m: {abc: a, def: b}, after: B}`
+	err := yaml.Unmarshal([]byte(data), &v)
+	c.Assert(err, ErrorMatches, ""+
+		"yaml: unmarshal errors:\n"+
+		"  line 1: cannot unmarshal !!str `A` into int\n"+
+		"  line 1: cannot unmarshal !!str `a` into int32\n"+
+		"  line 1: cannot unmarshal !!str `b` into int64\n"+
+		"  line 1: cannot unmarshal !!str `B` into int")
+}
+
+type failingUnmarshaler struct{}
+
+var failingErr = errors.New("failingErr")
+
+func (ft *failingUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return failingErr
+}
+
+func (s *S) TestUnmarshalerError(c *C) {
+	err := yaml.Unmarshal([]byte("a: b"), &failingUnmarshaler{})
+	c.Assert(err, Equals, failingErr)
+}
+
+type sliceUnmarshaler []int
+
+func (su *sliceUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var slice []int
+	err := unmarshal(&slice)
+	if err == nil {
+		*su = slice
+		return nil
+	}
+
+	var intVal int
+	err = unmarshal(&intVal)
+	if err == nil {
+		*su = []int{intVal}
+		return nil
+	}
+
+	return err
+}
+
+func (s *S) TestUnmarshalerRetry(c *C) {
+	var su sliceUnmarshaler
+	err := yaml.Unmarshal([]byte("[1, 2, 3]"), &su)
+	c.Assert(err, IsNil)
+	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1, 2, 3}))
+
+	err = yaml.Unmarshal([]byte("1"), &su)
+	c.Assert(err, IsNil)
+	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1}))
+}
+
+// From http://yaml.org/type/merge.html
+var mergeTests = `
+anchors:
+  list:
+    - &CENTER { "x": 1, "y": 2 }
+    - &LEFT   { "x": 0, "y": 2 }
+    - &BIG    { "r": 10 }
+    - &SMALL  { "r": 1 }
+
+# All the following maps are equal:
+
+plain:
+  # Explicit keys
+  "x": 1
+  "y": 2
+  "r": 10
+  label: center/big
+
+mergeOne:
+  # Merge one map
+  << : *CENTER
+  "r": 10
+  label: center/big
+
+mergeMultiple:
+  # Merge multiple maps
+  << : [ *CENTER, *BIG ]
+  label: center/big
+
+override:
+  # Override
+  << : [ *BIG, *LEFT, *SMALL ]
+  "x": 1
+  label: center/big
+
+shortTag:
+  # Explicit short merge tag
+  !!merge "<<" : [ *CENTER, *BIG ]
+  label: center/big
+
+longTag:
+  # Explicit merge long tag
+  !<tag:yaml.org,2002:merge> "<<" : [ *CENTER, *BIG ]
+  label: center/big
+
+inlineMap:
+  # Inlined map 
+  << : {"x": 1, "y": 2, "r": 10}
+  label: center/big
+
+inlineSequenceMap:
+  # Inlined map in sequence
+  << : [ *CENTER, {"r": 10} ]
+  label: center/big
+`
+
+func (s *S) TestMerge(c *C) {
+	var want = map[interface{}]interface{}{
+		"x":     1,
+		"y":     2,
+		"r":     10,
+		"label": "center/big",
+	}
+
+	var m map[interface{}]interface{}
+	err := yaml.Unmarshal([]byte(mergeTests), &m)
+	c.Assert(err, IsNil)
+	for name, test := range m {
+		if name == "anchors" {
+			continue
+		}
+		c.Assert(test, DeepEquals, want, Commentf("test %q failed", name))
+	}
+}
+
+func (s *S) TestMergeStruct(c *C) {
+	type Data struct {
+		X, Y, R int
+		Label   string
+	}
+	want := Data{1, 2, 10, "center/big"}
+
+	var m map[string]Data
+	err := yaml.Unmarshal([]byte(mergeTests), &m)
+	c.Assert(err, IsNil)
+	for name, test := range m {
+		if name == "anchors" {
+			continue
+		}
+		c.Assert(test, Equals, want, Commentf("test %q failed", name))
+	}
+}
+
+var unmarshalNullTests = []func() interface{}{
+	func() interface{} { var v interface{}; v = "v"; return &v },
+	func() interface{} { var s = "s"; return &s },
+	func() interface{} { var s = "s"; sptr := &s; return &sptr },
+	func() interface{} { var i = 1; return &i },
+	func() interface{} { var i = 1; iptr := &i; return &iptr },
+	func() interface{} { m := map[string]int{"s": 1}; return &m },
+	func() interface{} { m := map[string]int{"s": 1}; return m },
+}
+
+func (s *S) TestUnmarshalNull(c *C) {
+	for _, test := range unmarshalNullTests {
+		item := test()
+		zero := reflect.Zero(reflect.TypeOf(item).Elem()).Interface()
+		err := yaml.Unmarshal([]byte("null"), item)
+		c.Assert(err, IsNil)
+		if reflect.TypeOf(item).Kind() == reflect.Map {
+			c.Assert(reflect.ValueOf(item).Interface(), DeepEquals, reflect.MakeMap(reflect.TypeOf(item)).Interface())
+		} else {
+			c.Assert(reflect.ValueOf(item).Elem().Interface(), DeepEquals, zero)
+		}
+	}
+}
+
+func (s *S) TestUnmarshalSliceOnPreset(c *C) {
+	// Issue #48.
+	v := struct{ A []int }{[]int{1}}
+	yaml.Unmarshal([]byte("a: [2]"), &v)
+	c.Assert(v.A, DeepEquals, []int{2})
+}
+
+//var data []byte
+//func init() {
+//	var err error
+//	data, err = ioutil.ReadFile("/tmp/file.yaml")
+//	if err != nil {
+//		panic(err)
+//	}
+//}
+//
+//func (s *S) BenchmarkUnmarshal(c *C) {
+//	var err error
+//	for i := 0; i < c.N; i++ {
+//		var v map[string]interface{}
+//		err = yaml.Unmarshal(data, &v)
+//	}
+//	if err != nil {
+//		panic(err)
+//	}
+//}
+//
+//func (s *S) BenchmarkMarshal(c *C) {
+//	var v map[string]interface{}
+//	yaml.Unmarshal(data, &v)
+//	c.ResetTimer()
+//	for i := 0; i < c.N; i++ {
+//		yaml.Marshal(&v)
+//	}
+//}

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -1,0 +1,1685 @@
+package yaml
+
+import (
+	"bytes"
+)
+
+// Flush the buffer if needed.
+func flush(emitter *yaml_emitter_t) bool {
+	if emitter.buffer_pos+5 >= len(emitter.buffer) {
+		return yaml_emitter_flush(emitter)
+	}
+	return true
+}
+
+// Put a character to the output buffer.
+func put(emitter *yaml_emitter_t, value byte) bool {
+	if emitter.buffer_pos+5 >= len(emitter.buffer) && !yaml_emitter_flush(emitter) {
+		return false
+	}
+	emitter.buffer[emitter.buffer_pos] = value
+	emitter.buffer_pos++
+	emitter.column++
+	return true
+}
+
+// Put a line break to the output buffer.
+func put_break(emitter *yaml_emitter_t) bool {
+	if emitter.buffer_pos+5 >= len(emitter.buffer) && !yaml_emitter_flush(emitter) {
+		return false
+	}
+	switch emitter.line_break {
+	case yaml_CR_BREAK:
+		emitter.buffer[emitter.buffer_pos] = '\r'
+		emitter.buffer_pos += 1
+	case yaml_LN_BREAK:
+		emitter.buffer[emitter.buffer_pos] = '\n'
+		emitter.buffer_pos += 1
+	case yaml_CRLN_BREAK:
+		emitter.buffer[emitter.buffer_pos+0] = '\r'
+		emitter.buffer[emitter.buffer_pos+1] = '\n'
+		emitter.buffer_pos += 2
+	default:
+		panic("unknown line break setting")
+	}
+	emitter.column = 0
+	emitter.line++
+	return true
+}
+
+// Copy a character from a string into buffer.
+func write(emitter *yaml_emitter_t, s []byte, i *int) bool {
+	if emitter.buffer_pos+5 >= len(emitter.buffer) && !yaml_emitter_flush(emitter) {
+		return false
+	}
+	p := emitter.buffer_pos
+	w := width(s[*i])
+	switch w {
+	case 4:
+		emitter.buffer[p+3] = s[*i+3]
+		fallthrough
+	case 3:
+		emitter.buffer[p+2] = s[*i+2]
+		fallthrough
+	case 2:
+		emitter.buffer[p+1] = s[*i+1]
+		fallthrough
+	case 1:
+		emitter.buffer[p+0] = s[*i+0]
+	default:
+		panic("unknown character width")
+	}
+	emitter.column++
+	emitter.buffer_pos += w
+	*i += w
+	return true
+}
+
+// Write a whole string into buffer.
+func write_all(emitter *yaml_emitter_t, s []byte) bool {
+	for i := 0; i < len(s); {
+		if !write(emitter, s, &i) {
+			return false
+		}
+	}
+	return true
+}
+
+// Copy a line break character from a string into buffer.
+func write_break(emitter *yaml_emitter_t, s []byte, i *int) bool {
+	if s[*i] == '\n' {
+		if !put_break(emitter) {
+			return false
+		}
+		*i++
+	} else {
+		if !write(emitter, s, i) {
+			return false
+		}
+		emitter.column = 0
+		emitter.line++
+	}
+	return true
+}
+
+// Set an emitter error and return false.
+func yaml_emitter_set_emitter_error(emitter *yaml_emitter_t, problem string) bool {
+	emitter.error = yaml_EMITTER_ERROR
+	emitter.problem = problem
+	return false
+}
+
+// Emit an event.
+func yaml_emitter_emit(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	emitter.events = append(emitter.events, *event)
+	for !yaml_emitter_need_more_events(emitter) {
+		event := &emitter.events[emitter.events_head]
+		if !yaml_emitter_analyze_event(emitter, event) {
+			return false
+		}
+		if !yaml_emitter_state_machine(emitter, event) {
+			return false
+		}
+		yaml_event_delete(event)
+		emitter.events_head++
+	}
+	return true
+}
+
+// Check if we need to accumulate more events before emitting.
+//
+// We accumulate extra
+//  - 1 event for DOCUMENT-START
+//  - 2 events for SEQUENCE-START
+//  - 3 events for MAPPING-START
+//
+func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
+	if emitter.events_head == len(emitter.events) {
+		return true
+	}
+	var accumulate int
+	switch emitter.events[emitter.events_head].typ {
+	case yaml_DOCUMENT_START_EVENT:
+		accumulate = 1
+		break
+	case yaml_SEQUENCE_START_EVENT:
+		accumulate = 2
+		break
+	case yaml_MAPPING_START_EVENT:
+		accumulate = 3
+		break
+	default:
+		return false
+	}
+	if len(emitter.events)-emitter.events_head > accumulate {
+		return false
+	}
+	var level int
+	for i := emitter.events_head; i < len(emitter.events); i++ {
+		switch emitter.events[i].typ {
+		case yaml_STREAM_START_EVENT, yaml_DOCUMENT_START_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT:
+			level++
+		case yaml_STREAM_END_EVENT, yaml_DOCUMENT_END_EVENT, yaml_SEQUENCE_END_EVENT, yaml_MAPPING_END_EVENT:
+			level--
+		}
+		if level == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Append a directive to the directives stack.
+func yaml_emitter_append_tag_directive(emitter *yaml_emitter_t, value *yaml_tag_directive_t, allow_duplicates bool) bool {
+	for i := 0; i < len(emitter.tag_directives); i++ {
+		if bytes.Equal(value.handle, emitter.tag_directives[i].handle) {
+			if allow_duplicates {
+				return true
+			}
+			return yaml_emitter_set_emitter_error(emitter, "duplicate %TAG directive")
+		}
+	}
+
+	// [Go] Do we actually need to copy this given garbage collection
+	// and the lack of deallocating destructors?
+	tag_copy := yaml_tag_directive_t{
+		handle: make([]byte, len(value.handle)),
+		prefix: make([]byte, len(value.prefix)),
+	}
+	copy(tag_copy.handle, value.handle)
+	copy(tag_copy.prefix, value.prefix)
+	emitter.tag_directives = append(emitter.tag_directives, tag_copy)
+	return true
+}
+
+// Increase the indentation level.
+func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool) bool {
+	emitter.indents = append(emitter.indents, emitter.indent)
+	if emitter.indent < 0 {
+		if flow {
+			emitter.indent = emitter.best_indent
+		} else {
+			emitter.indent = 0
+		}
+	} else if !indentless {
+		emitter.indent += emitter.best_indent
+	}
+	return true
+}
+
+// State dispatcher.
+func yaml_emitter_state_machine(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	switch emitter.state {
+	default:
+	case yaml_EMIT_STREAM_START_STATE:
+		return yaml_emitter_emit_stream_start(emitter, event)
+
+	case yaml_EMIT_FIRST_DOCUMENT_START_STATE:
+		return yaml_emitter_emit_document_start(emitter, event, true)
+
+	case yaml_EMIT_DOCUMENT_START_STATE:
+		return yaml_emitter_emit_document_start(emitter, event, false)
+
+	case yaml_EMIT_DOCUMENT_CONTENT_STATE:
+		return yaml_emitter_emit_document_content(emitter, event)
+
+	case yaml_EMIT_DOCUMENT_END_STATE:
+		return yaml_emitter_emit_document_end(emitter, event)
+
+	case yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE:
+		return yaml_emitter_emit_flow_sequence_item(emitter, event, true)
+
+	case yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE:
+		return yaml_emitter_emit_flow_sequence_item(emitter, event, false)
+
+	case yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE:
+		return yaml_emitter_emit_flow_mapping_key(emitter, event, true)
+
+	case yaml_EMIT_FLOW_MAPPING_KEY_STATE:
+		return yaml_emitter_emit_flow_mapping_key(emitter, event, false)
+
+	case yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE:
+		return yaml_emitter_emit_flow_mapping_value(emitter, event, true)
+
+	case yaml_EMIT_FLOW_MAPPING_VALUE_STATE:
+		return yaml_emitter_emit_flow_mapping_value(emitter, event, false)
+
+	case yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE:
+		return yaml_emitter_emit_block_sequence_item(emitter, event, true)
+
+	case yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE:
+		return yaml_emitter_emit_block_sequence_item(emitter, event, false)
+
+	case yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE:
+		return yaml_emitter_emit_block_mapping_key(emitter, event, true)
+
+	case yaml_EMIT_BLOCK_MAPPING_KEY_STATE:
+		return yaml_emitter_emit_block_mapping_key(emitter, event, false)
+
+	case yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE:
+		return yaml_emitter_emit_block_mapping_value(emitter, event, true)
+
+	case yaml_EMIT_BLOCK_MAPPING_VALUE_STATE:
+		return yaml_emitter_emit_block_mapping_value(emitter, event, false)
+
+	case yaml_EMIT_END_STATE:
+		return yaml_emitter_set_emitter_error(emitter, "expected nothing after STREAM-END")
+	}
+	panic("invalid emitter state")
+}
+
+// Expect STREAM-START.
+func yaml_emitter_emit_stream_start(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if event.typ != yaml_STREAM_START_EVENT {
+		return yaml_emitter_set_emitter_error(emitter, "expected STREAM-START")
+	}
+	if emitter.encoding == yaml_ANY_ENCODING {
+		emitter.encoding = event.encoding
+		if emitter.encoding == yaml_ANY_ENCODING {
+			emitter.encoding = yaml_UTF8_ENCODING
+		}
+	}
+	if emitter.best_indent < 2 || emitter.best_indent > 9 {
+		emitter.best_indent = 2
+	}
+	if emitter.best_width >= 0 && emitter.best_width <= emitter.best_indent*2 {
+		emitter.best_width = 80
+	}
+	if emitter.best_width < 0 {
+		emitter.best_width = 1<<31 - 1
+	}
+	if emitter.line_break == yaml_ANY_BREAK {
+		emitter.line_break = yaml_LN_BREAK
+	}
+
+	emitter.indent = -1
+	emitter.line = 0
+	emitter.column = 0
+	emitter.whitespace = true
+	emitter.indention = true
+
+	if emitter.encoding != yaml_UTF8_ENCODING {
+		if !yaml_emitter_write_bom(emitter) {
+			return false
+		}
+	}
+	emitter.state = yaml_EMIT_FIRST_DOCUMENT_START_STATE
+	return true
+}
+
+// Expect DOCUMENT-START or STREAM-END.
+func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+
+	if event.typ == yaml_DOCUMENT_START_EVENT {
+
+		if event.version_directive != nil {
+			if !yaml_emitter_analyze_version_directive(emitter, event.version_directive) {
+				return false
+			}
+		}
+
+		for i := 0; i < len(event.tag_directives); i++ {
+			tag_directive := &event.tag_directives[i]
+			if !yaml_emitter_analyze_tag_directive(emitter, tag_directive) {
+				return false
+			}
+			if !yaml_emitter_append_tag_directive(emitter, tag_directive, false) {
+				return false
+			}
+		}
+
+		for i := 0; i < len(default_tag_directives); i++ {
+			tag_directive := &default_tag_directives[i]
+			if !yaml_emitter_append_tag_directive(emitter, tag_directive, true) {
+				return false
+			}
+		}
+
+		implicit := event.implicit
+		if !first || emitter.canonical {
+			implicit = false
+		}
+
+		if emitter.open_ended && (event.version_directive != nil || len(event.tag_directives) > 0) {
+			if !yaml_emitter_write_indicator(emitter, []byte("..."), true, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+
+		if event.version_directive != nil {
+			implicit = false
+			if !yaml_emitter_write_indicator(emitter, []byte("%YAML"), true, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indicator(emitter, []byte("1.1"), true, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+
+		if len(event.tag_directives) > 0 {
+			implicit = false
+			for i := 0; i < len(event.tag_directives); i++ {
+				tag_directive := &event.tag_directives[i]
+				if !yaml_emitter_write_indicator(emitter, []byte("%TAG"), true, false, false) {
+					return false
+				}
+				if !yaml_emitter_write_tag_handle(emitter, tag_directive.handle) {
+					return false
+				}
+				if !yaml_emitter_write_tag_content(emitter, tag_directive.prefix, true) {
+					return false
+				}
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+			}
+		}
+
+		if yaml_emitter_check_empty_document(emitter) {
+			implicit = false
+		}
+		if !implicit {
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+			if !yaml_emitter_write_indicator(emitter, []byte("---"), true, false, false) {
+				return false
+			}
+			if emitter.canonical {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+			}
+		}
+
+		emitter.state = yaml_EMIT_DOCUMENT_CONTENT_STATE
+		return true
+	}
+
+	if event.typ == yaml_STREAM_END_EVENT {
+		if emitter.open_ended {
+			if !yaml_emitter_write_indicator(emitter, []byte("..."), true, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+		if !yaml_emitter_flush(emitter) {
+			return false
+		}
+		emitter.state = yaml_EMIT_END_STATE
+		return true
+	}
+
+	return yaml_emitter_set_emitter_error(emitter, "expected DOCUMENT-START or STREAM-END")
+}
+
+// Expect the root node.
+func yaml_emitter_emit_document_content(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	emitter.states = append(emitter.states, yaml_EMIT_DOCUMENT_END_STATE)
+	return yaml_emitter_emit_node(emitter, event, true, false, false, false)
+}
+
+// Expect DOCUMENT-END.
+func yaml_emitter_emit_document_end(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if event.typ != yaml_DOCUMENT_END_EVENT {
+		return yaml_emitter_set_emitter_error(emitter, "expected DOCUMENT-END")
+	}
+	if !yaml_emitter_write_indent(emitter) {
+		return false
+	}
+	if !event.implicit {
+		// [Go] Allocate the slice elsewhere.
+		if !yaml_emitter_write_indicator(emitter, []byte("..."), true, false, false) {
+			return false
+		}
+		if !yaml_emitter_write_indent(emitter) {
+			return false
+		}
+	}
+	if !yaml_emitter_flush(emitter) {
+		return false
+	}
+	emitter.state = yaml_EMIT_DOCUMENT_START_STATE
+	emitter.tag_directives = emitter.tag_directives[:0]
+	return true
+}
+
+// Expect a flow item node.
+func yaml_emitter_emit_flow_sequence_item(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_write_indicator(emitter, []byte{'['}, true, true, false) {
+			return false
+		}
+		if !yaml_emitter_increase_indent(emitter, true, false) {
+			return false
+		}
+		emitter.flow_level++
+	}
+
+	if event.typ == yaml_SEQUENCE_END_EVENT {
+		emitter.flow_level--
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+		if emitter.canonical && !first {
+			if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+		if !yaml_emitter_write_indicator(emitter, []byte{']'}, false, false, false) {
+			return false
+		}
+		emitter.state = emitter.states[len(emitter.states)-1]
+		emitter.states = emitter.states[:len(emitter.states)-1]
+
+		return true
+	}
+
+	if !first {
+		if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
+			return false
+		}
+	}
+
+	if emitter.canonical || emitter.column > emitter.best_width {
+		if !yaml_emitter_write_indent(emitter) {
+			return false
+		}
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, true, false, false)
+}
+
+// Expect a flow key node.
+func yaml_emitter_emit_flow_mapping_key(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_write_indicator(emitter, []byte{'{'}, true, true, false) {
+			return false
+		}
+		if !yaml_emitter_increase_indent(emitter, true, false) {
+			return false
+		}
+		emitter.flow_level++
+	}
+
+	if event.typ == yaml_MAPPING_END_EVENT {
+		emitter.flow_level--
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+		if emitter.canonical && !first {
+			if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
+				return false
+			}
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+		if !yaml_emitter_write_indicator(emitter, []byte{'}'}, false, false, false) {
+			return false
+		}
+		emitter.state = emitter.states[len(emitter.states)-1]
+		emitter.states = emitter.states[:len(emitter.states)-1]
+		return true
+	}
+
+	if !first {
+		if !yaml_emitter_write_indicator(emitter, []byte{','}, false, false, false) {
+			return false
+		}
+	}
+	if emitter.canonical || emitter.column > emitter.best_width {
+		if !yaml_emitter_write_indent(emitter) {
+			return false
+		}
+	}
+
+	if !emitter.canonical && yaml_emitter_check_simple_key(emitter) {
+		emitter.states = append(emitter.states, yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE)
+		return yaml_emitter_emit_node(emitter, event, false, false, true, true)
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'?'}, true, false, false) {
+		return false
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_FLOW_MAPPING_VALUE_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, false, true, false)
+}
+
+// Expect a flow value node.
+func yaml_emitter_emit_flow_mapping_value(emitter *yaml_emitter_t, event *yaml_event_t, simple bool) bool {
+	if simple {
+		if !yaml_emitter_write_indicator(emitter, []byte{':'}, false, false, false) {
+			return false
+		}
+	} else {
+		if emitter.canonical || emitter.column > emitter.best_width {
+			if !yaml_emitter_write_indent(emitter) {
+				return false
+			}
+		}
+		if !yaml_emitter_write_indicator(emitter, []byte{':'}, true, false, false) {
+			return false
+		}
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_FLOW_MAPPING_KEY_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, false, true, false)
+}
+
+// Expect a block item node.
+func yaml_emitter_emit_block_sequence_item(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_increase_indent(emitter, false, emitter.mapping_context && !emitter.indention) {
+			return false
+		}
+	}
+	if event.typ == yaml_SEQUENCE_END_EVENT {
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+		emitter.state = emitter.states[len(emitter.states)-1]
+		emitter.states = emitter.states[:len(emitter.states)-1]
+		return true
+	}
+	if !yaml_emitter_write_indent(emitter) {
+		return false
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'-'}, true, false, true) {
+		return false
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, true, false, false)
+}
+
+// Expect a block key node.
+func yaml_emitter_emit_block_mapping_key(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_increase_indent(emitter, false, false) {
+			return false
+		}
+	}
+	if event.typ == yaml_MAPPING_END_EVENT {
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+		emitter.state = emitter.states[len(emitter.states)-1]
+		emitter.states = emitter.states[:len(emitter.states)-1]
+		return true
+	}
+	if !yaml_emitter_write_indent(emitter) {
+		return false
+	}
+	if yaml_emitter_check_simple_key(emitter) {
+		emitter.states = append(emitter.states, yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE)
+		return yaml_emitter_emit_node(emitter, event, false, false, true, true)
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'?'}, true, false, true) {
+		return false
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_BLOCK_MAPPING_VALUE_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, false, true, false)
+}
+
+// Expect a block value node.
+func yaml_emitter_emit_block_mapping_value(emitter *yaml_emitter_t, event *yaml_event_t, simple bool) bool {
+	if simple {
+		if !yaml_emitter_write_indicator(emitter, []byte{':'}, false, false, false) {
+			return false
+		}
+	} else {
+		if !yaml_emitter_write_indent(emitter) {
+			return false
+		}
+		if !yaml_emitter_write_indicator(emitter, []byte{':'}, true, false, true) {
+			return false
+		}
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_BLOCK_MAPPING_KEY_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, false, true, false)
+}
+
+// Expect a node.
+func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
+	root bool, sequence bool, mapping bool, simple_key bool) bool {
+
+	emitter.root_context = root
+	emitter.sequence_context = sequence
+	emitter.mapping_context = mapping
+	emitter.simple_key_context = simple_key
+
+	switch event.typ {
+	case yaml_ALIAS_EVENT:
+		return yaml_emitter_emit_alias(emitter, event)
+	case yaml_SCALAR_EVENT:
+		return yaml_emitter_emit_scalar(emitter, event)
+	case yaml_SEQUENCE_START_EVENT:
+		return yaml_emitter_emit_sequence_start(emitter, event)
+	case yaml_MAPPING_START_EVENT:
+		return yaml_emitter_emit_mapping_start(emitter, event)
+	default:
+		return yaml_emitter_set_emitter_error(emitter,
+			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
+	}
+	return false
+}
+
+// Expect ALIAS.
+func yaml_emitter_emit_alias(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if !yaml_emitter_process_anchor(emitter) {
+		return false
+	}
+	emitter.state = emitter.states[len(emitter.states)-1]
+	emitter.states = emitter.states[:len(emitter.states)-1]
+	return true
+}
+
+// Expect SCALAR.
+func yaml_emitter_emit_scalar(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if !yaml_emitter_select_scalar_style(emitter, event) {
+		return false
+	}
+	if !yaml_emitter_process_anchor(emitter) {
+		return false
+	}
+	if !yaml_emitter_process_tag(emitter) {
+		return false
+	}
+	if !yaml_emitter_increase_indent(emitter, true, false) {
+		return false
+	}
+	if !yaml_emitter_process_scalar(emitter) {
+		return false
+	}
+	emitter.indent = emitter.indents[len(emitter.indents)-1]
+	emitter.indents = emitter.indents[:len(emitter.indents)-1]
+	emitter.state = emitter.states[len(emitter.states)-1]
+	emitter.states = emitter.states[:len(emitter.states)-1]
+	return true
+}
+
+// Expect SEQUENCE-START.
+func yaml_emitter_emit_sequence_start(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if !yaml_emitter_process_anchor(emitter) {
+		return false
+	}
+	if !yaml_emitter_process_tag(emitter) {
+		return false
+	}
+	if emitter.flow_level > 0 || emitter.canonical || event.sequence_style() == yaml_FLOW_SEQUENCE_STYLE ||
+		yaml_emitter_check_empty_sequence(emitter) {
+		emitter.state = yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE
+	} else {
+		emitter.state = yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE
+	}
+	return true
+}
+
+// Expect MAPPING-START.
+func yaml_emitter_emit_mapping_start(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	if !yaml_emitter_process_anchor(emitter) {
+		return false
+	}
+	if !yaml_emitter_process_tag(emitter) {
+		return false
+	}
+	if emitter.flow_level > 0 || emitter.canonical || event.mapping_style() == yaml_FLOW_MAPPING_STYLE ||
+		yaml_emitter_check_empty_mapping(emitter) {
+		emitter.state = yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE
+	} else {
+		emitter.state = yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE
+	}
+	return true
+}
+
+// Check if the document content is an empty scalar.
+func yaml_emitter_check_empty_document(emitter *yaml_emitter_t) bool {
+	return false // [Go] Huh?
+}
+
+// Check if the next events represent an empty sequence.
+func yaml_emitter_check_empty_sequence(emitter *yaml_emitter_t) bool {
+	if len(emitter.events)-emitter.events_head < 2 {
+		return false
+	}
+	return emitter.events[emitter.events_head].typ == yaml_SEQUENCE_START_EVENT &&
+		emitter.events[emitter.events_head+1].typ == yaml_SEQUENCE_END_EVENT
+}
+
+// Check if the next events represent an empty mapping.
+func yaml_emitter_check_empty_mapping(emitter *yaml_emitter_t) bool {
+	if len(emitter.events)-emitter.events_head < 2 {
+		return false
+	}
+	return emitter.events[emitter.events_head].typ == yaml_MAPPING_START_EVENT &&
+		emitter.events[emitter.events_head+1].typ == yaml_MAPPING_END_EVENT
+}
+
+// Check if the next node can be expressed as a simple key.
+func yaml_emitter_check_simple_key(emitter *yaml_emitter_t) bool {
+	length := 0
+	switch emitter.events[emitter.events_head].typ {
+	case yaml_ALIAS_EVENT:
+		length += len(emitter.anchor_data.anchor)
+	case yaml_SCALAR_EVENT:
+		if emitter.scalar_data.multiline {
+			return false
+		}
+		length += len(emitter.anchor_data.anchor) +
+			len(emitter.tag_data.handle) +
+			len(emitter.tag_data.suffix) +
+			len(emitter.scalar_data.value)
+	case yaml_SEQUENCE_START_EVENT:
+		if !yaml_emitter_check_empty_sequence(emitter) {
+			return false
+		}
+		length += len(emitter.anchor_data.anchor) +
+			len(emitter.tag_data.handle) +
+			len(emitter.tag_data.suffix)
+	case yaml_MAPPING_START_EVENT:
+		if !yaml_emitter_check_empty_mapping(emitter) {
+			return false
+		}
+		length += len(emitter.anchor_data.anchor) +
+			len(emitter.tag_data.handle) +
+			len(emitter.tag_data.suffix)
+	default:
+		return false
+	}
+	return length <= 128
+}
+
+// Determine an acceptable scalar style.
+func yaml_emitter_select_scalar_style(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+
+	no_tag := len(emitter.tag_data.handle) == 0 && len(emitter.tag_data.suffix) == 0
+	if no_tag && !event.implicit && !event.quoted_implicit {
+		return yaml_emitter_set_emitter_error(emitter, "neither tag nor implicit flags are specified")
+	}
+
+	style := event.scalar_style()
+	if style == yaml_ANY_SCALAR_STYLE {
+		style = yaml_PLAIN_SCALAR_STYLE
+	}
+	if emitter.canonical {
+		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+	}
+	if emitter.simple_key_context && emitter.scalar_data.multiline {
+		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+	}
+
+	if style == yaml_PLAIN_SCALAR_STYLE {
+		if emitter.flow_level > 0 && !emitter.scalar_data.flow_plain_allowed ||
+			emitter.flow_level == 0 && !emitter.scalar_data.block_plain_allowed {
+			style = yaml_SINGLE_QUOTED_SCALAR_STYLE
+		}
+		if len(emitter.scalar_data.value) == 0 && (emitter.flow_level > 0 || emitter.simple_key_context) {
+			style = yaml_SINGLE_QUOTED_SCALAR_STYLE
+		}
+		if no_tag && !event.implicit {
+			style = yaml_SINGLE_QUOTED_SCALAR_STYLE
+		}
+	}
+	if style == yaml_SINGLE_QUOTED_SCALAR_STYLE {
+		if !emitter.scalar_data.single_quoted_allowed {
+			style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+		}
+	}
+	if style == yaml_LITERAL_SCALAR_STYLE || style == yaml_FOLDED_SCALAR_STYLE {
+		if !emitter.scalar_data.block_allowed || emitter.flow_level > 0 || emitter.simple_key_context {
+			style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+		}
+	}
+
+	if no_tag && !event.quoted_implicit && style != yaml_PLAIN_SCALAR_STYLE {
+		emitter.tag_data.handle = []byte{'!'}
+	}
+	emitter.scalar_data.style = style
+	return true
+}
+
+// Write an achor.
+func yaml_emitter_process_anchor(emitter *yaml_emitter_t) bool {
+	if emitter.anchor_data.anchor == nil {
+		return true
+	}
+	c := []byte{'&'}
+	if emitter.anchor_data.alias {
+		c[0] = '*'
+	}
+	if !yaml_emitter_write_indicator(emitter, c, true, false, false) {
+		return false
+	}
+	return yaml_emitter_write_anchor(emitter, emitter.anchor_data.anchor)
+}
+
+// Write a tag.
+func yaml_emitter_process_tag(emitter *yaml_emitter_t) bool {
+	if len(emitter.tag_data.handle) == 0 && len(emitter.tag_data.suffix) == 0 {
+		return true
+	}
+	if len(emitter.tag_data.handle) > 0 {
+		if !yaml_emitter_write_tag_handle(emitter, emitter.tag_data.handle) {
+			return false
+		}
+		if len(emitter.tag_data.suffix) > 0 {
+			if !yaml_emitter_write_tag_content(emitter, emitter.tag_data.suffix, false) {
+				return false
+			}
+		}
+	} else {
+		// [Go] Allocate these slices elsewhere.
+		if !yaml_emitter_write_indicator(emitter, []byte("!<"), true, false, false) {
+			return false
+		}
+		if !yaml_emitter_write_tag_content(emitter, emitter.tag_data.suffix, false) {
+			return false
+		}
+		if !yaml_emitter_write_indicator(emitter, []byte{'>'}, false, false, false) {
+			return false
+		}
+	}
+	return true
+}
+
+// Write a scalar.
+func yaml_emitter_process_scalar(emitter *yaml_emitter_t) bool {
+	switch emitter.scalar_data.style {
+	case yaml_PLAIN_SCALAR_STYLE:
+		return yaml_emitter_write_plain_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+
+	case yaml_SINGLE_QUOTED_SCALAR_STYLE:
+		return yaml_emitter_write_single_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+
+	case yaml_DOUBLE_QUOTED_SCALAR_STYLE:
+		return yaml_emitter_write_double_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+
+	case yaml_LITERAL_SCALAR_STYLE:
+		return yaml_emitter_write_literal_scalar(emitter, emitter.scalar_data.value)
+
+	case yaml_FOLDED_SCALAR_STYLE:
+		return yaml_emitter_write_folded_scalar(emitter, emitter.scalar_data.value)
+	}
+	panic("unknown scalar style")
+}
+
+// Check if a %YAML directive is valid.
+func yaml_emitter_analyze_version_directive(emitter *yaml_emitter_t, version_directive *yaml_version_directive_t) bool {
+	if version_directive.major != 1 || version_directive.minor != 1 {
+		return yaml_emitter_set_emitter_error(emitter, "incompatible %YAML directive")
+	}
+	return true
+}
+
+// Check if a %TAG directive is valid.
+func yaml_emitter_analyze_tag_directive(emitter *yaml_emitter_t, tag_directive *yaml_tag_directive_t) bool {
+	handle := tag_directive.handle
+	prefix := tag_directive.prefix
+	if len(handle) == 0 {
+		return yaml_emitter_set_emitter_error(emitter, "tag handle must not be empty")
+	}
+	if handle[0] != '!' {
+		return yaml_emitter_set_emitter_error(emitter, "tag handle must start with '!'")
+	}
+	if handle[len(handle)-1] != '!' {
+		return yaml_emitter_set_emitter_error(emitter, "tag handle must end with '!'")
+	}
+	for i := 1; i < len(handle)-1; i += width(handle[i]) {
+		if !is_alpha(handle, i) {
+			return yaml_emitter_set_emitter_error(emitter, "tag handle must contain alphanumerical characters only")
+		}
+	}
+	if len(prefix) == 0 {
+		return yaml_emitter_set_emitter_error(emitter, "tag prefix must not be empty")
+	}
+	return true
+}
+
+// Check if an anchor is valid.
+func yaml_emitter_analyze_anchor(emitter *yaml_emitter_t, anchor []byte, alias bool) bool {
+	if len(anchor) == 0 {
+		problem := "anchor value must not be empty"
+		if alias {
+			problem = "alias value must not be empty"
+		}
+		return yaml_emitter_set_emitter_error(emitter, problem)
+	}
+	for i := 0; i < len(anchor); i += width(anchor[i]) {
+		if !is_alpha(anchor, i) {
+			problem := "anchor value must contain alphanumerical characters only"
+			if alias {
+				problem = "alias value must contain alphanumerical characters only"
+			}
+			return yaml_emitter_set_emitter_error(emitter, problem)
+		}
+	}
+	emitter.anchor_data.anchor = anchor
+	emitter.anchor_data.alias = alias
+	return true
+}
+
+// Check if a tag is valid.
+func yaml_emitter_analyze_tag(emitter *yaml_emitter_t, tag []byte) bool {
+	if len(tag) == 0 {
+		return yaml_emitter_set_emitter_error(emitter, "tag value must not be empty")
+	}
+	for i := 0; i < len(emitter.tag_directives); i++ {
+		tag_directive := &emitter.tag_directives[i]
+		if bytes.HasPrefix(tag, tag_directive.prefix) {
+			emitter.tag_data.handle = tag_directive.handle
+			emitter.tag_data.suffix = tag[len(tag_directive.prefix):]
+			return true
+		}
+	}
+	emitter.tag_data.suffix = tag
+	return true
+}
+
+// Check if a scalar is valid.
+func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
+	var (
+		block_indicators   = false
+		flow_indicators    = false
+		line_breaks        = false
+		special_characters = false
+
+		leading_space  = false
+		leading_break  = false
+		trailing_space = false
+		trailing_break = false
+		break_space    = false
+		space_break    = false
+
+		preceeded_by_whitespace = false
+		followed_by_whitespace  = false
+		previous_space          = false
+		previous_break          = false
+	)
+
+	emitter.scalar_data.value = value
+
+	if len(value) == 0 {
+		emitter.scalar_data.multiline = false
+		emitter.scalar_data.flow_plain_allowed = false
+		emitter.scalar_data.block_plain_allowed = true
+		emitter.scalar_data.single_quoted_allowed = true
+		emitter.scalar_data.block_allowed = false
+		return true
+	}
+
+	if len(value) >= 3 && ((value[0] == '-' && value[1] == '-' && value[2] == '-') || (value[0] == '.' && value[1] == '.' && value[2] == '.')) {
+		block_indicators = true
+		flow_indicators = true
+	}
+
+	preceeded_by_whitespace = true
+	for i, w := 0, 0; i < len(value); i += w {
+		w = width(value[i])
+		followed_by_whitespace = i+w >= len(value) || is_blank(value, i+w)
+
+		if i == 0 {
+			switch value[i] {
+			case '#', ',', '[', ']', '{', '}', '&', '*', '!', '|', '>', '\'', '"', '%', '@', '`':
+				flow_indicators = true
+				block_indicators = true
+			case '?', ':':
+				flow_indicators = true
+				if followed_by_whitespace {
+					block_indicators = true
+				}
+			case '-':
+				if followed_by_whitespace {
+					flow_indicators = true
+					block_indicators = true
+				}
+			}
+		} else {
+			switch value[i] {
+			case ',', '?', '[', ']', '{', '}':
+				flow_indicators = true
+			case ':':
+				flow_indicators = true
+				if followed_by_whitespace {
+					block_indicators = true
+				}
+			case '#':
+				if preceeded_by_whitespace {
+					flow_indicators = true
+					block_indicators = true
+				}
+			}
+		}
+
+		if !is_printable(value, i) || !is_ascii(value, i) && !emitter.unicode {
+			special_characters = true
+		}
+		if is_space(value, i) {
+			if i == 0 {
+				leading_space = true
+			}
+			if i+width(value[i]) == len(value) {
+				trailing_space = true
+			}
+			if previous_break {
+				break_space = true
+			}
+			previous_space = true
+			previous_break = false
+		} else if is_break(value, i) {
+			line_breaks = true
+			if i == 0 {
+				leading_break = true
+			}
+			if i+width(value[i]) == len(value) {
+				trailing_break = true
+			}
+			if previous_space {
+				space_break = true
+			}
+			previous_space = false
+			previous_break = true
+		} else {
+			previous_space = false
+			previous_break = false
+		}
+
+		// [Go]: Why 'z'? Couldn't be the end of the string as that's the loop condition.
+		preceeded_by_whitespace = is_blankz(value, i)
+	}
+
+	emitter.scalar_data.multiline = line_breaks
+	emitter.scalar_data.flow_plain_allowed = true
+	emitter.scalar_data.block_plain_allowed = true
+	emitter.scalar_data.single_quoted_allowed = true
+	emitter.scalar_data.block_allowed = true
+
+	if leading_space || leading_break || trailing_space || trailing_break {
+		emitter.scalar_data.flow_plain_allowed = false
+		emitter.scalar_data.block_plain_allowed = false
+	}
+	if trailing_space {
+		emitter.scalar_data.block_allowed = false
+	}
+	if break_space {
+		emitter.scalar_data.flow_plain_allowed = false
+		emitter.scalar_data.block_plain_allowed = false
+		emitter.scalar_data.single_quoted_allowed = false
+	}
+	if space_break || special_characters {
+		emitter.scalar_data.flow_plain_allowed = false
+		emitter.scalar_data.block_plain_allowed = false
+		emitter.scalar_data.single_quoted_allowed = false
+		emitter.scalar_data.block_allowed = false
+	}
+	if line_breaks {
+		emitter.scalar_data.flow_plain_allowed = false
+		emitter.scalar_data.block_plain_allowed = false
+	}
+	if flow_indicators {
+		emitter.scalar_data.flow_plain_allowed = false
+	}
+	if block_indicators {
+		emitter.scalar_data.block_plain_allowed = false
+	}
+	return true
+}
+
+// Check if the event data is valid.
+func yaml_emitter_analyze_event(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+
+	emitter.anchor_data.anchor = nil
+	emitter.tag_data.handle = nil
+	emitter.tag_data.suffix = nil
+	emitter.scalar_data.value = nil
+
+	switch event.typ {
+	case yaml_ALIAS_EVENT:
+		if !yaml_emitter_analyze_anchor(emitter, event.anchor, true) {
+			return false
+		}
+
+	case yaml_SCALAR_EVENT:
+		if len(event.anchor) > 0 {
+			if !yaml_emitter_analyze_anchor(emitter, event.anchor, false) {
+				return false
+			}
+		}
+		if len(event.tag) > 0 && (emitter.canonical || (!event.implicit && !event.quoted_implicit)) {
+			if !yaml_emitter_analyze_tag(emitter, event.tag) {
+				return false
+			}
+		}
+		if !yaml_emitter_analyze_scalar(emitter, event.value) {
+			return false
+		}
+
+	case yaml_SEQUENCE_START_EVENT:
+		if len(event.anchor) > 0 {
+			if !yaml_emitter_analyze_anchor(emitter, event.anchor, false) {
+				return false
+			}
+		}
+		if len(event.tag) > 0 && (emitter.canonical || !event.implicit) {
+			if !yaml_emitter_analyze_tag(emitter, event.tag) {
+				return false
+			}
+		}
+
+	case yaml_MAPPING_START_EVENT:
+		if len(event.anchor) > 0 {
+			if !yaml_emitter_analyze_anchor(emitter, event.anchor, false) {
+				return false
+			}
+		}
+		if len(event.tag) > 0 && (emitter.canonical || !event.implicit) {
+			if !yaml_emitter_analyze_tag(emitter, event.tag) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Write the BOM character.
+func yaml_emitter_write_bom(emitter *yaml_emitter_t) bool {
+	if !flush(emitter) {
+		return false
+	}
+	pos := emitter.buffer_pos
+	emitter.buffer[pos+0] = '\xEF'
+	emitter.buffer[pos+1] = '\xBB'
+	emitter.buffer[pos+2] = '\xBF'
+	emitter.buffer_pos += 3
+	return true
+}
+
+func yaml_emitter_write_indent(emitter *yaml_emitter_t) bool {
+	indent := emitter.indent
+	if indent < 0 {
+		indent = 0
+	}
+	if !emitter.indention || emitter.column > indent || (emitter.column == indent && !emitter.whitespace) {
+		if !put_break(emitter) {
+			return false
+		}
+	}
+	for emitter.column < indent {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+	emitter.whitespace = true
+	emitter.indention = true
+	return true
+}
+
+func yaml_emitter_write_indicator(emitter *yaml_emitter_t, indicator []byte, need_whitespace, is_whitespace, is_indention bool) bool {
+	if need_whitespace && !emitter.whitespace {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+	if !write_all(emitter, indicator) {
+		return false
+	}
+	emitter.whitespace = is_whitespace
+	emitter.indention = (emitter.indention && is_indention)
+	emitter.open_ended = false
+	return true
+}
+
+func yaml_emitter_write_anchor(emitter *yaml_emitter_t, value []byte) bool {
+	if !write_all(emitter, value) {
+		return false
+	}
+	emitter.whitespace = false
+	emitter.indention = false
+	return true
+}
+
+func yaml_emitter_write_tag_handle(emitter *yaml_emitter_t, value []byte) bool {
+	if !emitter.whitespace {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+	if !write_all(emitter, value) {
+		return false
+	}
+	emitter.whitespace = false
+	emitter.indention = false
+	return true
+}
+
+func yaml_emitter_write_tag_content(emitter *yaml_emitter_t, value []byte, need_whitespace bool) bool {
+	if need_whitespace && !emitter.whitespace {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+	for i := 0; i < len(value); {
+		var must_write bool
+		switch value[i] {
+		case ';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '_', '.', '~', '*', '\'', '(', ')', '[', ']':
+			must_write = true
+		default:
+			must_write = is_alpha(value, i)
+		}
+		if must_write {
+			if !write(emitter, value, &i) {
+				return false
+			}
+		} else {
+			w := width(value[i])
+			for k := 0; k < w; k++ {
+				octet := value[i]
+				i++
+				if !put(emitter, '%') {
+					return false
+				}
+
+				c := octet >> 4
+				if c < 10 {
+					c += '0'
+				} else {
+					c += 'A' - 10
+				}
+				if !put(emitter, c) {
+					return false
+				}
+
+				c = octet & 0x0f
+				if c < 10 {
+					c += '0'
+				} else {
+					c += 'A' - 10
+				}
+				if !put(emitter, c) {
+					return false
+				}
+			}
+		}
+	}
+	emitter.whitespace = false
+	emitter.indention = false
+	return true
+}
+
+func yaml_emitter_write_plain_scalar(emitter *yaml_emitter_t, value []byte, allow_breaks bool) bool {
+	if !emitter.whitespace {
+		if !put(emitter, ' ') {
+			return false
+		}
+	}
+
+	spaces := false
+	breaks := false
+	for i := 0; i < len(value); {
+		if is_space(value, i) {
+			if allow_breaks && !spaces && emitter.column > emitter.best_width && !is_space(value, i+1) {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				i += width(value[i])
+			} else {
+				if !write(emitter, value, &i) {
+					return false
+				}
+			}
+			spaces = true
+		} else if is_break(value, i) {
+			if !breaks && value[i] == '\n' {
+				if !put_break(emitter) {
+					return false
+				}
+			}
+			if !write_break(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = true
+			breaks = true
+		} else {
+			if breaks {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+			}
+			if !write(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = false
+			spaces = false
+			breaks = false
+		}
+	}
+
+	emitter.whitespace = false
+	emitter.indention = false
+	if emitter.root_context {
+		emitter.open_ended = true
+	}
+
+	return true
+}
+
+func yaml_emitter_write_single_quoted_scalar(emitter *yaml_emitter_t, value []byte, allow_breaks bool) bool {
+
+	if !yaml_emitter_write_indicator(emitter, []byte{'\''}, true, false, false) {
+		return false
+	}
+
+	spaces := false
+	breaks := false
+	for i := 0; i < len(value); {
+		if is_space(value, i) {
+			if allow_breaks && !spaces && emitter.column > emitter.best_width && i > 0 && i < len(value)-1 && !is_space(value, i+1) {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				i += width(value[i])
+			} else {
+				if !write(emitter, value, &i) {
+					return false
+				}
+			}
+			spaces = true
+		} else if is_break(value, i) {
+			if !breaks && value[i] == '\n' {
+				if !put_break(emitter) {
+					return false
+				}
+			}
+			if !write_break(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = true
+			breaks = true
+		} else {
+			if breaks {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+			}
+			if value[i] == '\'' {
+				if !put(emitter, '\'') {
+					return false
+				}
+			}
+			if !write(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = false
+			spaces = false
+			breaks = false
+		}
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'\''}, false, false, false) {
+		return false
+	}
+	emitter.whitespace = false
+	emitter.indention = false
+	return true
+}
+
+func yaml_emitter_write_double_quoted_scalar(emitter *yaml_emitter_t, value []byte, allow_breaks bool) bool {
+	spaces := false
+	if !yaml_emitter_write_indicator(emitter, []byte{'"'}, true, false, false) {
+		return false
+	}
+
+	for i := 0; i < len(value); {
+		if !is_printable(value, i) || (!emitter.unicode && !is_ascii(value, i)) ||
+			is_bom(value, i) || is_break(value, i) ||
+			value[i] == '"' || value[i] == '\\' {
+
+			octet := value[i]
+
+			var w int
+			var v rune
+			switch {
+			case octet&0x80 == 0x00:
+				w, v = 1, rune(octet&0x7F)
+			case octet&0xE0 == 0xC0:
+				w, v = 2, rune(octet&0x1F)
+			case octet&0xF0 == 0xE0:
+				w, v = 3, rune(octet&0x0F)
+			case octet&0xF8 == 0xF0:
+				w, v = 4, rune(octet&0x07)
+			}
+			for k := 1; k < w; k++ {
+				octet = value[i+k]
+				v = (v << 6) + (rune(octet) & 0x3F)
+			}
+			i += w
+
+			if !put(emitter, '\\') {
+				return false
+			}
+
+			var ok bool
+			switch v {
+			case 0x00:
+				ok = put(emitter, '0')
+			case 0x07:
+				ok = put(emitter, 'a')
+			case 0x08:
+				ok = put(emitter, 'b')
+			case 0x09:
+				ok = put(emitter, 't')
+			case 0x0A:
+				ok = put(emitter, 'n')
+			case 0x0b:
+				ok = put(emitter, 'v')
+			case 0x0c:
+				ok = put(emitter, 'f')
+			case 0x0d:
+				ok = put(emitter, 'r')
+			case 0x1b:
+				ok = put(emitter, 'e')
+			case 0x22:
+				ok = put(emitter, '"')
+			case 0x5c:
+				ok = put(emitter, '\\')
+			case 0x85:
+				ok = put(emitter, 'N')
+			case 0xA0:
+				ok = put(emitter, '_')
+			case 0x2028:
+				ok = put(emitter, 'L')
+			case 0x2029:
+				ok = put(emitter, 'P')
+			default:
+				if v <= 0xFF {
+					ok = put(emitter, 'x')
+					w = 2
+				} else if v <= 0xFFFF {
+					ok = put(emitter, 'u')
+					w = 4
+				} else {
+					ok = put(emitter, 'U')
+					w = 8
+				}
+				for k := (w - 1) * 4; ok && k >= 0; k -= 4 {
+					digit := byte((v >> uint(k)) & 0x0F)
+					if digit < 10 {
+						ok = put(emitter, digit+'0')
+					} else {
+						ok = put(emitter, digit+'A'-10)
+					}
+				}
+			}
+			if !ok {
+				return false
+			}
+			spaces = false
+		} else if is_space(value, i) {
+			if allow_breaks && !spaces && emitter.column > emitter.best_width && i > 0 && i < len(value)-1 {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				if is_space(value, i+1) {
+					if !put(emitter, '\\') {
+						return false
+					}
+				}
+				i += width(value[i])
+			} else if !write(emitter, value, &i) {
+				return false
+			}
+			spaces = true
+		} else {
+			if !write(emitter, value, &i) {
+				return false
+			}
+			spaces = false
+		}
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'"'}, false, false, false) {
+		return false
+	}
+	emitter.whitespace = false
+	emitter.indention = false
+	return true
+}
+
+func yaml_emitter_write_block_scalar_hints(emitter *yaml_emitter_t, value []byte) bool {
+	if is_space(value, 0) || is_break(value, 0) {
+		indent_hint := []byte{'0' + byte(emitter.best_indent)}
+		if !yaml_emitter_write_indicator(emitter, indent_hint, false, false, false) {
+			return false
+		}
+	}
+
+	emitter.open_ended = false
+
+	var chomp_hint [1]byte
+	if len(value) == 0 {
+		chomp_hint[0] = '-'
+	} else {
+		i := len(value) - 1
+		for value[i]&0xC0 == 0x80 {
+			i--
+		}
+		if !is_break(value, i) {
+			chomp_hint[0] = '-'
+		} else if i == 0 {
+			chomp_hint[0] = '+'
+			emitter.open_ended = true
+		} else {
+			i--
+			for value[i]&0xC0 == 0x80 {
+				i--
+			}
+			if is_break(value, i) {
+				chomp_hint[0] = '+'
+				emitter.open_ended = true
+			}
+		}
+	}
+	if chomp_hint[0] != 0 {
+		if !yaml_emitter_write_indicator(emitter, chomp_hint[:], false, false, false) {
+			return false
+		}
+	}
+	return true
+}
+
+func yaml_emitter_write_literal_scalar(emitter *yaml_emitter_t, value []byte) bool {
+	if !yaml_emitter_write_indicator(emitter, []byte{'|'}, true, false, false) {
+		return false
+	}
+	if !yaml_emitter_write_block_scalar_hints(emitter, value) {
+		return false
+	}
+	if !put_break(emitter) {
+		return false
+	}
+	emitter.indention = true
+	emitter.whitespace = true
+	breaks := true
+	for i := 0; i < len(value); {
+		if is_break(value, i) {
+			if !write_break(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = true
+			breaks = true
+		} else {
+			if breaks {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+			}
+			if !write(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = false
+			breaks = false
+		}
+	}
+
+	return true
+}
+
+func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) bool {
+	if !yaml_emitter_write_indicator(emitter, []byte{'>'}, true, false, false) {
+		return false
+	}
+	if !yaml_emitter_write_block_scalar_hints(emitter, value) {
+		return false
+	}
+
+	if !put_break(emitter) {
+		return false
+	}
+	emitter.indention = true
+	emitter.whitespace = true
+
+	breaks := true
+	leading_spaces := true
+	for i := 0; i < len(value); {
+		if is_break(value, i) {
+			if !breaks && !leading_spaces && value[i] == '\n' {
+				k := 0
+				for is_break(value, k) {
+					k += width(value[k])
+				}
+				if !is_blankz(value, k) {
+					if !put_break(emitter) {
+						return false
+					}
+				}
+			}
+			if !write_break(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = true
+			breaks = true
+		} else {
+			if breaks {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				leading_spaces = is_blank(value, i)
+			}
+			if !breaks && is_space(value, i) && !is_space(value, i+1) && emitter.column > emitter.best_width {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				i += width(value[i])
+			} else {
+				if !write(emitter, value, &i) {
+					return false
+				}
+			}
+			emitter.indention = false
+			breaks = false
+		}
+	}
+	return true
+}

--- a/vendor/gopkg.in/yaml.v2/encode.go
+++ b/vendor/gopkg.in/yaml.v2/encode.go
@@ -1,0 +1,306 @@
+package yaml
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type encoder struct {
+	emitter yaml_emitter_t
+	event   yaml_event_t
+	out     []byte
+	flow    bool
+}
+
+func newEncoder() (e *encoder) {
+	e = &encoder{}
+	e.must(yaml_emitter_initialize(&e.emitter))
+	yaml_emitter_set_output_string(&e.emitter, &e.out)
+	yaml_emitter_set_unicode(&e.emitter, true)
+	e.must(yaml_stream_start_event_initialize(&e.event, yaml_UTF8_ENCODING))
+	e.emit()
+	e.must(yaml_document_start_event_initialize(&e.event, nil, nil, true))
+	e.emit()
+	return e
+}
+
+func (e *encoder) finish() {
+	e.must(yaml_document_end_event_initialize(&e.event, true))
+	e.emit()
+	e.emitter.open_ended = false
+	e.must(yaml_stream_end_event_initialize(&e.event))
+	e.emit()
+}
+
+func (e *encoder) destroy() {
+	yaml_emitter_delete(&e.emitter)
+}
+
+func (e *encoder) emit() {
+	// This will internally delete the e.event value.
+	if !yaml_emitter_emit(&e.emitter, &e.event) && e.event.typ != yaml_DOCUMENT_END_EVENT && e.event.typ != yaml_STREAM_END_EVENT {
+		e.must(false)
+	}
+}
+
+func (e *encoder) must(ok bool) {
+	if !ok {
+		msg := e.emitter.problem
+		if msg == "" {
+			msg = "unknown problem generating YAML content"
+		}
+		failf("%s", msg)
+	}
+}
+
+func (e *encoder) marshal(tag string, in reflect.Value) {
+	if !in.IsValid() {
+		e.nilv()
+		return
+	}
+	iface := in.Interface()
+	if m, ok := iface.(Marshaler); ok {
+		v, err := m.MarshalYAML()
+		if err != nil {
+			fail(err)
+		}
+		if v == nil {
+			e.nilv()
+			return
+		}
+		in = reflect.ValueOf(v)
+	} else if m, ok := iface.(encoding.TextMarshaler); ok {
+		text, err := m.MarshalText()
+		if err != nil {
+			fail(err)
+		}
+		in = reflect.ValueOf(string(text))
+	}
+	switch in.Kind() {
+	case reflect.Interface:
+		if in.IsNil() {
+			e.nilv()
+		} else {
+			e.marshal(tag, in.Elem())
+		}
+	case reflect.Map:
+		e.mapv(tag, in)
+	case reflect.Ptr:
+		if in.IsNil() {
+			e.nilv()
+		} else {
+			e.marshal(tag, in.Elem())
+		}
+	case reflect.Struct:
+		e.structv(tag, in)
+	case reflect.Slice:
+		if in.Type().Elem() == mapItemType {
+			e.itemsv(tag, in)
+		} else {
+			e.slicev(tag, in)
+		}
+	case reflect.String:
+		e.stringv(tag, in)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if in.Type() == durationType {
+			e.stringv(tag, reflect.ValueOf(iface.(time.Duration).String()))
+		} else {
+			e.intv(tag, in)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		e.uintv(tag, in)
+	case reflect.Float32, reflect.Float64:
+		e.floatv(tag, in)
+	case reflect.Bool:
+		e.boolv(tag, in)
+	default:
+		panic("cannot marshal type: " + in.Type().String())
+	}
+}
+
+func (e *encoder) mapv(tag string, in reflect.Value) {
+	e.mappingv(tag, func() {
+		keys := keyList(in.MapKeys())
+		sort.Sort(keys)
+		for _, k := range keys {
+			e.marshal("", k)
+			e.marshal("", in.MapIndex(k))
+		}
+	})
+}
+
+func (e *encoder) itemsv(tag string, in reflect.Value) {
+	e.mappingv(tag, func() {
+		slice := in.Convert(reflect.TypeOf([]MapItem{})).Interface().([]MapItem)
+		for _, item := range slice {
+			e.marshal("", reflect.ValueOf(item.Key))
+			e.marshal("", reflect.ValueOf(item.Value))
+		}
+	})
+}
+
+func (e *encoder) structv(tag string, in reflect.Value) {
+	sinfo, err := getStructInfo(in.Type())
+	if err != nil {
+		panic(err)
+	}
+	e.mappingv(tag, func() {
+		for _, info := range sinfo.FieldsList {
+			var value reflect.Value
+			if info.Inline == nil {
+				value = in.Field(info.Num)
+			} else {
+				value = in.FieldByIndex(info.Inline)
+			}
+			if info.OmitEmpty && isZero(value) {
+				continue
+			}
+			e.marshal("", reflect.ValueOf(info.Key))
+			e.flow = info.Flow
+			e.marshal("", value)
+		}
+		if sinfo.InlineMap >= 0 {
+			m := in.Field(sinfo.InlineMap)
+			if m.Len() > 0 {
+				e.flow = false
+				keys := keyList(m.MapKeys())
+				sort.Sort(keys)
+				for _, k := range keys {
+					if _, found := sinfo.FieldsMap[k.String()]; found {
+						panic(fmt.Sprintf("Can't have key %q in inlined map; conflicts with struct field", k.String()))
+					}
+					e.marshal("", k)
+					e.flow = false
+					e.marshal("", m.MapIndex(k))
+				}
+			}
+		}
+	})
+}
+
+func (e *encoder) mappingv(tag string, f func()) {
+	implicit := tag == ""
+	style := yaml_BLOCK_MAPPING_STYLE
+	if e.flow {
+		e.flow = false
+		style = yaml_FLOW_MAPPING_STYLE
+	}
+	e.must(yaml_mapping_start_event_initialize(&e.event, nil, []byte(tag), implicit, style))
+	e.emit()
+	f()
+	e.must(yaml_mapping_end_event_initialize(&e.event))
+	e.emit()
+}
+
+func (e *encoder) slicev(tag string, in reflect.Value) {
+	implicit := tag == ""
+	style := yaml_BLOCK_SEQUENCE_STYLE
+	if e.flow {
+		e.flow = false
+		style = yaml_FLOW_SEQUENCE_STYLE
+	}
+	e.must(yaml_sequence_start_event_initialize(&e.event, nil, []byte(tag), implicit, style))
+	e.emit()
+	n := in.Len()
+	for i := 0; i < n; i++ {
+		e.marshal("", in.Index(i))
+	}
+	e.must(yaml_sequence_end_event_initialize(&e.event))
+	e.emit()
+}
+
+// isBase60 returns whether s is in base 60 notation as defined in YAML 1.1.
+//
+// The base 60 float notation in YAML 1.1 is a terrible idea and is unsupported
+// in YAML 1.2 and by this package, but these should be marshalled quoted for
+// the time being for compatibility with other parsers.
+func isBase60Float(s string) (result bool) {
+	// Fast path.
+	if s == "" {
+		return false
+	}
+	c := s[0]
+	if !(c == '+' || c == '-' || c >= '0' && c <= '9') || strings.IndexByte(s, ':') < 0 {
+		return false
+	}
+	// Do the full match.
+	return base60float.MatchString(s)
+}
+
+// From http://yaml.org/type/float.html, except the regular expression there
+// is bogus. In practice parsers do not enforce the "\.[0-9_]*" suffix.
+var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0-9_]*)?$`)
+
+func (e *encoder) stringv(tag string, in reflect.Value) {
+	var style yaml_scalar_style_t
+	s := in.String()
+	rtag, rs := resolve("", s)
+	if rtag == yaml_BINARY_TAG {
+		if tag == "" || tag == yaml_STR_TAG {
+			tag = rtag
+			s = rs.(string)
+		} else if tag == yaml_BINARY_TAG {
+			failf("explicitly tagged !!binary data must be base64-encoded")
+		} else {
+			failf("cannot marshal invalid UTF-8 data as %s", shortTag(tag))
+		}
+	}
+	if tag == "" && (rtag != yaml_STR_TAG || isBase60Float(s)) {
+		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+	} else if strings.Contains(s, "\n") {
+		style = yaml_LITERAL_SCALAR_STYLE
+	} else {
+		style = yaml_PLAIN_SCALAR_STYLE
+	}
+	e.emitScalar(s, "", tag, style)
+}
+
+func (e *encoder) boolv(tag string, in reflect.Value) {
+	var s string
+	if in.Bool() {
+		s = "true"
+	} else {
+		s = "false"
+	}
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) intv(tag string, in reflect.Value) {
+	s := strconv.FormatInt(in.Int(), 10)
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) uintv(tag string, in reflect.Value) {
+	s := strconv.FormatUint(in.Uint(), 10)
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) floatv(tag string, in reflect.Value) {
+	// FIXME: Handle 64 bits here.
+	s := strconv.FormatFloat(float64(in.Float()), 'g', -1, 32)
+	switch s {
+	case "+Inf":
+		s = ".inf"
+	case "-Inf":
+		s = "-.inf"
+	case "NaN":
+		s = ".nan"
+	}
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) nilv() {
+	e.emitScalar("null", "", "", yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_t) {
+	implicit := tag == ""
+	e.must(yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(tag), []byte(value), implicit, implicit, style))
+	e.emit()
+}

--- a/vendor/gopkg.in/yaml.v2/encode_test.go
+++ b/vendor/gopkg.in/yaml.v2/encode_test.go
@@ -1,0 +1,501 @@
+package yaml_test
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+	"net"
+	"os"
+)
+
+var marshalIntTest = 123
+
+var marshalTests = []struct {
+	value interface{}
+	data  string
+}{
+	{
+		nil,
+		"null\n",
+	}, {
+		&struct{}{},
+		"{}\n",
+	}, {
+		map[string]string{"v": "hi"},
+		"v: hi\n",
+	}, {
+		map[string]interface{}{"v": "hi"},
+		"v: hi\n",
+	}, {
+		map[string]string{"v": "true"},
+		"v: \"true\"\n",
+	}, {
+		map[string]string{"v": "false"},
+		"v: \"false\"\n",
+	}, {
+		map[string]interface{}{"v": true},
+		"v: true\n",
+	}, {
+		map[string]interface{}{"v": false},
+		"v: false\n",
+	}, {
+		map[string]interface{}{"v": 10},
+		"v: 10\n",
+	}, {
+		map[string]interface{}{"v": -10},
+		"v: -10\n",
+	}, {
+		map[string]uint{"v": 42},
+		"v: 42\n",
+	}, {
+		map[string]interface{}{"v": int64(4294967296)},
+		"v: 4294967296\n",
+	}, {
+		map[string]int64{"v": int64(4294967296)},
+		"v: 4294967296\n",
+	}, {
+		map[string]uint64{"v": 4294967296},
+		"v: 4294967296\n",
+	}, {
+		map[string]interface{}{"v": "10"},
+		"v: \"10\"\n",
+	}, {
+		map[string]interface{}{"v": 0.1},
+		"v: 0.1\n",
+	}, {
+		map[string]interface{}{"v": float64(0.1)},
+		"v: 0.1\n",
+	}, {
+		map[string]interface{}{"v": -0.1},
+		"v: -0.1\n",
+	}, {
+		map[string]interface{}{"v": math.Inf(+1)},
+		"v: .inf\n",
+	}, {
+		map[string]interface{}{"v": math.Inf(-1)},
+		"v: -.inf\n",
+	}, {
+		map[string]interface{}{"v": math.NaN()},
+		"v: .nan\n",
+	}, {
+		map[string]interface{}{"v": nil},
+		"v: null\n",
+	}, {
+		map[string]interface{}{"v": ""},
+		"v: \"\"\n",
+	}, {
+		map[string][]string{"v": []string{"A", "B"}},
+		"v:\n- A\n- B\n",
+	}, {
+		map[string][]string{"v": []string{"A", "B\nC"}},
+		"v:\n- A\n- |-\n  B\n  C\n",
+	}, {
+		map[string][]interface{}{"v": []interface{}{"A", 1, map[string][]int{"B": []int{2, 3}}}},
+		"v:\n- A\n- 1\n- B:\n  - 2\n  - 3\n",
+	}, {
+		map[string]interface{}{"a": map[interface{}]interface{}{"b": "c"}},
+		"a:\n  b: c\n",
+	}, {
+		map[string]interface{}{"a": "-"},
+		"a: '-'\n",
+	},
+
+	// Simple values.
+	{
+		&marshalIntTest,
+		"123\n",
+	},
+
+	// Structures
+	{
+		&struct{ Hello string }{"world"},
+		"hello: world\n",
+	}, {
+		&struct {
+			A struct {
+				B string
+			}
+		}{struct{ B string }{"c"}},
+		"a:\n  b: c\n",
+	}, {
+		&struct {
+			A *struct {
+				B string
+			}
+		}{&struct{ B string }{"c"}},
+		"a:\n  b: c\n",
+	}, {
+		&struct {
+			A *struct {
+				B string
+			}
+		}{},
+		"a: null\n",
+	}, {
+		&struct{ A int }{1},
+		"a: 1\n",
+	}, {
+		&struct{ A []int }{[]int{1, 2}},
+		"a:\n- 1\n- 2\n",
+	}, {
+		&struct {
+			B int "a"
+		}{1},
+		"a: 1\n",
+	}, {
+		&struct{ A bool }{true},
+		"a: true\n",
+	},
+
+	// Conditional flag
+	{
+		&struct {
+			A int "a,omitempty"
+			B int "b,omitempty"
+		}{1, 0},
+		"a: 1\n",
+	}, {
+		&struct {
+			A int "a,omitempty"
+			B int "b,omitempty"
+		}{0, 0},
+		"{}\n",
+	}, {
+		&struct {
+			A *struct{ X, y int } "a,omitempty,flow"
+		}{&struct{ X, y int }{1, 2}},
+		"a: {x: 1}\n",
+	}, {
+		&struct {
+			A *struct{ X, y int } "a,omitempty,flow"
+		}{nil},
+		"{}\n",
+	}, {
+		&struct {
+			A *struct{ X, y int } "a,omitempty,flow"
+		}{&struct{ X, y int }{}},
+		"a: {x: 0}\n",
+	}, {
+		&struct {
+			A struct{ X, y int } "a,omitempty,flow"
+		}{struct{ X, y int }{1, 2}},
+		"a: {x: 1}\n",
+	}, {
+		&struct {
+			A struct{ X, y int } "a,omitempty,flow"
+		}{struct{ X, y int }{0, 1}},
+		"{}\n",
+	}, {
+		&struct {
+			A float64 "a,omitempty"
+			B float64 "b,omitempty"
+		}{1, 0},
+		"a: 1\n",
+	},
+
+	// Flow flag
+	{
+		&struct {
+			A []int "a,flow"
+		}{[]int{1, 2}},
+		"a: [1, 2]\n",
+	}, {
+		&struct {
+			A map[string]string "a,flow"
+		}{map[string]string{"b": "c", "d": "e"}},
+		"a: {b: c, d: e}\n",
+	}, {
+		&struct {
+			A struct {
+				B, D string
+			} "a,flow"
+		}{struct{ B, D string }{"c", "e"}},
+		"a: {b: c, d: e}\n",
+	},
+
+	// Unexported field
+	{
+		&struct {
+			u int
+			A int
+		}{0, 1},
+		"a: 1\n",
+	},
+
+	// Ignored field
+	{
+		&struct {
+			A int
+			B int "-"
+		}{1, 2},
+		"a: 1\n",
+	},
+
+	// Struct inlining
+	{
+		&struct {
+			A int
+			C inlineB `yaml:",inline"`
+		}{1, inlineB{2, inlineC{3}}},
+		"a: 1\nb: 2\nc: 3\n",
+	},
+
+	// Map inlining
+	{
+		&struct {
+			A int
+			C map[string]int `yaml:",inline"`
+		}{1, map[string]int{"b": 2, "c": 3}},
+		"a: 1\nb: 2\nc: 3\n",
+	},
+
+	// Duration
+	{
+		map[string]time.Duration{"a": 3 * time.Second},
+		"a: 3s\n",
+	},
+
+	// Issue #24: bug in map merging logic.
+	{
+		map[string]string{"a": "<foo>"},
+		"a: <foo>\n",
+	},
+
+	// Issue #34: marshal unsupported base 60 floats quoted for compatibility
+	// with old YAML 1.1 parsers.
+	{
+		map[string]string{"a": "1:1"},
+		"a: \"1:1\"\n",
+	},
+
+	// Binary data.
+	{
+		map[string]string{"a": "\x00"},
+		"a: \"\\0\"\n",
+	}, {
+		map[string]string{"a": "\x80\x81\x82"},
+		"a: !!binary gIGC\n",
+	}, {
+		map[string]string{"a": strings.Repeat("\x90", 54)},
+		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
+	},
+
+	// Ordered maps.
+	{
+		&yaml.MapSlice{{"b", 2}, {"a", 1}, {"d", 4}, {"c", 3}, {"sub", yaml.MapSlice{{"e", 5}}}},
+		"b: 2\na: 1\nd: 4\nc: 3\nsub:\n  e: 5\n",
+	},
+
+	// Encode unicode as utf-8 rather than in escaped form.
+	{
+		map[string]string{"a": "你好"},
+		"a: 你好\n",
+	},
+
+	// Support encoding.TextMarshaler.
+	{
+		map[string]net.IP{"a": net.IPv4(1, 2, 3, 4)},
+		"a: 1.2.3.4\n",
+	},
+	{
+		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+		"a: 2015-02-24T18:19:39Z\n",
+	},
+
+	// Ensure strings containing ": " are quoted (reported as PR #43, but not reproducible).
+	{
+		map[string]string{"a": "b: c"},
+		"a: 'b: c'\n",
+	},
+
+	// Containing hash mark ('#') in string should be quoted
+	{
+		map[string]string{"a": "Hello #comment"},
+		"a: 'Hello #comment'\n",
+	},
+	{
+		map[string]string{"a": "你好 #comment"},
+		"a: '你好 #comment'\n",
+	},
+}
+
+func (s *S) TestMarshal(c *C) {
+	defer os.Setenv("TZ", os.Getenv("TZ"))
+	os.Setenv("TZ", "UTC")
+	for _, item := range marshalTests {
+		data, err := yaml.Marshal(item.value)
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, item.data)
+	}
+}
+
+var marshalErrorTests = []struct {
+	value interface{}
+	error string
+	panic string
+}{{
+	value: &struct {
+		B       int
+		inlineB ",inline"
+	}{1, inlineB{2, inlineC{3}}},
+	panic: `Duplicated key 'b' in struct struct \{ B int; .*`,
+}, {
+	value: &struct {
+		A int
+		B map[string]int ",inline"
+	}{1, map[string]int{"a": 2}},
+	panic: `Can't have key "a" in inlined map; conflicts with struct field`,
+}}
+
+func (s *S) TestMarshalErrors(c *C) {
+	for _, item := range marshalErrorTests {
+		if item.panic != "" {
+			c.Assert(func() { yaml.Marshal(item.value) }, PanicMatches, item.panic)
+		} else {
+			_, err := yaml.Marshal(item.value)
+			c.Assert(err, ErrorMatches, item.error)
+		}
+	}
+}
+
+func (s *S) TestMarshalTypeCache(c *C) {
+	var data []byte
+	var err error
+	func() {
+		type T struct{ A int }
+		data, err = yaml.Marshal(&T{})
+		c.Assert(err, IsNil)
+	}()
+	func() {
+		type T struct{ B int }
+		data, err = yaml.Marshal(&T{})
+		c.Assert(err, IsNil)
+	}()
+	c.Assert(string(data), Equals, "b: 0\n")
+}
+
+var marshalerTests = []struct {
+	data  string
+	value interface{}
+}{
+	{"_:\n  hi: there\n", map[interface{}]interface{}{"hi": "there"}},
+	{"_:\n- 1\n- A\n", []interface{}{1, "A"}},
+	{"_: 10\n", 10},
+	{"_: null\n", nil},
+	{"_: BAR!\n", "BAR!"},
+}
+
+type marshalerType struct {
+	value interface{}
+}
+
+func (o marshalerType) MarshalText() ([]byte, error) {
+	panic("MarshalText called on type with MarshalYAML")
+}
+
+func (o marshalerType) MarshalYAML() (interface{}, error) {
+	return o.value, nil
+}
+
+type marshalerValue struct {
+	Field marshalerType "_"
+}
+
+func (s *S) TestMarshaler(c *C) {
+	for _, item := range marshalerTests {
+		obj := &marshalerValue{}
+		obj.Field.value = item.value
+		data, err := yaml.Marshal(obj)
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, string(item.data))
+	}
+}
+
+func (s *S) TestMarshalerWholeDocument(c *C) {
+	obj := &marshalerType{}
+	obj.value = map[string]string{"hello": "world!"}
+	data, err := yaml.Marshal(obj)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, "hello: world!\n")
+}
+
+type failingMarshaler struct{}
+
+func (ft *failingMarshaler) MarshalYAML() (interface{}, error) {
+	return nil, failingErr
+}
+
+func (s *S) TestMarshalerError(c *C) {
+	_, err := yaml.Marshal(&failingMarshaler{})
+	c.Assert(err, Equals, failingErr)
+}
+
+func (s *S) TestSortedOutput(c *C) {
+	order := []interface{}{
+		false,
+		true,
+		1,
+		uint(1),
+		1.0,
+		1.1,
+		1.2,
+		2,
+		uint(2),
+		2.0,
+		2.1,
+		"",
+		".1",
+		".2",
+		".a",
+		"1",
+		"2",
+		"a!10",
+		"a/2",
+		"a/10",
+		"a~10",
+		"ab/1",
+		"b/1",
+		"b/01",
+		"b/2",
+		"b/02",
+		"b/3",
+		"b/03",
+		"b1",
+		"b01",
+		"b3",
+		"c2.10",
+		"c10.2",
+		"d1",
+		"d12",
+		"d12a",
+	}
+	m := make(map[interface{}]int)
+	for _, k := range order {
+		m[k] = 1
+	}
+	data, err := yaml.Marshal(m)
+	c.Assert(err, IsNil)
+	out := "\n" + string(data)
+	last := 0
+	for i, k := range order {
+		repr := fmt.Sprint(k)
+		if s, ok := k.(string); ok {
+			if _, err = strconv.ParseFloat(repr, 32); s == "" || err == nil {
+				repr = `"` + repr + `"`
+			}
+		}
+		index := strings.Index(out, "\n"+repr+":")
+		if index == -1 {
+			c.Fatalf("%#v is not in the output: %#v", k, out)
+		}
+		if index < last {
+			c.Fatalf("%#v was generated before %#v: %q", k, order[i-1], out)
+		}
+		last = index
+	}
+}

--- a/vendor/gopkg.in/yaml.v2/parserc.go
+++ b/vendor/gopkg.in/yaml.v2/parserc.go
@@ -1,0 +1,1096 @@
+package yaml
+
+import (
+	"bytes"
+)
+
+// The parser implements the following grammar:
+//
+// stream               ::= STREAM-START implicit_document? explicit_document* STREAM-END
+// implicit_document    ::= block_node DOCUMENT-END*
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+// block_node_or_indentless_sequence    ::=
+//                          ALIAS
+//                          | properties (block_content | indentless_block_sequence)?
+//                          | block_content
+//                          | indentless_block_sequence
+// block_node           ::= ALIAS
+//                          | properties block_content?
+//                          | block_content
+// flow_node            ::= ALIAS
+//                          | properties flow_content?
+//                          | flow_content
+// properties           ::= TAG ANCHOR? | ANCHOR TAG?
+// block_content        ::= block_collection | flow_collection | SCALAR
+// flow_content         ::= flow_collection | SCALAR
+// block_collection     ::= block_sequence | block_mapping
+// flow_collection      ::= flow_sequence | flow_mapping
+// block_sequence       ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
+// indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
+// block_mapping        ::= BLOCK-MAPPING_START
+//                          ((KEY block_node_or_indentless_sequence?)?
+//                          (VALUE block_node_or_indentless_sequence?)?)*
+//                          BLOCK-END
+// flow_sequence        ::= FLOW-SEQUENCE-START
+//                          (flow_sequence_entry FLOW-ENTRY)*
+//                          flow_sequence_entry?
+//                          FLOW-SEQUENCE-END
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+// flow_mapping         ::= FLOW-MAPPING-START
+//                          (flow_mapping_entry FLOW-ENTRY)*
+//                          flow_mapping_entry?
+//                          FLOW-MAPPING-END
+// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+
+// Peek the next token in the token queue.
+func peek_token(parser *yaml_parser_t) *yaml_token_t {
+	if parser.token_available || yaml_parser_fetch_more_tokens(parser) {
+		return &parser.tokens[parser.tokens_head]
+	}
+	return nil
+}
+
+// Remove the next token from the queue (must be called after peek_token).
+func skip_token(parser *yaml_parser_t) {
+	parser.token_available = false
+	parser.tokens_parsed++
+	parser.stream_end_produced = parser.tokens[parser.tokens_head].typ == yaml_STREAM_END_TOKEN
+	parser.tokens_head++
+}
+
+// Get the next event.
+func yaml_parser_parse(parser *yaml_parser_t, event *yaml_event_t) bool {
+	// Erase the event object.
+	*event = yaml_event_t{}
+
+	// No events after the end of the stream or error.
+	if parser.stream_end_produced || parser.error != yaml_NO_ERROR || parser.state == yaml_PARSE_END_STATE {
+		return true
+	}
+
+	// Generate the next event.
+	return yaml_parser_state_machine(parser, event)
+}
+
+// Set parser error.
+func yaml_parser_set_parser_error(parser *yaml_parser_t, problem string, problem_mark yaml_mark_t) bool {
+	parser.error = yaml_PARSER_ERROR
+	parser.problem = problem
+	parser.problem_mark = problem_mark
+	return false
+}
+
+func yaml_parser_set_parser_error_context(parser *yaml_parser_t, context string, context_mark yaml_mark_t, problem string, problem_mark yaml_mark_t) bool {
+	parser.error = yaml_PARSER_ERROR
+	parser.context = context
+	parser.context_mark = context_mark
+	parser.problem = problem
+	parser.problem_mark = problem_mark
+	return false
+}
+
+// State dispatcher.
+func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool {
+	//trace("yaml_parser_state_machine", "state:", parser.state.String())
+
+	switch parser.state {
+	case yaml_PARSE_STREAM_START_STATE:
+		return yaml_parser_parse_stream_start(parser, event)
+
+	case yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE:
+		return yaml_parser_parse_document_start(parser, event, true)
+
+	case yaml_PARSE_DOCUMENT_START_STATE:
+		return yaml_parser_parse_document_start(parser, event, false)
+
+	case yaml_PARSE_DOCUMENT_CONTENT_STATE:
+		return yaml_parser_parse_document_content(parser, event)
+
+	case yaml_PARSE_DOCUMENT_END_STATE:
+		return yaml_parser_parse_document_end(parser, event)
+
+	case yaml_PARSE_BLOCK_NODE_STATE:
+		return yaml_parser_parse_node(parser, event, true, false)
+
+	case yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
+		return yaml_parser_parse_node(parser, event, true, true)
+
+	case yaml_PARSE_FLOW_NODE_STATE:
+		return yaml_parser_parse_node(parser, event, false, false)
+
+	case yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
+		return yaml_parser_parse_block_sequence_entry(parser, event, true)
+
+	case yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE:
+		return yaml_parser_parse_block_sequence_entry(parser, event, false)
+
+	case yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE:
+		return yaml_parser_parse_indentless_sequence_entry(parser, event)
+
+	case yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE:
+		return yaml_parser_parse_block_mapping_key(parser, event, true)
+
+	case yaml_PARSE_BLOCK_MAPPING_KEY_STATE:
+		return yaml_parser_parse_block_mapping_key(parser, event, false)
+
+	case yaml_PARSE_BLOCK_MAPPING_VALUE_STATE:
+		return yaml_parser_parse_block_mapping_value(parser, event)
+
+	case yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE:
+		return yaml_parser_parse_flow_sequence_entry(parser, event, true)
+
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE:
+		return yaml_parser_parse_flow_sequence_entry(parser, event, false)
+
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE:
+		return yaml_parser_parse_flow_sequence_entry_mapping_key(parser, event)
+
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE:
+		return yaml_parser_parse_flow_sequence_entry_mapping_value(parser, event)
+
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE:
+		return yaml_parser_parse_flow_sequence_entry_mapping_end(parser, event)
+
+	case yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE:
+		return yaml_parser_parse_flow_mapping_key(parser, event, true)
+
+	case yaml_PARSE_FLOW_MAPPING_KEY_STATE:
+		return yaml_parser_parse_flow_mapping_key(parser, event, false)
+
+	case yaml_PARSE_FLOW_MAPPING_VALUE_STATE:
+		return yaml_parser_parse_flow_mapping_value(parser, event, false)
+
+	case yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE:
+		return yaml_parser_parse_flow_mapping_value(parser, event, true)
+
+	default:
+		panic("invalid parser state")
+	}
+	return false
+}
+
+// Parse the production:
+// stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
+//              ************
+func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ != yaml_STREAM_START_TOKEN {
+		return yaml_parser_set_parser_error(parser, "did not find expected <stream-start>", token.start_mark)
+	}
+	parser.state = yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE
+	*event = yaml_event_t{
+		typ:        yaml_STREAM_START_EVENT,
+		start_mark: token.start_mark,
+		end_mark:   token.end_mark,
+		encoding:   token.encoding,
+	}
+	skip_token(parser)
+	return true
+}
+
+// Parse the productions:
+// implicit_document    ::= block_node DOCUMENT-END*
+//                          *
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//                          *************************
+func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t, implicit bool) bool {
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	// Parse extra document end indicators.
+	if !implicit {
+		for token.typ == yaml_DOCUMENT_END_TOKEN {
+			skip_token(parser)
+			token = peek_token(parser)
+			if token == nil {
+				return false
+			}
+		}
+	}
+
+	if implicit && token.typ != yaml_VERSION_DIRECTIVE_TOKEN &&
+		token.typ != yaml_TAG_DIRECTIVE_TOKEN &&
+		token.typ != yaml_DOCUMENT_START_TOKEN &&
+		token.typ != yaml_STREAM_END_TOKEN {
+		// Parse an implicit document.
+		if !yaml_parser_process_directives(parser, nil, nil) {
+			return false
+		}
+		parser.states = append(parser.states, yaml_PARSE_DOCUMENT_END_STATE)
+		parser.state = yaml_PARSE_BLOCK_NODE_STATE
+
+		*event = yaml_event_t{
+			typ:        yaml_DOCUMENT_START_EVENT,
+			start_mark: token.start_mark,
+			end_mark:   token.end_mark,
+		}
+
+	} else if token.typ != yaml_STREAM_END_TOKEN {
+		// Parse an explicit document.
+		var version_directive *yaml_version_directive_t
+		var tag_directives []yaml_tag_directive_t
+		start_mark := token.start_mark
+		if !yaml_parser_process_directives(parser, &version_directive, &tag_directives) {
+			return false
+		}
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_DOCUMENT_START_TOKEN {
+			yaml_parser_set_parser_error(parser,
+				"did not find expected <document start>", token.start_mark)
+			return false
+		}
+		parser.states = append(parser.states, yaml_PARSE_DOCUMENT_END_STATE)
+		parser.state = yaml_PARSE_DOCUMENT_CONTENT_STATE
+		end_mark := token.end_mark
+
+		*event = yaml_event_t{
+			typ:               yaml_DOCUMENT_START_EVENT,
+			start_mark:        start_mark,
+			end_mark:          end_mark,
+			version_directive: version_directive,
+			tag_directives:    tag_directives,
+			implicit:          false,
+		}
+		skip_token(parser)
+
+	} else {
+		// Parse the stream end.
+		parser.state = yaml_PARSE_END_STATE
+		*event = yaml_event_t{
+			typ:        yaml_STREAM_END_EVENT,
+			start_mark: token.start_mark,
+			end_mark:   token.end_mark,
+		}
+		skip_token(parser)
+	}
+
+	return true
+}
+
+// Parse the productions:
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//                                                    ***********
+//
+func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ == yaml_VERSION_DIRECTIVE_TOKEN ||
+		token.typ == yaml_TAG_DIRECTIVE_TOKEN ||
+		token.typ == yaml_DOCUMENT_START_TOKEN ||
+		token.typ == yaml_DOCUMENT_END_TOKEN ||
+		token.typ == yaml_STREAM_END_TOKEN {
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+		return yaml_parser_process_empty_scalar(parser, event,
+			token.start_mark)
+	}
+	return yaml_parser_parse_node(parser, event, true, false)
+}
+
+// Parse the productions:
+// implicit_document    ::= block_node DOCUMENT-END*
+//                                     *************
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
+//
+func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	start_mark := token.start_mark
+	end_mark := token.start_mark
+
+	implicit := true
+	if token.typ == yaml_DOCUMENT_END_TOKEN {
+		end_mark = token.end_mark
+		skip_token(parser)
+		implicit = false
+	}
+
+	parser.tag_directives = parser.tag_directives[:0]
+
+	parser.state = yaml_PARSE_DOCUMENT_START_STATE
+	*event = yaml_event_t{
+		typ:        yaml_DOCUMENT_END_EVENT,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		implicit:   implicit,
+	}
+	return true
+}
+
+// Parse the productions:
+// block_node_or_indentless_sequence    ::=
+//                          ALIAS
+//                          *****
+//                          | properties (block_content | indentless_block_sequence)?
+//                            **********  *
+//                          | block_content | indentless_block_sequence
+//                            *
+// block_node           ::= ALIAS
+//                          *****
+//                          | properties block_content?
+//                            ********** *
+//                          | block_content
+//                            *
+// flow_node            ::= ALIAS
+//                          *****
+//                          | properties flow_content?
+//                            ********** *
+//                          | flow_content
+//                            *
+// properties           ::= TAG ANCHOR? | ANCHOR TAG?
+//                          *************************
+// block_content        ::= block_collection | flow_collection | SCALAR
+//                                                               ******
+// flow_content         ::= flow_collection | SCALAR
+//                                            ******
+func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, indentless_sequence bool) bool {
+	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	if token.typ == yaml_ALIAS_TOKEN {
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+		*event = yaml_event_t{
+			typ:        yaml_ALIAS_EVENT,
+			start_mark: token.start_mark,
+			end_mark:   token.end_mark,
+			anchor:     token.value,
+		}
+		skip_token(parser)
+		return true
+	}
+
+	start_mark := token.start_mark
+	end_mark := token.start_mark
+
+	var tag_token bool
+	var tag_handle, tag_suffix, anchor []byte
+	var tag_mark yaml_mark_t
+	if token.typ == yaml_ANCHOR_TOKEN {
+		anchor = token.value
+		start_mark = token.start_mark
+		end_mark = token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ == yaml_TAG_TOKEN {
+			tag_token = true
+			tag_handle = token.value
+			tag_suffix = token.suffix
+			tag_mark = token.start_mark
+			end_mark = token.end_mark
+			skip_token(parser)
+			token = peek_token(parser)
+			if token == nil {
+				return false
+			}
+		}
+	} else if token.typ == yaml_TAG_TOKEN {
+		tag_token = true
+		tag_handle = token.value
+		tag_suffix = token.suffix
+		start_mark = token.start_mark
+		tag_mark = token.start_mark
+		end_mark = token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ == yaml_ANCHOR_TOKEN {
+			anchor = token.value
+			end_mark = token.end_mark
+			skip_token(parser)
+			token = peek_token(parser)
+			if token == nil {
+				return false
+			}
+		}
+	}
+
+	var tag []byte
+	if tag_token {
+		if len(tag_handle) == 0 {
+			tag = tag_suffix
+			tag_suffix = nil
+		} else {
+			for i := range parser.tag_directives {
+				if bytes.Equal(parser.tag_directives[i].handle, tag_handle) {
+					tag = append([]byte(nil), parser.tag_directives[i].prefix...)
+					tag = append(tag, tag_suffix...)
+					break
+				}
+			}
+			if len(tag) == 0 {
+				yaml_parser_set_parser_error_context(parser,
+					"while parsing a node", start_mark,
+					"found undefined tag handle", tag_mark)
+				return false
+			}
+		}
+	}
+
+	implicit := len(tag) == 0
+	if indentless_sequence && token.typ == yaml_BLOCK_ENTRY_TOKEN {
+		end_mark = token.end_mark
+		parser.state = yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE
+		*event = yaml_event_t{
+			typ:        yaml_SEQUENCE_START_EVENT,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			anchor:     anchor,
+			tag:        tag,
+			implicit:   implicit,
+			style:      yaml_style_t(yaml_BLOCK_SEQUENCE_STYLE),
+		}
+		return true
+	}
+	if token.typ == yaml_SCALAR_TOKEN {
+		var plain_implicit, quoted_implicit bool
+		end_mark = token.end_mark
+		if (len(tag) == 0 && token.style == yaml_PLAIN_SCALAR_STYLE) || (len(tag) == 1 && tag[0] == '!') {
+			plain_implicit = true
+		} else if len(tag) == 0 {
+			quoted_implicit = true
+		}
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+
+		*event = yaml_event_t{
+			typ:             yaml_SCALAR_EVENT,
+			start_mark:      start_mark,
+			end_mark:        end_mark,
+			anchor:          anchor,
+			tag:             tag,
+			value:           token.value,
+			implicit:        plain_implicit,
+			quoted_implicit: quoted_implicit,
+			style:           yaml_style_t(token.style),
+		}
+		skip_token(parser)
+		return true
+	}
+	if token.typ == yaml_FLOW_SEQUENCE_START_TOKEN {
+		// [Go] Some of the events below can be merged as they differ only on style.
+		end_mark = token.end_mark
+		parser.state = yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE
+		*event = yaml_event_t{
+			typ:        yaml_SEQUENCE_START_EVENT,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			anchor:     anchor,
+			tag:        tag,
+			implicit:   implicit,
+			style:      yaml_style_t(yaml_FLOW_SEQUENCE_STYLE),
+		}
+		return true
+	}
+	if token.typ == yaml_FLOW_MAPPING_START_TOKEN {
+		end_mark = token.end_mark
+		parser.state = yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE
+		*event = yaml_event_t{
+			typ:        yaml_MAPPING_START_EVENT,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			anchor:     anchor,
+			tag:        tag,
+			implicit:   implicit,
+			style:      yaml_style_t(yaml_FLOW_MAPPING_STYLE),
+		}
+		return true
+	}
+	if block && token.typ == yaml_BLOCK_SEQUENCE_START_TOKEN {
+		end_mark = token.end_mark
+		parser.state = yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE
+		*event = yaml_event_t{
+			typ:        yaml_SEQUENCE_START_EVENT,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			anchor:     anchor,
+			tag:        tag,
+			implicit:   implicit,
+			style:      yaml_style_t(yaml_BLOCK_SEQUENCE_STYLE),
+		}
+		return true
+	}
+	if block && token.typ == yaml_BLOCK_MAPPING_START_TOKEN {
+		end_mark = token.end_mark
+		parser.state = yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE
+		*event = yaml_event_t{
+			typ:        yaml_MAPPING_START_EVENT,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			anchor:     anchor,
+			tag:        tag,
+			implicit:   implicit,
+			style:      yaml_style_t(yaml_BLOCK_MAPPING_STYLE),
+		}
+		return true
+	}
+	if len(anchor) > 0 || len(tag) > 0 {
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+
+		*event = yaml_event_t{
+			typ:             yaml_SCALAR_EVENT,
+			start_mark:      start_mark,
+			end_mark:        end_mark,
+			anchor:          anchor,
+			tag:             tag,
+			implicit:        implicit,
+			quoted_implicit: false,
+			style:           yaml_style_t(yaml_PLAIN_SCALAR_STYLE),
+		}
+		return true
+	}
+
+	context := "while parsing a flow node"
+	if block {
+		context = "while parsing a block node"
+	}
+	yaml_parser_set_parser_error_context(parser, context, start_mark,
+		"did not find expected node content", token.start_mark)
+	return false
+}
+
+// Parse the productions:
+// block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
+//                    ********************  *********** *             *********
+//
+func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+	if first {
+		token := peek_token(parser)
+		parser.marks = append(parser.marks, token.start_mark)
+		skip_token(parser)
+	}
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
+		mark := token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_BLOCK_ENTRY_TOKEN && token.typ != yaml_BLOCK_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE)
+			return yaml_parser_parse_node(parser, event, true, false)
+		} else {
+			parser.state = yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE
+			return yaml_parser_process_empty_scalar(parser, event, mark)
+		}
+	}
+	if token.typ == yaml_BLOCK_END_TOKEN {
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+		parser.marks = parser.marks[:len(parser.marks)-1]
+
+		*event = yaml_event_t{
+			typ:        yaml_SEQUENCE_END_EVENT,
+			start_mark: token.start_mark,
+			end_mark:   token.end_mark,
+		}
+
+		skip_token(parser)
+		return true
+	}
+
+	context_mark := parser.marks[len(parser.marks)-1]
+	parser.marks = parser.marks[:len(parser.marks)-1]
+	return yaml_parser_set_parser_error_context(parser,
+		"while parsing a block collection", context_mark,
+		"did not find expected '-' indicator", token.start_mark)
+}
+
+// Parse the productions:
+// indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
+//                           *********** *
+func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
+		mark := token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_BLOCK_ENTRY_TOKEN &&
+			token.typ != yaml_KEY_TOKEN &&
+			token.typ != yaml_VALUE_TOKEN &&
+			token.typ != yaml_BLOCK_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE)
+			return yaml_parser_parse_node(parser, event, true, false)
+		}
+		parser.state = yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE
+		return yaml_parser_process_empty_scalar(parser, event, mark)
+	}
+	parser.state = parser.states[len(parser.states)-1]
+	parser.states = parser.states[:len(parser.states)-1]
+
+	*event = yaml_event_t{
+		typ:        yaml_SEQUENCE_END_EVENT,
+		start_mark: token.start_mark,
+		end_mark:   token.start_mark, // [Go] Shouldn't this be token.end_mark?
+	}
+	return true
+}
+
+// Parse the productions:
+// block_mapping        ::= BLOCK-MAPPING_START
+//                          *******************
+//                          ((KEY block_node_or_indentless_sequence?)?
+//                            *** *
+//                          (VALUE block_node_or_indentless_sequence?)?)*
+//
+//                          BLOCK-END
+//                          *********
+//
+func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+	if first {
+		token := peek_token(parser)
+		parser.marks = append(parser.marks, token.start_mark)
+		skip_token(parser)
+	}
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	if token.typ == yaml_KEY_TOKEN {
+		mark := token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_KEY_TOKEN &&
+			token.typ != yaml_VALUE_TOKEN &&
+			token.typ != yaml_BLOCK_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_VALUE_STATE)
+			return yaml_parser_parse_node(parser, event, true, true)
+		} else {
+			parser.state = yaml_PARSE_BLOCK_MAPPING_VALUE_STATE
+			return yaml_parser_process_empty_scalar(parser, event, mark)
+		}
+	} else if token.typ == yaml_BLOCK_END_TOKEN {
+		parser.state = parser.states[len(parser.states)-1]
+		parser.states = parser.states[:len(parser.states)-1]
+		parser.marks = parser.marks[:len(parser.marks)-1]
+		*event = yaml_event_t{
+			typ:        yaml_MAPPING_END_EVENT,
+			start_mark: token.start_mark,
+			end_mark:   token.end_mark,
+		}
+		skip_token(parser)
+		return true
+	}
+
+	context_mark := parser.marks[len(parser.marks)-1]
+	parser.marks = parser.marks[:len(parser.marks)-1]
+	return yaml_parser_set_parser_error_context(parser,
+		"while parsing a block mapping", context_mark,
+		"did not find expected key", token.start_mark)
+}
+
+// Parse the productions:
+// block_mapping        ::= BLOCK-MAPPING_START
+//
+//                          ((KEY block_node_or_indentless_sequence?)?
+//
+//                          (VALUE block_node_or_indentless_sequence?)?)*
+//                           ***** *
+//                          BLOCK-END
+//
+//
+func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ == yaml_VALUE_TOKEN {
+		mark := token.end_mark
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_KEY_TOKEN &&
+			token.typ != yaml_VALUE_TOKEN &&
+			token.typ != yaml_BLOCK_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_KEY_STATE)
+			return yaml_parser_parse_node(parser, event, true, true)
+		}
+		parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
+		return yaml_parser_process_empty_scalar(parser, event, mark)
+	}
+	parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
+	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+}
+
+// Parse the productions:
+// flow_sequence        ::= FLOW-SEQUENCE-START
+//                          *******************
+//                          (flow_sequence_entry FLOW-ENTRY)*
+//                           *                   **********
+//                          flow_sequence_entry?
+//                          *
+//                          FLOW-SEQUENCE-END
+//                          *****************
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                          *
+//
+func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+	if first {
+		token := peek_token(parser)
+		parser.marks = append(parser.marks, token.start_mark)
+		skip_token(parser)
+	}
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
+		if !first {
+			if token.typ == yaml_FLOW_ENTRY_TOKEN {
+				skip_token(parser)
+				token = peek_token(parser)
+				if token == nil {
+					return false
+				}
+			} else {
+				context_mark := parser.marks[len(parser.marks)-1]
+				parser.marks = parser.marks[:len(parser.marks)-1]
+				return yaml_parser_set_parser_error_context(parser,
+					"while parsing a flow sequence", context_mark,
+					"did not find expected ',' or ']'", token.start_mark)
+			}
+		}
+
+		if token.typ == yaml_KEY_TOKEN {
+			parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE
+			*event = yaml_event_t{
+				typ:        yaml_MAPPING_START_EVENT,
+				start_mark: token.start_mark,
+				end_mark:   token.end_mark,
+				implicit:   true,
+				style:      yaml_style_t(yaml_FLOW_MAPPING_STYLE),
+			}
+			skip_token(parser)
+			return true
+		} else if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE)
+			return yaml_parser_parse_node(parser, event, false, false)
+		}
+	}
+
+	parser.state = parser.states[len(parser.states)-1]
+	parser.states = parser.states[:len(parser.states)-1]
+	parser.marks = parser.marks[:len(parser.marks)-1]
+
+	*event = yaml_event_t{
+		typ:        yaml_SEQUENCE_END_EVENT,
+		start_mark: token.start_mark,
+		end_mark:   token.end_mark,
+	}
+
+	skip_token(parser)
+	return true
+}
+
+//
+// Parse the productions:
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                                      *** *
+//
+func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ != yaml_VALUE_TOKEN &&
+		token.typ != yaml_FLOW_ENTRY_TOKEN &&
+		token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
+		parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE)
+		return yaml_parser_parse_node(parser, event, false, false)
+	}
+	mark := token.end_mark
+	skip_token(parser)
+	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE
+	return yaml_parser_process_empty_scalar(parser, event, mark)
+}
+
+// Parse the productions:
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                                                      ***** *
+//
+func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if token.typ == yaml_VALUE_TOKEN {
+		skip_token(parser)
+		token := peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE)
+			return yaml_parser_parse_node(parser, event, false, false)
+		}
+	}
+	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE
+	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+}
+
+// Parse the productions:
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                                                                      *
+//
+func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, event *yaml_event_t) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE
+	*event = yaml_event_t{
+		typ:        yaml_MAPPING_END_EVENT,
+		start_mark: token.start_mark,
+		end_mark:   token.start_mark, // [Go] Shouldn't this be end_mark?
+	}
+	return true
+}
+
+// Parse the productions:
+// flow_mapping         ::= FLOW-MAPPING-START
+//                          ******************
+//                          (flow_mapping_entry FLOW-ENTRY)*
+//                           *                  **********
+//                          flow_mapping_entry?
+//                          ******************
+//                          FLOW-MAPPING-END
+//                          ****************
+// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                          *           *** *
+//
+func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+	if first {
+		token := peek_token(parser)
+		parser.marks = append(parser.marks, token.start_mark)
+		skip_token(parser)
+	}
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
+		if !first {
+			if token.typ == yaml_FLOW_ENTRY_TOKEN {
+				skip_token(parser)
+				token = peek_token(parser)
+				if token == nil {
+					return false
+				}
+			} else {
+				context_mark := parser.marks[len(parser.marks)-1]
+				parser.marks = parser.marks[:len(parser.marks)-1]
+				return yaml_parser_set_parser_error_context(parser,
+					"while parsing a flow mapping", context_mark,
+					"did not find expected ',' or '}'", token.start_mark)
+			}
+		}
+
+		if token.typ == yaml_KEY_TOKEN {
+			skip_token(parser)
+			token = peek_token(parser)
+			if token == nil {
+				return false
+			}
+			if token.typ != yaml_VALUE_TOKEN &&
+				token.typ != yaml_FLOW_ENTRY_TOKEN &&
+				token.typ != yaml_FLOW_MAPPING_END_TOKEN {
+				parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_VALUE_STATE)
+				return yaml_parser_parse_node(parser, event, false, false)
+			} else {
+				parser.state = yaml_PARSE_FLOW_MAPPING_VALUE_STATE
+				return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+			}
+		} else if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE)
+			return yaml_parser_parse_node(parser, event, false, false)
+		}
+	}
+
+	parser.state = parser.states[len(parser.states)-1]
+	parser.states = parser.states[:len(parser.states)-1]
+	parser.marks = parser.marks[:len(parser.marks)-1]
+	*event = yaml_event_t{
+		typ:        yaml_MAPPING_END_EVENT,
+		start_mark: token.start_mark,
+		end_mark:   token.end_mark,
+	}
+	skip_token(parser)
+	return true
+}
+
+// Parse the productions:
+// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//                                   *                  ***** *
+//
+func yaml_parser_parse_flow_mapping_value(parser *yaml_parser_t, event *yaml_event_t, empty bool) bool {
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+	if empty {
+		parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
+		return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	}
+	if token.typ == yaml_VALUE_TOKEN {
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_MAPPING_END_TOKEN {
+			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_KEY_STATE)
+			return yaml_parser_parse_node(parser, event, false, false)
+		}
+	}
+	parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
+	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+}
+
+// Generate an empty scalar event.
+func yaml_parser_process_empty_scalar(parser *yaml_parser_t, event *yaml_event_t, mark yaml_mark_t) bool {
+	*event = yaml_event_t{
+		typ:        yaml_SCALAR_EVENT,
+		start_mark: mark,
+		end_mark:   mark,
+		value:      nil, // Empty
+		implicit:   true,
+		style:      yaml_style_t(yaml_PLAIN_SCALAR_STYLE),
+	}
+	return true
+}
+
+var default_tag_directives = []yaml_tag_directive_t{
+	{[]byte("!"), []byte("!")},
+	{[]byte("!!"), []byte("tag:yaml.org,2002:")},
+}
+
+// Parse directives.
+func yaml_parser_process_directives(parser *yaml_parser_t,
+	version_directive_ref **yaml_version_directive_t,
+	tag_directives_ref *[]yaml_tag_directive_t) bool {
+
+	var version_directive *yaml_version_directive_t
+	var tag_directives []yaml_tag_directive_t
+
+	token := peek_token(parser)
+	if token == nil {
+		return false
+	}
+
+	for token.typ == yaml_VERSION_DIRECTIVE_TOKEN || token.typ == yaml_TAG_DIRECTIVE_TOKEN {
+		if token.typ == yaml_VERSION_DIRECTIVE_TOKEN {
+			if version_directive != nil {
+				yaml_parser_set_parser_error(parser,
+					"found duplicate %YAML directive", token.start_mark)
+				return false
+			}
+			if token.major != 1 || token.minor != 1 {
+				yaml_parser_set_parser_error(parser,
+					"found incompatible YAML document", token.start_mark)
+				return false
+			}
+			version_directive = &yaml_version_directive_t{
+				major: token.major,
+				minor: token.minor,
+			}
+		} else if token.typ == yaml_TAG_DIRECTIVE_TOKEN {
+			value := yaml_tag_directive_t{
+				handle: token.value,
+				prefix: token.prefix,
+			}
+			if !yaml_parser_append_tag_directive(parser, value, false, token.start_mark) {
+				return false
+			}
+			tag_directives = append(tag_directives, value)
+		}
+
+		skip_token(parser)
+		token = peek_token(parser)
+		if token == nil {
+			return false
+		}
+	}
+
+	for i := range default_tag_directives {
+		if !yaml_parser_append_tag_directive(parser, default_tag_directives[i], true, token.start_mark) {
+			return false
+		}
+	}
+
+	if version_directive_ref != nil {
+		*version_directive_ref = version_directive
+	}
+	if tag_directives_ref != nil {
+		*tag_directives_ref = tag_directives
+	}
+	return true
+}
+
+// Append a tag directive to the directives stack.
+func yaml_parser_append_tag_directive(parser *yaml_parser_t, value yaml_tag_directive_t, allow_duplicates bool, mark yaml_mark_t) bool {
+	for i := range parser.tag_directives {
+		if bytes.Equal(value.handle, parser.tag_directives[i].handle) {
+			if allow_duplicates {
+				return true
+			}
+			return yaml_parser_set_parser_error(parser, "found duplicate %TAG directive", mark)
+		}
+	}
+
+	// [Go] I suspect the copy is unnecessary. This was likely done
+	// because there was no way to track ownership of the data.
+	value_copy := yaml_tag_directive_t{
+		handle: make([]byte, len(value.handle)),
+		prefix: make([]byte, len(value.prefix)),
+	}
+	copy(value_copy.handle, value.handle)
+	copy(value_copy.prefix, value.prefix)
+	parser.tag_directives = append(parser.tag_directives, value_copy)
+	return true
+}

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -1,0 +1,391 @@
+package yaml
+
+import (
+	"io"
+)
+
+// Set the reader error and return 0.
+func yaml_parser_set_reader_error(parser *yaml_parser_t, problem string, offset int, value int) bool {
+	parser.error = yaml_READER_ERROR
+	parser.problem = problem
+	parser.problem_offset = offset
+	parser.problem_value = value
+	return false
+}
+
+// Byte order marks.
+const (
+	bom_UTF8    = "\xef\xbb\xbf"
+	bom_UTF16LE = "\xff\xfe"
+	bom_UTF16BE = "\xfe\xff"
+)
+
+// Determine the input stream encoding by checking the BOM symbol. If no BOM is
+// found, the UTF-8 encoding is assumed. Return 1 on success, 0 on failure.
+func yaml_parser_determine_encoding(parser *yaml_parser_t) bool {
+	// Ensure that we had enough bytes in the raw buffer.
+	for !parser.eof && len(parser.raw_buffer)-parser.raw_buffer_pos < 3 {
+		if !yaml_parser_update_raw_buffer(parser) {
+			return false
+		}
+	}
+
+	// Determine the encoding.
+	buf := parser.raw_buffer
+	pos := parser.raw_buffer_pos
+	avail := len(buf) - pos
+	if avail >= 2 && buf[pos] == bom_UTF16LE[0] && buf[pos+1] == bom_UTF16LE[1] {
+		parser.encoding = yaml_UTF16LE_ENCODING
+		parser.raw_buffer_pos += 2
+		parser.offset += 2
+	} else if avail >= 2 && buf[pos] == bom_UTF16BE[0] && buf[pos+1] == bom_UTF16BE[1] {
+		parser.encoding = yaml_UTF16BE_ENCODING
+		parser.raw_buffer_pos += 2
+		parser.offset += 2
+	} else if avail >= 3 && buf[pos] == bom_UTF8[0] && buf[pos+1] == bom_UTF8[1] && buf[pos+2] == bom_UTF8[2] {
+		parser.encoding = yaml_UTF8_ENCODING
+		parser.raw_buffer_pos += 3
+		parser.offset += 3
+	} else {
+		parser.encoding = yaml_UTF8_ENCODING
+	}
+	return true
+}
+
+// Update the raw buffer.
+func yaml_parser_update_raw_buffer(parser *yaml_parser_t) bool {
+	size_read := 0
+
+	// Return if the raw buffer is full.
+	if parser.raw_buffer_pos == 0 && len(parser.raw_buffer) == cap(parser.raw_buffer) {
+		return true
+	}
+
+	// Return on EOF.
+	if parser.eof {
+		return true
+	}
+
+	// Move the remaining bytes in the raw buffer to the beginning.
+	if parser.raw_buffer_pos > 0 && parser.raw_buffer_pos < len(parser.raw_buffer) {
+		copy(parser.raw_buffer, parser.raw_buffer[parser.raw_buffer_pos:])
+	}
+	parser.raw_buffer = parser.raw_buffer[:len(parser.raw_buffer)-parser.raw_buffer_pos]
+	parser.raw_buffer_pos = 0
+
+	// Call the read handler to fill the buffer.
+	size_read, err := parser.read_handler(parser, parser.raw_buffer[len(parser.raw_buffer):cap(parser.raw_buffer)])
+	parser.raw_buffer = parser.raw_buffer[:len(parser.raw_buffer)+size_read]
+	if err == io.EOF {
+		parser.eof = true
+	} else if err != nil {
+		return yaml_parser_set_reader_error(parser, "input error: "+err.Error(), parser.offset, -1)
+	}
+	return true
+}
+
+// Ensure that the buffer contains at least `length` characters.
+// Return true on success, false on failure.
+//
+// The length is supposed to be significantly less that the buffer size.
+func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
+	if parser.read_handler == nil {
+		panic("read handler must be set")
+	}
+
+	// If the EOF flag is set and the raw buffer is empty, do nothing.
+	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {
+		return true
+	}
+
+	// Return if the buffer contains enough characters.
+	if parser.unread >= length {
+		return true
+	}
+
+	// Determine the input encoding if it is not known yet.
+	if parser.encoding == yaml_ANY_ENCODING {
+		if !yaml_parser_determine_encoding(parser) {
+			return false
+		}
+	}
+
+	// Move the unread characters to the beginning of the buffer.
+	buffer_len := len(parser.buffer)
+	if parser.buffer_pos > 0 && parser.buffer_pos < buffer_len {
+		copy(parser.buffer, parser.buffer[parser.buffer_pos:])
+		buffer_len -= parser.buffer_pos
+		parser.buffer_pos = 0
+	} else if parser.buffer_pos == buffer_len {
+		buffer_len = 0
+		parser.buffer_pos = 0
+	}
+
+	// Open the whole buffer for writing, and cut it before returning.
+	parser.buffer = parser.buffer[:cap(parser.buffer)]
+
+	// Fill the buffer until it has enough characters.
+	first := true
+	for parser.unread < length {
+
+		// Fill the raw buffer if necessary.
+		if !first || parser.raw_buffer_pos == len(parser.raw_buffer) {
+			if !yaml_parser_update_raw_buffer(parser) {
+				parser.buffer = parser.buffer[:buffer_len]
+				return false
+			}
+		}
+		first = false
+
+		// Decode the raw buffer.
+	inner:
+		for parser.raw_buffer_pos != len(parser.raw_buffer) {
+			var value rune
+			var width int
+
+			raw_unread := len(parser.raw_buffer) - parser.raw_buffer_pos
+
+			// Decode the next character.
+			switch parser.encoding {
+			case yaml_UTF8_ENCODING:
+				// Decode a UTF-8 character.  Check RFC 3629
+				// (http://www.ietf.org/rfc/rfc3629.txt) for more details.
+				//
+				// The following table (taken from the RFC) is used for
+				// decoding.
+				//
+				//    Char. number range |        UTF-8 octet sequence
+				//      (hexadecimal)    |              (binary)
+				//   --------------------+------------------------------------
+				//   0000 0000-0000 007F | 0xxxxxxx
+				//   0000 0080-0000 07FF | 110xxxxx 10xxxxxx
+				//   0000 0800-0000 FFFF | 1110xxxx 10xxxxxx 10xxxxxx
+				//   0001 0000-0010 FFFF | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+				//
+				// Additionally, the characters in the range 0xD800-0xDFFF
+				// are prohibited as they are reserved for use with UTF-16
+				// surrogate pairs.
+
+				// Determine the length of the UTF-8 sequence.
+				octet := parser.raw_buffer[parser.raw_buffer_pos]
+				switch {
+				case octet&0x80 == 0x00:
+					width = 1
+				case octet&0xE0 == 0xC0:
+					width = 2
+				case octet&0xF0 == 0xE0:
+					width = 3
+				case octet&0xF8 == 0xF0:
+					width = 4
+				default:
+					// The leading octet is invalid.
+					return yaml_parser_set_reader_error(parser,
+						"invalid leading UTF-8 octet",
+						parser.offset, int(octet))
+				}
+
+				// Check if the raw buffer contains an incomplete character.
+				if width > raw_unread {
+					if parser.eof {
+						return yaml_parser_set_reader_error(parser,
+							"incomplete UTF-8 octet sequence",
+							parser.offset, -1)
+					}
+					break inner
+				}
+
+				// Decode the leading octet.
+				switch {
+				case octet&0x80 == 0x00:
+					value = rune(octet & 0x7F)
+				case octet&0xE0 == 0xC0:
+					value = rune(octet & 0x1F)
+				case octet&0xF0 == 0xE0:
+					value = rune(octet & 0x0F)
+				case octet&0xF8 == 0xF0:
+					value = rune(octet & 0x07)
+				default:
+					value = 0
+				}
+
+				// Check and decode the trailing octets.
+				for k := 1; k < width; k++ {
+					octet = parser.raw_buffer[parser.raw_buffer_pos+k]
+
+					// Check if the octet is valid.
+					if (octet & 0xC0) != 0x80 {
+						return yaml_parser_set_reader_error(parser,
+							"invalid trailing UTF-8 octet",
+							parser.offset+k, int(octet))
+					}
+
+					// Decode the octet.
+					value = (value << 6) + rune(octet&0x3F)
+				}
+
+				// Check the length of the sequence against the value.
+				switch {
+				case width == 1:
+				case width == 2 && value >= 0x80:
+				case width == 3 && value >= 0x800:
+				case width == 4 && value >= 0x10000:
+				default:
+					return yaml_parser_set_reader_error(parser,
+						"invalid length of a UTF-8 sequence",
+						parser.offset, -1)
+				}
+
+				// Check the range of the value.
+				if value >= 0xD800 && value <= 0xDFFF || value > 0x10FFFF {
+					return yaml_parser_set_reader_error(parser,
+						"invalid Unicode character",
+						parser.offset, int(value))
+				}
+
+			case yaml_UTF16LE_ENCODING, yaml_UTF16BE_ENCODING:
+				var low, high int
+				if parser.encoding == yaml_UTF16LE_ENCODING {
+					low, high = 0, 1
+				} else {
+					high, low = 1, 0
+				}
+
+				// The UTF-16 encoding is not as simple as one might
+				// naively think.  Check RFC 2781
+				// (http://www.ietf.org/rfc/rfc2781.txt).
+				//
+				// Normally, two subsequent bytes describe a Unicode
+				// character.  However a special technique (called a
+				// surrogate pair) is used for specifying character
+				// values larger than 0xFFFF.
+				//
+				// A surrogate pair consists of two pseudo-characters:
+				//      high surrogate area (0xD800-0xDBFF)
+				//      low surrogate area (0xDC00-0xDFFF)
+				//
+				// The following formulas are used for decoding
+				// and encoding characters using surrogate pairs:
+				//
+				//  U  = U' + 0x10000   (0x01 00 00 <= U <= 0x10 FF FF)
+				//  U' = yyyyyyyyyyxxxxxxxxxx   (0 <= U' <= 0x0F FF FF)
+				//  W1 = 110110yyyyyyyyyy
+				//  W2 = 110111xxxxxxxxxx
+				//
+				// where U is the character value, W1 is the high surrogate
+				// area, W2 is the low surrogate area.
+
+				// Check for incomplete UTF-16 character.
+				if raw_unread < 2 {
+					if parser.eof {
+						return yaml_parser_set_reader_error(parser,
+							"incomplete UTF-16 character",
+							parser.offset, -1)
+					}
+					break inner
+				}
+
+				// Get the character.
+				value = rune(parser.raw_buffer[parser.raw_buffer_pos+low]) +
+					(rune(parser.raw_buffer[parser.raw_buffer_pos+high]) << 8)
+
+				// Check for unexpected low surrogate area.
+				if value&0xFC00 == 0xDC00 {
+					return yaml_parser_set_reader_error(parser,
+						"unexpected low surrogate area",
+						parser.offset, int(value))
+				}
+
+				// Check for a high surrogate area.
+				if value&0xFC00 == 0xD800 {
+					width = 4
+
+					// Check for incomplete surrogate pair.
+					if raw_unread < 4 {
+						if parser.eof {
+							return yaml_parser_set_reader_error(parser,
+								"incomplete UTF-16 surrogate pair",
+								parser.offset, -1)
+						}
+						break inner
+					}
+
+					// Get the next character.
+					value2 := rune(parser.raw_buffer[parser.raw_buffer_pos+low+2]) +
+						(rune(parser.raw_buffer[parser.raw_buffer_pos+high+2]) << 8)
+
+					// Check for a low surrogate area.
+					if value2&0xFC00 != 0xDC00 {
+						return yaml_parser_set_reader_error(parser,
+							"expected low surrogate area",
+							parser.offset+2, int(value2))
+					}
+
+					// Generate the value of the surrogate pair.
+					value = 0x10000 + ((value & 0x3FF) << 10) + (value2 & 0x3FF)
+				} else {
+					width = 2
+				}
+
+			default:
+				panic("impossible")
+			}
+
+			// Check if the character is in the allowed range:
+			//      #x9 | #xA | #xD | [#x20-#x7E]               (8 bit)
+			//      | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD]    (16 bit)
+			//      | [#x10000-#x10FFFF]                        (32 bit)
+			switch {
+			case value == 0x09:
+			case value == 0x0A:
+			case value == 0x0D:
+			case value >= 0x20 && value <= 0x7E:
+			case value == 0x85:
+			case value >= 0xA0 && value <= 0xD7FF:
+			case value >= 0xE000 && value <= 0xFFFD:
+			case value >= 0x10000 && value <= 0x10FFFF:
+			default:
+				return yaml_parser_set_reader_error(parser,
+					"control characters are not allowed",
+					parser.offset, int(value))
+			}
+
+			// Move the raw pointers.
+			parser.raw_buffer_pos += width
+			parser.offset += width
+
+			// Finally put the character into the buffer.
+			if value <= 0x7F {
+				// 0000 0000-0000 007F . 0xxxxxxx
+				parser.buffer[buffer_len+0] = byte(value)
+			} else if value <= 0x7FF {
+				// 0000 0080-0000 07FF . 110xxxxx 10xxxxxx
+				parser.buffer[buffer_len+0] = byte(0xC0 + (value >> 6))
+				parser.buffer[buffer_len+1] = byte(0x80 + (value & 0x3F))
+			} else if value <= 0xFFFF {
+				// 0000 0800-0000 FFFF . 1110xxxx 10xxxxxx 10xxxxxx
+				parser.buffer[buffer_len+0] = byte(0xE0 + (value >> 12))
+				parser.buffer[buffer_len+1] = byte(0x80 + ((value >> 6) & 0x3F))
+				parser.buffer[buffer_len+2] = byte(0x80 + (value & 0x3F))
+			} else {
+				// 0001 0000-0010 FFFF . 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+				parser.buffer[buffer_len+0] = byte(0xF0 + (value >> 18))
+				parser.buffer[buffer_len+1] = byte(0x80 + ((value >> 12) & 0x3F))
+				parser.buffer[buffer_len+2] = byte(0x80 + ((value >> 6) & 0x3F))
+				parser.buffer[buffer_len+3] = byte(0x80 + (value & 0x3F))
+			}
+			buffer_len += width
+
+			parser.unread++
+		}
+
+		// On EOF, put NUL into the buffer and return.
+		if parser.eof {
+			parser.buffer[buffer_len] = 0
+			buffer_len++
+			parser.unread++
+			break
+		}
+	}
+	parser.buffer = parser.buffer[:buffer_len]
+	return true
+}

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -1,0 +1,203 @@
+package yaml
+
+import (
+	"encoding/base64"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+type resolveMapItem struct {
+	value interface{}
+	tag   string
+}
+
+var resolveTable = make([]byte, 256)
+var resolveMap = make(map[string]resolveMapItem)
+
+func init() {
+	t := resolveTable
+	t[int('+')] = 'S' // Sign
+	t[int('-')] = 'S'
+	for _, c := range "0123456789" {
+		t[int(c)] = 'D' // Digit
+	}
+	for _, c := range "yYnNtTfFoO~" {
+		t[int(c)] = 'M' // In map
+	}
+	t[int('.')] = '.' // Float (potentially in map)
+
+	var resolveMapList = []struct {
+		v   interface{}
+		tag string
+		l   []string
+	}{
+		{true, yaml_BOOL_TAG, []string{"y", "Y", "yes", "Yes", "YES"}},
+		{true, yaml_BOOL_TAG, []string{"true", "True", "TRUE"}},
+		{true, yaml_BOOL_TAG, []string{"on", "On", "ON"}},
+		{false, yaml_BOOL_TAG, []string{"n", "N", "no", "No", "NO"}},
+		{false, yaml_BOOL_TAG, []string{"false", "False", "FALSE"}},
+		{false, yaml_BOOL_TAG, []string{"off", "Off", "OFF"}},
+		{nil, yaml_NULL_TAG, []string{"", "~", "null", "Null", "NULL"}},
+		{math.NaN(), yaml_FLOAT_TAG, []string{".nan", ".NaN", ".NAN"}},
+		{math.Inf(+1), yaml_FLOAT_TAG, []string{".inf", ".Inf", ".INF"}},
+		{math.Inf(+1), yaml_FLOAT_TAG, []string{"+.inf", "+.Inf", "+.INF"}},
+		{math.Inf(-1), yaml_FLOAT_TAG, []string{"-.inf", "-.Inf", "-.INF"}},
+		{"<<", yaml_MERGE_TAG, []string{"<<"}},
+	}
+
+	m := resolveMap
+	for _, item := range resolveMapList {
+		for _, s := range item.l {
+			m[s] = resolveMapItem{item.v, item.tag}
+		}
+	}
+}
+
+const longTagPrefix = "tag:yaml.org,2002:"
+
+func shortTag(tag string) string {
+	// TODO This can easily be made faster and produce less garbage.
+	if strings.HasPrefix(tag, longTagPrefix) {
+		return "!!" + tag[len(longTagPrefix):]
+	}
+	return tag
+}
+
+func longTag(tag string) string {
+	if strings.HasPrefix(tag, "!!") {
+		return longTagPrefix + tag[2:]
+	}
+	return tag
+}
+
+func resolvableTag(tag string) bool {
+	switch tag {
+	case "", yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG:
+		return true
+	}
+	return false
+}
+
+func resolve(tag string, in string) (rtag string, out interface{}) {
+	if !resolvableTag(tag) {
+		return tag, in
+	}
+
+	defer func() {
+		switch tag {
+		case "", rtag, yaml_STR_TAG, yaml_BINARY_TAG:
+			return
+		}
+		failf("cannot decode %s `%s` as a %s", shortTag(rtag), in, shortTag(tag))
+	}()
+
+	// Any data is accepted as a !!str or !!binary.
+	// Otherwise, the prefix is enough of a hint about what it might be.
+	hint := byte('N')
+	if in != "" {
+		hint = resolveTable[in[0]]
+	}
+	if hint != 0 && tag != yaml_STR_TAG && tag != yaml_BINARY_TAG {
+		// Handle things we can lookup in a map.
+		if item, ok := resolveMap[in]; ok {
+			return item.tag, item.value
+		}
+
+		// Base 60 floats are a bad idea, were dropped in YAML 1.2, and
+		// are purposefully unsupported here. They're still quoted on
+		// the way out for compatibility with other parser, though.
+
+		switch hint {
+		case 'M':
+			// We've already checked the map above.
+
+		case '.':
+			// Not in the map, so maybe a normal float.
+			floatv, err := strconv.ParseFloat(in, 64)
+			if err == nil {
+				return yaml_FLOAT_TAG, floatv
+			}
+
+		case 'D', 'S':
+			// Int, float, or timestamp.
+			plain := strings.Replace(in, "_", "", -1)
+			intv, err := strconv.ParseInt(plain, 0, 64)
+			if err == nil {
+				if intv == int64(int(intv)) {
+					return yaml_INT_TAG, int(intv)
+				} else {
+					return yaml_INT_TAG, intv
+				}
+			}
+			uintv, err := strconv.ParseUint(plain, 0, 64)
+			if err == nil {
+				return yaml_INT_TAG, uintv
+			}
+			floatv, err := strconv.ParseFloat(plain, 64)
+			if err == nil {
+				return yaml_FLOAT_TAG, floatv
+			}
+			if strings.HasPrefix(plain, "0b") {
+				intv, err := strconv.ParseInt(plain[2:], 2, 64)
+				if err == nil {
+					if intv == int64(int(intv)) {
+						return yaml_INT_TAG, int(intv)
+					} else {
+						return yaml_INT_TAG, intv
+					}
+				}
+				uintv, err := strconv.ParseUint(plain[2:], 2, 64)
+				if err == nil {
+					return yaml_INT_TAG, uintv
+				}
+			} else if strings.HasPrefix(plain, "-0b") {
+				intv, err := strconv.ParseInt(plain[3:], 2, 64)
+				if err == nil {
+					if intv == int64(int(intv)) {
+						return yaml_INT_TAG, -int(intv)
+					} else {
+						return yaml_INT_TAG, -intv
+					}
+				}
+			}
+			// XXX Handle timestamps here.
+
+		default:
+			panic("resolveTable item not yet handled: " + string(rune(hint)) + " (with " + in + ")")
+		}
+	}
+	if tag == yaml_BINARY_TAG {
+		return yaml_BINARY_TAG, in
+	}
+	if utf8.ValidString(in) {
+		return yaml_STR_TAG, in
+	}
+	return yaml_BINARY_TAG, encodeBase64(in)
+}
+
+// encodeBase64 encodes s as base64 that is broken up into multiple lines
+// as appropriate for the resulting length.
+func encodeBase64(s string) string {
+	const lineLen = 70
+	encLen := base64.StdEncoding.EncodedLen(len(s))
+	lines := encLen/lineLen + 1
+	buf := make([]byte, encLen*2+lines)
+	in := buf[0:encLen]
+	out := buf[encLen:]
+	base64.StdEncoding.Encode(in, []byte(s))
+	k := 0
+	for i := 0; i < len(in); i += lineLen {
+		j := i + lineLen
+		if j > len(in) {
+			j = len(in)
+		}
+		k += copy(out[k:], in[i:j])
+		if lines > 1 {
+			out[k] = '\n'
+			k++
+		}
+	}
+	return string(out[:k])
+}

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -1,0 +1,2710 @@
+package yaml
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Introduction
+// ************
+//
+// The following notes assume that you are familiar with the YAML specification
+// (http://yaml.org/spec/cvs/current.html).  We mostly follow it, although in
+// some cases we are less restrictive that it requires.
+//
+// The process of transforming a YAML stream into a sequence of events is
+// divided on two steps: Scanning and Parsing.
+//
+// The Scanner transforms the input stream into a sequence of tokens, while the
+// parser transform the sequence of tokens produced by the Scanner into a
+// sequence of parsing events.
+//
+// The Scanner is rather clever and complicated. The Parser, on the contrary,
+// is a straightforward implementation of a recursive-descendant parser (or,
+// LL(1) parser, as it is usually called).
+//
+// Actually there are two issues of Scanning that might be called "clever", the
+// rest is quite straightforward.  The issues are "block collection start" and
+// "simple keys".  Both issues are explained below in details.
+//
+// Here the Scanning step is explained and implemented.  We start with the list
+// of all the tokens produced by the Scanner together with short descriptions.
+//
+// Now, tokens:
+//
+//      STREAM-START(encoding)          # The stream start.
+//      STREAM-END                      # The stream end.
+//      VERSION-DIRECTIVE(major,minor)  # The '%YAML' directive.
+//      TAG-DIRECTIVE(handle,prefix)    # The '%TAG' directive.
+//      DOCUMENT-START                  # '---'
+//      DOCUMENT-END                    # '...'
+//      BLOCK-SEQUENCE-START            # Indentation increase denoting a block
+//      BLOCK-MAPPING-START             # sequence or a block mapping.
+//      BLOCK-END                       # Indentation decrease.
+//      FLOW-SEQUENCE-START             # '['
+//      FLOW-SEQUENCE-END               # ']'
+//      BLOCK-SEQUENCE-START            # '{'
+//      BLOCK-SEQUENCE-END              # '}'
+//      BLOCK-ENTRY                     # '-'
+//      FLOW-ENTRY                      # ','
+//      KEY                             # '?' or nothing (simple keys).
+//      VALUE                           # ':'
+//      ALIAS(anchor)                   # '*anchor'
+//      ANCHOR(anchor)                  # '&anchor'
+//      TAG(handle,suffix)              # '!handle!suffix'
+//      SCALAR(value,style)             # A scalar.
+//
+// The following two tokens are "virtual" tokens denoting the beginning and the
+// end of the stream:
+//
+//      STREAM-START(encoding)
+//      STREAM-END
+//
+// We pass the information about the input stream encoding with the
+// STREAM-START token.
+//
+// The next two tokens are responsible for tags:
+//
+//      VERSION-DIRECTIVE(major,minor)
+//      TAG-DIRECTIVE(handle,prefix)
+//
+// Example:
+//
+//      %YAML   1.1
+//      %TAG    !   !foo
+//      %TAG    !yaml!  tag:yaml.org,2002:
+//      ---
+//
+// The correspoding sequence of tokens:
+//
+//      STREAM-START(utf-8)
+//      VERSION-DIRECTIVE(1,1)
+//      TAG-DIRECTIVE("!","!foo")
+//      TAG-DIRECTIVE("!yaml","tag:yaml.org,2002:")
+//      DOCUMENT-START
+//      STREAM-END
+//
+// Note that the VERSION-DIRECTIVE and TAG-DIRECTIVE tokens occupy a whole
+// line.
+//
+// The document start and end indicators are represented by:
+//
+//      DOCUMENT-START
+//      DOCUMENT-END
+//
+// Note that if a YAML stream contains an implicit document (without '---'
+// and '...' indicators), no DOCUMENT-START and DOCUMENT-END tokens will be
+// produced.
+//
+// In the following examples, we present whole documents together with the
+// produced tokens.
+//
+//      1. An implicit document:
+//
+//          'a scalar'
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          SCALAR("a scalar",single-quoted)
+//          STREAM-END
+//
+//      2. An explicit document:
+//
+//          ---
+//          'a scalar'
+//          ...
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          DOCUMENT-START
+//          SCALAR("a scalar",single-quoted)
+//          DOCUMENT-END
+//          STREAM-END
+//
+//      3. Several documents in a stream:
+//
+//          'a scalar'
+//          ---
+//          'another scalar'
+//          ---
+//          'yet another scalar'
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          SCALAR("a scalar",single-quoted)
+//          DOCUMENT-START
+//          SCALAR("another scalar",single-quoted)
+//          DOCUMENT-START
+//          SCALAR("yet another scalar",single-quoted)
+//          STREAM-END
+//
+// We have already introduced the SCALAR token above.  The following tokens are
+// used to describe aliases, anchors, tag, and scalars:
+//
+//      ALIAS(anchor)
+//      ANCHOR(anchor)
+//      TAG(handle,suffix)
+//      SCALAR(value,style)
+//
+// The following series of examples illustrate the usage of these tokens:
+//
+//      1. A recursive sequence:
+//
+//          &A [ *A ]
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          ANCHOR("A")
+//          FLOW-SEQUENCE-START
+//          ALIAS("A")
+//          FLOW-SEQUENCE-END
+//          STREAM-END
+//
+//      2. A tagged scalar:
+//
+//          !!float "3.14"  # A good approximation.
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          TAG("!!","float")
+//          SCALAR("3.14",double-quoted)
+//          STREAM-END
+//
+//      3. Various scalar styles:
+//
+//          --- # Implicit empty plain scalars do not produce tokens.
+//          --- a plain scalar
+//          --- 'a single-quoted scalar'
+//          --- "a double-quoted scalar"
+//          --- |-
+//            a literal scalar
+//          --- >-
+//            a folded
+//            scalar
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          DOCUMENT-START
+//          DOCUMENT-START
+//          SCALAR("a plain scalar",plain)
+//          DOCUMENT-START
+//          SCALAR("a single-quoted scalar",single-quoted)
+//          DOCUMENT-START
+//          SCALAR("a double-quoted scalar",double-quoted)
+//          DOCUMENT-START
+//          SCALAR("a literal scalar",literal)
+//          DOCUMENT-START
+//          SCALAR("a folded scalar",folded)
+//          STREAM-END
+//
+// Now it's time to review collection-related tokens. We will start with
+// flow collections:
+//
+//      FLOW-SEQUENCE-START
+//      FLOW-SEQUENCE-END
+//      FLOW-MAPPING-START
+//      FLOW-MAPPING-END
+//      FLOW-ENTRY
+//      KEY
+//      VALUE
+//
+// The tokens FLOW-SEQUENCE-START, FLOW-SEQUENCE-END, FLOW-MAPPING-START, and
+// FLOW-MAPPING-END represent the indicators '[', ']', '{', and '}'
+// correspondingly.  FLOW-ENTRY represent the ',' indicator.  Finally the
+// indicators '?' and ':', which are used for denoting mapping keys and values,
+// are represented by the KEY and VALUE tokens.
+//
+// The following examples show flow collections:
+//
+//      1. A flow sequence:
+//
+//          [item 1, item 2, item 3]
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          FLOW-SEQUENCE-START
+//          SCALAR("item 1",plain)
+//          FLOW-ENTRY
+//          SCALAR("item 2",plain)
+//          FLOW-ENTRY
+//          SCALAR("item 3",plain)
+//          FLOW-SEQUENCE-END
+//          STREAM-END
+//
+//      2. A flow mapping:
+//
+//          {
+//              a simple key: a value,  # Note that the KEY token is produced.
+//              ? a complex key: another value,
+//          }
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          FLOW-MAPPING-START
+//          KEY
+//          SCALAR("a simple key",plain)
+//          VALUE
+//          SCALAR("a value",plain)
+//          FLOW-ENTRY
+//          KEY
+//          SCALAR("a complex key",plain)
+//          VALUE
+//          SCALAR("another value",plain)
+//          FLOW-ENTRY
+//          FLOW-MAPPING-END
+//          STREAM-END
+//
+// A simple key is a key which is not denoted by the '?' indicator.  Note that
+// the Scanner still produce the KEY token whenever it encounters a simple key.
+//
+// For scanning block collections, the following tokens are used (note that we
+// repeat KEY and VALUE here):
+//
+//      BLOCK-SEQUENCE-START
+//      BLOCK-MAPPING-START
+//      BLOCK-END
+//      BLOCK-ENTRY
+//      KEY
+//      VALUE
+//
+// The tokens BLOCK-SEQUENCE-START and BLOCK-MAPPING-START denote indentation
+// increase that precedes a block collection (cf. the INDENT token in Python).
+// The token BLOCK-END denote indentation decrease that ends a block collection
+// (cf. the DEDENT token in Python).  However YAML has some syntax pecularities
+// that makes detections of these tokens more complex.
+//
+// The tokens BLOCK-ENTRY, KEY, and VALUE are used to represent the indicators
+// '-', '?', and ':' correspondingly.
+//
+// The following examples show how the tokens BLOCK-SEQUENCE-START,
+// BLOCK-MAPPING-START, and BLOCK-END are emitted by the Scanner:
+//
+//      1. Block sequences:
+//
+//          - item 1
+//          - item 2
+//          -
+//            - item 3.1
+//            - item 3.2
+//          -
+//            key 1: value 1
+//            key 2: value 2
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          SCALAR("item 1",plain)
+//          BLOCK-ENTRY
+//          SCALAR("item 2",plain)
+//          BLOCK-ENTRY
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          SCALAR("item 3.1",plain)
+//          BLOCK-ENTRY
+//          SCALAR("item 3.2",plain)
+//          BLOCK-END
+//          BLOCK-ENTRY
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("key 1",plain)
+//          VALUE
+//          SCALAR("value 1",plain)
+//          KEY
+//          SCALAR("key 2",plain)
+//          VALUE
+//          SCALAR("value 2",plain)
+//          BLOCK-END
+//          BLOCK-END
+//          STREAM-END
+//
+//      2. Block mappings:
+//
+//          a simple key: a value   # The KEY token is produced here.
+//          ? a complex key
+//          : another value
+//          a mapping:
+//            key 1: value 1
+//            key 2: value 2
+//          a sequence:
+//            - item 1
+//            - item 2
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("a simple key",plain)
+//          VALUE
+//          SCALAR("a value",plain)
+//          KEY
+//          SCALAR("a complex key",plain)
+//          VALUE
+//          SCALAR("another value",plain)
+//          KEY
+//          SCALAR("a mapping",plain)
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("key 1",plain)
+//          VALUE
+//          SCALAR("value 1",plain)
+//          KEY
+//          SCALAR("key 2",plain)
+//          VALUE
+//          SCALAR("value 2",plain)
+//          BLOCK-END
+//          KEY
+//          SCALAR("a sequence",plain)
+//          VALUE
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          SCALAR("item 1",plain)
+//          BLOCK-ENTRY
+//          SCALAR("item 2",plain)
+//          BLOCK-END
+//          BLOCK-END
+//          STREAM-END
+//
+// YAML does not always require to start a new block collection from a new
+// line.  If the current line contains only '-', '?', and ':' indicators, a new
+// block collection may start at the current line.  The following examples
+// illustrate this case:
+//
+//      1. Collections in a sequence:
+//
+//          - - item 1
+//            - item 2
+//          - key 1: value 1
+//            key 2: value 2
+//          - ? complex key
+//            : complex value
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          SCALAR("item 1",plain)
+//          BLOCK-ENTRY
+//          SCALAR("item 2",plain)
+//          BLOCK-END
+//          BLOCK-ENTRY
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("key 1",plain)
+//          VALUE
+//          SCALAR("value 1",plain)
+//          KEY
+//          SCALAR("key 2",plain)
+//          VALUE
+//          SCALAR("value 2",plain)
+//          BLOCK-END
+//          BLOCK-ENTRY
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("complex key")
+//          VALUE
+//          SCALAR("complex value")
+//          BLOCK-END
+//          BLOCK-END
+//          STREAM-END
+//
+//      2. Collections in a mapping:
+//
+//          ? a sequence
+//          : - item 1
+//            - item 2
+//          ? a mapping
+//          : key 1: value 1
+//            key 2: value 2
+//
+//      Tokens:
+//
+//          STREAM-START(utf-8)
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("a sequence",plain)
+//          VALUE
+//          BLOCK-SEQUENCE-START
+//          BLOCK-ENTRY
+//          SCALAR("item 1",plain)
+//          BLOCK-ENTRY
+//          SCALAR("item 2",plain)
+//          BLOCK-END
+//          KEY
+//          SCALAR("a mapping",plain)
+//          VALUE
+//          BLOCK-MAPPING-START
+//          KEY
+//          SCALAR("key 1",plain)
+//          VALUE
+//          SCALAR("value 1",plain)
+//          KEY
+//          SCALAR("key 2",plain)
+//          VALUE
+//          SCALAR("value 2",plain)
+//          BLOCK-END
+//          BLOCK-END
+//          STREAM-END
+//
+// YAML also permits non-indented sequences if they are included into a block
+// mapping.  In this case, the token BLOCK-SEQUENCE-START is not produced:
+//
+//      key:
+//      - item 1    # BLOCK-SEQUENCE-START is NOT produced here.
+//      - item 2
+//
+// Tokens:
+//
+//      STREAM-START(utf-8)
+//      BLOCK-MAPPING-START
+//      KEY
+//      SCALAR("key",plain)
+//      VALUE
+//      BLOCK-ENTRY
+//      SCALAR("item 1",plain)
+//      BLOCK-ENTRY
+//      SCALAR("item 2",plain)
+//      BLOCK-END
+//
+
+// Ensure that the buffer contains the required number of characters.
+// Return true on success, false on failure (reader error or memory error).
+func cache(parser *yaml_parser_t, length int) bool {
+	// [Go] This was inlined: !cache(A, B) -> unread < B && !update(A, B)
+	return parser.unread >= length || yaml_parser_update_buffer(parser, length)
+}
+
+// Advance the buffer pointer.
+func skip(parser *yaml_parser_t) {
+	parser.mark.index++
+	parser.mark.column++
+	parser.unread--
+	parser.buffer_pos += width(parser.buffer[parser.buffer_pos])
+}
+
+func skip_line(parser *yaml_parser_t) {
+	if is_crlf(parser.buffer, parser.buffer_pos) {
+		parser.mark.index += 2
+		parser.mark.column = 0
+		parser.mark.line++
+		parser.unread -= 2
+		parser.buffer_pos += 2
+	} else if is_break(parser.buffer, parser.buffer_pos) {
+		parser.mark.index++
+		parser.mark.column = 0
+		parser.mark.line++
+		parser.unread--
+		parser.buffer_pos += width(parser.buffer[parser.buffer_pos])
+	}
+}
+
+// Copy a character to a string buffer and advance pointers.
+func read(parser *yaml_parser_t, s []byte) []byte {
+	w := width(parser.buffer[parser.buffer_pos])
+	if w == 0 {
+		panic("invalid character sequence")
+	}
+	if len(s) == 0 {
+		s = make([]byte, 0, 32)
+	}
+	if w == 1 && len(s)+w <= cap(s) {
+		s = s[:len(s)+1]
+		s[len(s)-1] = parser.buffer[parser.buffer_pos]
+		parser.buffer_pos++
+	} else {
+		s = append(s, parser.buffer[parser.buffer_pos:parser.buffer_pos+w]...)
+		parser.buffer_pos += w
+	}
+	parser.mark.index++
+	parser.mark.column++
+	parser.unread--
+	return s
+}
+
+// Copy a line break character to a string buffer and advance pointers.
+func read_line(parser *yaml_parser_t, s []byte) []byte {
+	buf := parser.buffer
+	pos := parser.buffer_pos
+	switch {
+	case buf[pos] == '\r' && buf[pos+1] == '\n':
+		// CR LF . LF
+		s = append(s, '\n')
+		parser.buffer_pos += 2
+		parser.mark.index++
+		parser.unread--
+	case buf[pos] == '\r' || buf[pos] == '\n':
+		// CR|LF . LF
+		s = append(s, '\n')
+		parser.buffer_pos += 1
+	case buf[pos] == '\xC2' && buf[pos+1] == '\x85':
+		// NEL . LF
+		s = append(s, '\n')
+		parser.buffer_pos += 2
+	case buf[pos] == '\xE2' && buf[pos+1] == '\x80' && (buf[pos+2] == '\xA8' || buf[pos+2] == '\xA9'):
+		// LS|PS . LS|PS
+		s = append(s, buf[parser.buffer_pos:pos+3]...)
+		parser.buffer_pos += 3
+	default:
+		return s
+	}
+	parser.mark.index++
+	parser.mark.column = 0
+	parser.mark.line++
+	parser.unread--
+	return s
+}
+
+// Get the next token.
+func yaml_parser_scan(parser *yaml_parser_t, token *yaml_token_t) bool {
+	// Erase the token object.
+	*token = yaml_token_t{} // [Go] Is this necessary?
+
+	// No tokens after STREAM-END or error.
+	if parser.stream_end_produced || parser.error != yaml_NO_ERROR {
+		return true
+	}
+
+	// Ensure that the tokens queue contains enough tokens.
+	if !parser.token_available {
+		if !yaml_parser_fetch_more_tokens(parser) {
+			return false
+		}
+	}
+
+	// Fetch the next token from the queue.
+	*token = parser.tokens[parser.tokens_head]
+	parser.tokens_head++
+	parser.tokens_parsed++
+	parser.token_available = false
+
+	if token.typ == yaml_STREAM_END_TOKEN {
+		parser.stream_end_produced = true
+	}
+	return true
+}
+
+// Set the scanner error and return false.
+func yaml_parser_set_scanner_error(parser *yaml_parser_t, context string, context_mark yaml_mark_t, problem string) bool {
+	parser.error = yaml_SCANNER_ERROR
+	parser.context = context
+	parser.context_mark = context_mark
+	parser.problem = problem
+	parser.problem_mark = parser.mark
+	return false
+}
+
+func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, context_mark yaml_mark_t, problem string) bool {
+	context := "while parsing a tag"
+	if directive {
+		context = "while parsing a %TAG directive"
+	}
+	return yaml_parser_set_scanner_error(parser, context, context_mark, "did not find URI escaped octet")
+}
+
+func trace(args ...interface{}) func() {
+	pargs := append([]interface{}{"+++"}, args...)
+	fmt.Println(pargs...)
+	pargs = append([]interface{}{"---"}, args...)
+	return func() { fmt.Println(pargs...) }
+}
+
+// Ensure that the tokens queue contains at least one token which can be
+// returned to the Parser.
+func yaml_parser_fetch_more_tokens(parser *yaml_parser_t) bool {
+	// While we need more tokens to fetch, do it.
+	for {
+		// Check if we really need to fetch more tokens.
+		need_more_tokens := false
+
+		if parser.tokens_head == len(parser.tokens) {
+			// Queue is empty.
+			need_more_tokens = true
+		} else {
+			// Check if any potential simple key may occupy the head position.
+			if !yaml_parser_stale_simple_keys(parser) {
+				return false
+			}
+
+			for i := range parser.simple_keys {
+				simple_key := &parser.simple_keys[i]
+				if simple_key.possible && simple_key.token_number == parser.tokens_parsed {
+					need_more_tokens = true
+					break
+				}
+			}
+		}
+
+		// We are finished.
+		if !need_more_tokens {
+			break
+		}
+		// Fetch the next token.
+		if !yaml_parser_fetch_next_token(parser) {
+			return false
+		}
+	}
+
+	parser.token_available = true
+	return true
+}
+
+// The dispatcher for token fetchers.
+func yaml_parser_fetch_next_token(parser *yaml_parser_t) bool {
+	// Ensure that the buffer is initialized.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	// Check if we just started scanning.  Fetch STREAM-START then.
+	if !parser.stream_start_produced {
+		return yaml_parser_fetch_stream_start(parser)
+	}
+
+	// Eat whitespaces and comments until we reach the next token.
+	if !yaml_parser_scan_to_next_token(parser) {
+		return false
+	}
+
+	// Remove obsolete potential simple keys.
+	if !yaml_parser_stale_simple_keys(parser) {
+		return false
+	}
+
+	// Check the indentation level against the current column.
+	if !yaml_parser_unroll_indent(parser, parser.mark.column) {
+		return false
+	}
+
+	// Ensure that the buffer contains at least 4 characters.  4 is the length
+	// of the longest indicators ('--- ' and '... ').
+	if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+		return false
+	}
+
+	// Is it the end of the stream?
+	if is_z(parser.buffer, parser.buffer_pos) {
+		return yaml_parser_fetch_stream_end(parser)
+	}
+
+	// Is it a directive?
+	if parser.mark.column == 0 && parser.buffer[parser.buffer_pos] == '%' {
+		return yaml_parser_fetch_directive(parser)
+	}
+
+	buf := parser.buffer
+	pos := parser.buffer_pos
+
+	// Is it the document start indicator?
+	if parser.mark.column == 0 && buf[pos] == '-' && buf[pos+1] == '-' && buf[pos+2] == '-' && is_blankz(buf, pos+3) {
+		return yaml_parser_fetch_document_indicator(parser, yaml_DOCUMENT_START_TOKEN)
+	}
+
+	// Is it the document end indicator?
+	if parser.mark.column == 0 && buf[pos] == '.' && buf[pos+1] == '.' && buf[pos+2] == '.' && is_blankz(buf, pos+3) {
+		return yaml_parser_fetch_document_indicator(parser, yaml_DOCUMENT_END_TOKEN)
+	}
+
+	// Is it the flow sequence start indicator?
+	if buf[pos] == '[' {
+		return yaml_parser_fetch_flow_collection_start(parser, yaml_FLOW_SEQUENCE_START_TOKEN)
+	}
+
+	// Is it the flow mapping start indicator?
+	if parser.buffer[parser.buffer_pos] == '{' {
+		return yaml_parser_fetch_flow_collection_start(parser, yaml_FLOW_MAPPING_START_TOKEN)
+	}
+
+	// Is it the flow sequence end indicator?
+	if parser.buffer[parser.buffer_pos] == ']' {
+		return yaml_parser_fetch_flow_collection_end(parser,
+			yaml_FLOW_SEQUENCE_END_TOKEN)
+	}
+
+	// Is it the flow mapping end indicator?
+	if parser.buffer[parser.buffer_pos] == '}' {
+		return yaml_parser_fetch_flow_collection_end(parser,
+			yaml_FLOW_MAPPING_END_TOKEN)
+	}
+
+	// Is it the flow entry indicator?
+	if parser.buffer[parser.buffer_pos] == ',' {
+		return yaml_parser_fetch_flow_entry(parser)
+	}
+
+	// Is it the block entry indicator?
+	if parser.buffer[parser.buffer_pos] == '-' && is_blankz(parser.buffer, parser.buffer_pos+1) {
+		return yaml_parser_fetch_block_entry(parser)
+	}
+
+	// Is it the key indicator?
+	if parser.buffer[parser.buffer_pos] == '?' && (parser.flow_level > 0 || is_blankz(parser.buffer, parser.buffer_pos+1)) {
+		return yaml_parser_fetch_key(parser)
+	}
+
+	// Is it the value indicator?
+	if parser.buffer[parser.buffer_pos] == ':' && (parser.flow_level > 0 || is_blankz(parser.buffer, parser.buffer_pos+1)) {
+		return yaml_parser_fetch_value(parser)
+	}
+
+	// Is it an alias?
+	if parser.buffer[parser.buffer_pos] == '*' {
+		return yaml_parser_fetch_anchor(parser, yaml_ALIAS_TOKEN)
+	}
+
+	// Is it an anchor?
+	if parser.buffer[parser.buffer_pos] == '&' {
+		return yaml_parser_fetch_anchor(parser, yaml_ANCHOR_TOKEN)
+	}
+
+	// Is it a tag?
+	if parser.buffer[parser.buffer_pos] == '!' {
+		return yaml_parser_fetch_tag(parser)
+	}
+
+	// Is it a literal scalar?
+	if parser.buffer[parser.buffer_pos] == '|' && parser.flow_level == 0 {
+		return yaml_parser_fetch_block_scalar(parser, true)
+	}
+
+	// Is it a folded scalar?
+	if parser.buffer[parser.buffer_pos] == '>' && parser.flow_level == 0 {
+		return yaml_parser_fetch_block_scalar(parser, false)
+	}
+
+	// Is it a single-quoted scalar?
+	if parser.buffer[parser.buffer_pos] == '\'' {
+		return yaml_parser_fetch_flow_scalar(parser, true)
+	}
+
+	// Is it a double-quoted scalar?
+	if parser.buffer[parser.buffer_pos] == '"' {
+		return yaml_parser_fetch_flow_scalar(parser, false)
+	}
+
+	// Is it a plain scalar?
+	//
+	// A plain scalar may start with any non-blank characters except
+	//
+	//      '-', '?', ':', ',', '[', ']', '{', '}',
+	//      '#', '&', '*', '!', '|', '>', '\'', '\"',
+	//      '%', '@', '`'.
+	//
+	// In the block context (and, for the '-' indicator, in the flow context
+	// too), it may also start with the characters
+	//
+	//      '-', '?', ':'
+	//
+	// if it is followed by a non-space character.
+	//
+	// The last rule is more restrictive than the specification requires.
+	// [Go] Make this logic more reasonable.
+	//switch parser.buffer[parser.buffer_pos] {
+	//case '-', '?', ':', ',', '?', '-', ',', ':', ']', '[', '}', '{', '&', '#', '!', '*', '>', '|', '"', '\'', '@', '%', '-', '`':
+	//}
+	if !(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '-' ||
+		parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':' ||
+		parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == '[' ||
+		parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
+		parser.buffer[parser.buffer_pos] == '}' || parser.buffer[parser.buffer_pos] == '#' ||
+		parser.buffer[parser.buffer_pos] == '&' || parser.buffer[parser.buffer_pos] == '*' ||
+		parser.buffer[parser.buffer_pos] == '!' || parser.buffer[parser.buffer_pos] == '|' ||
+		parser.buffer[parser.buffer_pos] == '>' || parser.buffer[parser.buffer_pos] == '\'' ||
+		parser.buffer[parser.buffer_pos] == '"' || parser.buffer[parser.buffer_pos] == '%' ||
+		parser.buffer[parser.buffer_pos] == '@' || parser.buffer[parser.buffer_pos] == '`') ||
+		(parser.buffer[parser.buffer_pos] == '-' && !is_blank(parser.buffer, parser.buffer_pos+1)) ||
+		(parser.flow_level == 0 &&
+			(parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':') &&
+			!is_blankz(parser.buffer, parser.buffer_pos+1)) {
+		return yaml_parser_fetch_plain_scalar(parser)
+	}
+
+	// If we don't determine the token type so far, it is an error.
+	return yaml_parser_set_scanner_error(parser,
+		"while scanning for the next token", parser.mark,
+		"found character that cannot start any token")
+}
+
+// Check the list of potential simple keys and remove the positions that
+// cannot contain simple keys anymore.
+func yaml_parser_stale_simple_keys(parser *yaml_parser_t) bool {
+	// Check for a potential simple key for each flow level.
+	for i := range parser.simple_keys {
+		simple_key := &parser.simple_keys[i]
+
+		// The specification requires that a simple key
+		//
+		//  - is limited to a single line,
+		//  - is shorter than 1024 characters.
+		if simple_key.possible && (simple_key.mark.line < parser.mark.line || simple_key.mark.index+1024 < parser.mark.index) {
+
+			// Check if the potential simple key to be removed is required.
+			if simple_key.required {
+				return yaml_parser_set_scanner_error(parser,
+					"while scanning a simple key", simple_key.mark,
+					"could not find expected ':'")
+			}
+			simple_key.possible = false
+		}
+	}
+	return true
+}
+
+// Check if a simple key may start at the current position and add it if
+// needed.
+func yaml_parser_save_simple_key(parser *yaml_parser_t) bool {
+	// A simple key is required at the current position if the scanner is in
+	// the block context and the current column coincides with the indentation
+	// level.
+
+	required := parser.flow_level == 0 && parser.indent == parser.mark.column
+
+	// A simple key is required only when it is the first token in the current
+	// line.  Therefore it is always allowed.  But we add a check anyway.
+	if required && !parser.simple_key_allowed {
+		panic("should not happen")
+	}
+
+	//
+	// If the current position may start a simple key, save it.
+	//
+	if parser.simple_key_allowed {
+		simple_key := yaml_simple_key_t{
+			possible:     true,
+			required:     required,
+			token_number: parser.tokens_parsed + (len(parser.tokens) - parser.tokens_head),
+		}
+		simple_key.mark = parser.mark
+
+		if !yaml_parser_remove_simple_key(parser) {
+			return false
+		}
+		parser.simple_keys[len(parser.simple_keys)-1] = simple_key
+	}
+	return true
+}
+
+// Remove a potential simple key at the current flow level.
+func yaml_parser_remove_simple_key(parser *yaml_parser_t) bool {
+	i := len(parser.simple_keys) - 1
+	if parser.simple_keys[i].possible {
+		// If the key is required, it is an error.
+		if parser.simple_keys[i].required {
+			return yaml_parser_set_scanner_error(parser,
+				"while scanning a simple key", parser.simple_keys[i].mark,
+				"could not find expected ':'")
+		}
+	}
+	// Remove the key from the stack.
+	parser.simple_keys[i].possible = false
+	return true
+}
+
+// Increase the flow level and resize the simple key list if needed.
+func yaml_parser_increase_flow_level(parser *yaml_parser_t) bool {
+	// Reset the simple key on the next level.
+	parser.simple_keys = append(parser.simple_keys, yaml_simple_key_t{})
+
+	// Increase the flow level.
+	parser.flow_level++
+	return true
+}
+
+// Decrease the flow level.
+func yaml_parser_decrease_flow_level(parser *yaml_parser_t) bool {
+	if parser.flow_level > 0 {
+		parser.flow_level--
+		parser.simple_keys = parser.simple_keys[:len(parser.simple_keys)-1]
+	}
+	return true
+}
+
+// Push the current indentation level to the stack and set the new level
+// the current column is greater than the indentation level.  In this case,
+// append or insert the specified token into the token queue.
+func yaml_parser_roll_indent(parser *yaml_parser_t, column, number int, typ yaml_token_type_t, mark yaml_mark_t) bool {
+	// In the flow context, do nothing.
+	if parser.flow_level > 0 {
+		return true
+	}
+
+	if parser.indent < column {
+		// Push the current indentation level to the stack and set the new
+		// indentation level.
+		parser.indents = append(parser.indents, parser.indent)
+		parser.indent = column
+
+		// Create a token and insert it into the queue.
+		token := yaml_token_t{
+			typ:        typ,
+			start_mark: mark,
+			end_mark:   mark,
+		}
+		if number > -1 {
+			number -= parser.tokens_parsed
+		}
+		yaml_insert_token(parser, number, &token)
+	}
+	return true
+}
+
+// Pop indentation levels from the indents stack until the current level
+// becomes less or equal to the column.  For each indentation level, append
+// the BLOCK-END token.
+func yaml_parser_unroll_indent(parser *yaml_parser_t, column int) bool {
+	// In the flow context, do nothing.
+	if parser.flow_level > 0 {
+		return true
+	}
+
+	// Loop through the indentation levels in the stack.
+	for parser.indent > column {
+		// Create a token and append it to the queue.
+		token := yaml_token_t{
+			typ:        yaml_BLOCK_END_TOKEN,
+			start_mark: parser.mark,
+			end_mark:   parser.mark,
+		}
+		yaml_insert_token(parser, -1, &token)
+
+		// Pop the indentation level.
+		parser.indent = parser.indents[len(parser.indents)-1]
+		parser.indents = parser.indents[:len(parser.indents)-1]
+	}
+	return true
+}
+
+// Initialize the scanner and produce the STREAM-START token.
+func yaml_parser_fetch_stream_start(parser *yaml_parser_t) bool {
+
+	// Set the initial indentation.
+	parser.indent = -1
+
+	// Initialize the simple key stack.
+	parser.simple_keys = append(parser.simple_keys, yaml_simple_key_t{})
+
+	// A simple key is allowed at the beginning of the stream.
+	parser.simple_key_allowed = true
+
+	// We have started.
+	parser.stream_start_produced = true
+
+	// Create the STREAM-START token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_STREAM_START_TOKEN,
+		start_mark: parser.mark,
+		end_mark:   parser.mark,
+		encoding:   parser.encoding,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the STREAM-END token and shut down the scanner.
+func yaml_parser_fetch_stream_end(parser *yaml_parser_t) bool {
+
+	// Force new line.
+	if parser.mark.column != 0 {
+		parser.mark.column = 0
+		parser.mark.line++
+	}
+
+	// Reset the indentation level.
+	if !yaml_parser_unroll_indent(parser, -1) {
+		return false
+	}
+
+	// Reset simple keys.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	parser.simple_key_allowed = false
+
+	// Create the STREAM-END token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_STREAM_END_TOKEN,
+		start_mark: parser.mark,
+		end_mark:   parser.mark,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce a VERSION-DIRECTIVE or TAG-DIRECTIVE token.
+func yaml_parser_fetch_directive(parser *yaml_parser_t) bool {
+	// Reset the indentation level.
+	if !yaml_parser_unroll_indent(parser, -1) {
+		return false
+	}
+
+	// Reset simple keys.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	parser.simple_key_allowed = false
+
+	// Create the YAML-DIRECTIVE or TAG-DIRECTIVE token.
+	token := yaml_token_t{}
+	if !yaml_parser_scan_directive(parser, &token) {
+		return false
+	}
+	// Append the token to the queue.
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the DOCUMENT-START or DOCUMENT-END token.
+func yaml_parser_fetch_document_indicator(parser *yaml_parser_t, typ yaml_token_type_t) bool {
+	// Reset the indentation level.
+	if !yaml_parser_unroll_indent(parser, -1) {
+		return false
+	}
+
+	// Reset simple keys.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	parser.simple_key_allowed = false
+
+	// Consume the token.
+	start_mark := parser.mark
+
+	skip(parser)
+	skip(parser)
+	skip(parser)
+
+	end_mark := parser.mark
+
+	// Create the DOCUMENT-START or DOCUMENT-END token.
+	token := yaml_token_t{
+		typ:        typ,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	// Append the token to the queue.
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the FLOW-SEQUENCE-START or FLOW-MAPPING-START token.
+func yaml_parser_fetch_flow_collection_start(parser *yaml_parser_t, typ yaml_token_type_t) bool {
+	// The indicators '[' and '{' may start a simple key.
+	if !yaml_parser_save_simple_key(parser) {
+		return false
+	}
+
+	// Increase the flow level.
+	if !yaml_parser_increase_flow_level(parser) {
+		return false
+	}
+
+	// A simple key may follow the indicators '[' and '{'.
+	parser.simple_key_allowed = true
+
+	// Consume the token.
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the FLOW-SEQUENCE-START of FLOW-MAPPING-START token.
+	token := yaml_token_t{
+		typ:        typ,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	// Append the token to the queue.
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the FLOW-SEQUENCE-END or FLOW-MAPPING-END token.
+func yaml_parser_fetch_flow_collection_end(parser *yaml_parser_t, typ yaml_token_type_t) bool {
+	// Reset any potential simple key on the current flow level.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	// Decrease the flow level.
+	if !yaml_parser_decrease_flow_level(parser) {
+		return false
+	}
+
+	// No simple keys after the indicators ']' and '}'.
+	parser.simple_key_allowed = false
+
+	// Consume the token.
+
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the FLOW-SEQUENCE-END of FLOW-MAPPING-END token.
+	token := yaml_token_t{
+		typ:        typ,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	// Append the token to the queue.
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the FLOW-ENTRY token.
+func yaml_parser_fetch_flow_entry(parser *yaml_parser_t) bool {
+	// Reset any potential simple keys on the current flow level.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	// Simple keys are allowed after ','.
+	parser.simple_key_allowed = true
+
+	// Consume the token.
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the FLOW-ENTRY token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_FLOW_ENTRY_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the BLOCK-ENTRY token.
+func yaml_parser_fetch_block_entry(parser *yaml_parser_t) bool {
+	// Check if the scanner is in the block context.
+	if parser.flow_level == 0 {
+		// Check if we are allowed to start a new entry.
+		if !parser.simple_key_allowed {
+			return yaml_parser_set_scanner_error(parser, "", parser.mark,
+				"block sequence entries are not allowed in this context")
+		}
+		// Add the BLOCK-SEQUENCE-START token if needed.
+		if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_SEQUENCE_START_TOKEN, parser.mark) {
+			return false
+		}
+	} else {
+		// It is an error for the '-' indicator to occur in the flow context,
+		// but we let the Parser detect and report about it because the Parser
+		// is able to point to the context.
+	}
+
+	// Reset any potential simple keys on the current flow level.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	// Simple keys are allowed after '-'.
+	parser.simple_key_allowed = true
+
+	// Consume the token.
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the BLOCK-ENTRY token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_BLOCK_ENTRY_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the KEY token.
+func yaml_parser_fetch_key(parser *yaml_parser_t) bool {
+
+	// In the block context, additional checks are required.
+	if parser.flow_level == 0 {
+		// Check if we are allowed to start a new key (not nessesary simple).
+		if !parser.simple_key_allowed {
+			return yaml_parser_set_scanner_error(parser, "", parser.mark,
+				"mapping keys are not allowed in this context")
+		}
+		// Add the BLOCK-MAPPING-START token if needed.
+		if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
+			return false
+		}
+	}
+
+	// Reset any potential simple keys on the current flow level.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	// Simple keys are allowed after '?' in the block context.
+	parser.simple_key_allowed = parser.flow_level == 0
+
+	// Consume the token.
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the KEY token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_KEY_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the VALUE token.
+func yaml_parser_fetch_value(parser *yaml_parser_t) bool {
+
+	simple_key := &parser.simple_keys[len(parser.simple_keys)-1]
+
+	// Have we found a simple key?
+	if simple_key.possible {
+		// Create the KEY token and insert it into the queue.
+		token := yaml_token_t{
+			typ:        yaml_KEY_TOKEN,
+			start_mark: simple_key.mark,
+			end_mark:   simple_key.mark,
+		}
+		yaml_insert_token(parser, simple_key.token_number-parser.tokens_parsed, &token)
+
+		// In the block context, we may need to add the BLOCK-MAPPING-START token.
+		if !yaml_parser_roll_indent(parser, simple_key.mark.column,
+			simple_key.token_number,
+			yaml_BLOCK_MAPPING_START_TOKEN, simple_key.mark) {
+			return false
+		}
+
+		// Remove the simple key.
+		simple_key.possible = false
+
+		// A simple key cannot follow another simple key.
+		parser.simple_key_allowed = false
+
+	} else {
+		// The ':' indicator follows a complex key.
+
+		// In the block context, extra checks are required.
+		if parser.flow_level == 0 {
+
+			// Check if we are allowed to start a complex value.
+			if !parser.simple_key_allowed {
+				return yaml_parser_set_scanner_error(parser, "", parser.mark,
+					"mapping values are not allowed in this context")
+			}
+
+			// Add the BLOCK-MAPPING-START token if needed.
+			if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_MAPPING_START_TOKEN, parser.mark) {
+				return false
+			}
+		}
+
+		// Simple keys after ':' are allowed in the block context.
+		parser.simple_key_allowed = parser.flow_level == 0
+	}
+
+	// Consume the token.
+	start_mark := parser.mark
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create the VALUE token and append it to the queue.
+	token := yaml_token_t{
+		typ:        yaml_VALUE_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the ALIAS or ANCHOR token.
+func yaml_parser_fetch_anchor(parser *yaml_parser_t, typ yaml_token_type_t) bool {
+	// An anchor or an alias could be a simple key.
+	if !yaml_parser_save_simple_key(parser) {
+		return false
+	}
+
+	// A simple key cannot follow an anchor or an alias.
+	parser.simple_key_allowed = false
+
+	// Create the ALIAS or ANCHOR token and append it to the queue.
+	var token yaml_token_t
+	if !yaml_parser_scan_anchor(parser, &token, typ) {
+		return false
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the TAG token.
+func yaml_parser_fetch_tag(parser *yaml_parser_t) bool {
+	// A tag could be a simple key.
+	if !yaml_parser_save_simple_key(parser) {
+		return false
+	}
+
+	// A simple key cannot follow a tag.
+	parser.simple_key_allowed = false
+
+	// Create the TAG token and append it to the queue.
+	var token yaml_token_t
+	if !yaml_parser_scan_tag(parser, &token) {
+		return false
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the SCALAR(...,literal) or SCALAR(...,folded) tokens.
+func yaml_parser_fetch_block_scalar(parser *yaml_parser_t, literal bool) bool {
+	// Remove any potential simple keys.
+	if !yaml_parser_remove_simple_key(parser) {
+		return false
+	}
+
+	// A simple key may follow a block scalar.
+	parser.simple_key_allowed = true
+
+	// Create the SCALAR token and append it to the queue.
+	var token yaml_token_t
+	if !yaml_parser_scan_block_scalar(parser, &token, literal) {
+		return false
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the SCALAR(...,single-quoted) or SCALAR(...,double-quoted) tokens.
+func yaml_parser_fetch_flow_scalar(parser *yaml_parser_t, single bool) bool {
+	// A plain scalar could be a simple key.
+	if !yaml_parser_save_simple_key(parser) {
+		return false
+	}
+
+	// A simple key cannot follow a flow scalar.
+	parser.simple_key_allowed = false
+
+	// Create the SCALAR token and append it to the queue.
+	var token yaml_token_t
+	if !yaml_parser_scan_flow_scalar(parser, &token, single) {
+		return false
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Produce the SCALAR(...,plain) token.
+func yaml_parser_fetch_plain_scalar(parser *yaml_parser_t) bool {
+	// A plain scalar could be a simple key.
+	if !yaml_parser_save_simple_key(parser) {
+		return false
+	}
+
+	// A simple key cannot follow a flow scalar.
+	parser.simple_key_allowed = false
+
+	// Create the SCALAR token and append it to the queue.
+	var token yaml_token_t
+	if !yaml_parser_scan_plain_scalar(parser, &token) {
+		return false
+	}
+	yaml_insert_token(parser, -1, &token)
+	return true
+}
+
+// Eat whitespaces and comments until the next token is found.
+func yaml_parser_scan_to_next_token(parser *yaml_parser_t) bool {
+
+	// Until the next token is not found.
+	for {
+		// Allow the BOM mark to start a line.
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+		if parser.mark.column == 0 && is_bom(parser.buffer, parser.buffer_pos) {
+			skip(parser)
+		}
+
+		// Eat whitespaces.
+		// Tabs are allowed:
+		//  - in the flow context
+		//  - in the block context, but not at the beginning of the line or
+		//  after '-', '?', or ':' (complex value).
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+
+		for parser.buffer[parser.buffer_pos] == ' ' || ((parser.flow_level > 0 || !parser.simple_key_allowed) && parser.buffer[parser.buffer_pos] == '\t') {
+			skip(parser)
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+
+		// Eat a comment until a line break.
+		if parser.buffer[parser.buffer_pos] == '#' {
+			for !is_breakz(parser.buffer, parser.buffer_pos) {
+				skip(parser)
+				if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+					return false
+				}
+			}
+		}
+
+		// If it is a line break, eat it.
+		if is_break(parser.buffer, parser.buffer_pos) {
+			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				return false
+			}
+			skip_line(parser)
+
+			// In the block context, a new line may start a simple key.
+			if parser.flow_level == 0 {
+				parser.simple_key_allowed = true
+			}
+		} else {
+			break // We have found a token.
+		}
+	}
+
+	return true
+}
+
+// Scan a YAML-DIRECTIVE or TAG-DIRECTIVE token.
+//
+// Scope:
+//      %YAML    1.1    # a comment \n
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//      %TAG    !yaml!  tag:yaml.org,2002:  \n
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//
+func yaml_parser_scan_directive(parser *yaml_parser_t, token *yaml_token_t) bool {
+	// Eat '%'.
+	start_mark := parser.mark
+	skip(parser)
+
+	// Scan the directive name.
+	var name []byte
+	if !yaml_parser_scan_directive_name(parser, start_mark, &name) {
+		return false
+	}
+
+	// Is it a YAML directive?
+	if bytes.Equal(name, []byte("YAML")) {
+		// Scan the VERSION directive value.
+		var major, minor int8
+		if !yaml_parser_scan_version_directive_value(parser, start_mark, &major, &minor) {
+			return false
+		}
+		end_mark := parser.mark
+
+		// Create a VERSION-DIRECTIVE token.
+		*token = yaml_token_t{
+			typ:        yaml_VERSION_DIRECTIVE_TOKEN,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			major:      major,
+			minor:      minor,
+		}
+
+		// Is it a TAG directive?
+	} else if bytes.Equal(name, []byte("TAG")) {
+		// Scan the TAG directive value.
+		var handle, prefix []byte
+		if !yaml_parser_scan_tag_directive_value(parser, start_mark, &handle, &prefix) {
+			return false
+		}
+		end_mark := parser.mark
+
+		// Create a TAG-DIRECTIVE token.
+		*token = yaml_token_t{
+			typ:        yaml_TAG_DIRECTIVE_TOKEN,
+			start_mark: start_mark,
+			end_mark:   end_mark,
+			value:      handle,
+			prefix:     prefix,
+		}
+
+		// Unknown directive.
+	} else {
+		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+			start_mark, "found uknown directive name")
+		return false
+	}
+
+	// Eat the rest of the line including any comments.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	for is_blank(parser.buffer, parser.buffer_pos) {
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	if parser.buffer[parser.buffer_pos] == '#' {
+		for !is_breakz(parser.buffer, parser.buffer_pos) {
+			skip(parser)
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+	}
+
+	// Check if we are at the end of the line.
+	if !is_breakz(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+			start_mark, "did not find expected comment or line break")
+		return false
+	}
+
+	// Eat a line break.
+	if is_break(parser.buffer, parser.buffer_pos) {
+		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			return false
+		}
+		skip_line(parser)
+	}
+
+	return true
+}
+
+// Scan the directive name.
+//
+// Scope:
+//      %YAML   1.1     # a comment \n
+//       ^^^^
+//      %TAG    !yaml!  tag:yaml.org,2002:  \n
+//       ^^^
+//
+func yaml_parser_scan_directive_name(parser *yaml_parser_t, start_mark yaml_mark_t, name *[]byte) bool {
+	// Consume the directive name.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	var s []byte
+	for is_alpha(parser.buffer, parser.buffer_pos) {
+		s = read(parser, s)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Check if the name is empty.
+	if len(s) == 0 {
+		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+			start_mark, "could not find expected directive name")
+		return false
+	}
+
+	// Check for an blank character after the name.
+	if !is_blankz(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a directive",
+			start_mark, "found unexpected non-alphabetical character")
+		return false
+	}
+	*name = s
+	return true
+}
+
+// Scan the value of VERSION-DIRECTIVE.
+//
+// Scope:
+//      %YAML   1.1     # a comment \n
+//           ^^^^^^
+func yaml_parser_scan_version_directive_value(parser *yaml_parser_t, start_mark yaml_mark_t, major, minor *int8) bool {
+	// Eat whitespaces.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	for is_blank(parser.buffer, parser.buffer_pos) {
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Consume the major version number.
+	if !yaml_parser_scan_version_directive_number(parser, start_mark, major) {
+		return false
+	}
+
+	// Eat '.'.
+	if parser.buffer[parser.buffer_pos] != '.' {
+		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+			start_mark, "did not find expected digit or '.' character")
+	}
+
+	skip(parser)
+
+	// Consume the minor version number.
+	if !yaml_parser_scan_version_directive_number(parser, start_mark, minor) {
+		return false
+	}
+	return true
+}
+
+const max_number_length = 2
+
+// Scan the version number of VERSION-DIRECTIVE.
+//
+// Scope:
+//      %YAML   1.1     # a comment \n
+//              ^
+//      %YAML   1.1     # a comment \n
+//                ^
+func yaml_parser_scan_version_directive_number(parser *yaml_parser_t, start_mark yaml_mark_t, number *int8) bool {
+
+	// Repeat while the next character is digit.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	var value, length int8
+	for is_digit(parser.buffer, parser.buffer_pos) {
+		// Check if the number is too long.
+		length++
+		if length > max_number_length {
+			return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+				start_mark, "found extremely long version number")
+		}
+		value = value*10 + int8(as_digit(parser.buffer, parser.buffer_pos))
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Check if the number was present.
+	if length == 0 {
+		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+			start_mark, "did not find expected version number")
+	}
+	*number = value
+	return true
+}
+
+// Scan the value of a TAG-DIRECTIVE token.
+//
+// Scope:
+//      %TAG    !yaml!  tag:yaml.org,2002:  \n
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//
+func yaml_parser_scan_tag_directive_value(parser *yaml_parser_t, start_mark yaml_mark_t, handle, prefix *[]byte) bool {
+	var handle_value, prefix_value []byte
+
+	// Eat whitespaces.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	for is_blank(parser.buffer, parser.buffer_pos) {
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Scan a handle.
+	if !yaml_parser_scan_tag_handle(parser, true, start_mark, &handle_value) {
+		return false
+	}
+
+	// Expect a whitespace.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	if !is_blank(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a %TAG directive",
+			start_mark, "did not find expected whitespace")
+		return false
+	}
+
+	// Eat whitespaces.
+	for is_blank(parser.buffer, parser.buffer_pos) {
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Scan a prefix.
+	if !yaml_parser_scan_tag_uri(parser, true, nil, start_mark, &prefix_value) {
+		return false
+	}
+
+	// Expect a whitespace or line break.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	if !is_blankz(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a %TAG directive",
+			start_mark, "did not find expected whitespace or line break")
+		return false
+	}
+
+	*handle = handle_value
+	*prefix = prefix_value
+	return true
+}
+
+func yaml_parser_scan_anchor(parser *yaml_parser_t, token *yaml_token_t, typ yaml_token_type_t) bool {
+	var s []byte
+
+	// Eat the indicator character.
+	start_mark := parser.mark
+	skip(parser)
+
+	// Consume the value.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	for is_alpha(parser.buffer, parser.buffer_pos) {
+		s = read(parser, s)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	end_mark := parser.mark
+
+	/*
+	 * Check if length of the anchor is greater than 0 and it is followed by
+	 * a whitespace character or one of the indicators:
+	 *
+	 *      '?', ':', ',', ']', '}', '%', '@', '`'.
+	 */
+
+	if len(s) == 0 ||
+		!(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '?' ||
+			parser.buffer[parser.buffer_pos] == ':' || parser.buffer[parser.buffer_pos] == ',' ||
+			parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '}' ||
+			parser.buffer[parser.buffer_pos] == '%' || parser.buffer[parser.buffer_pos] == '@' ||
+			parser.buffer[parser.buffer_pos] == '`') {
+		context := "while scanning an alias"
+		if typ == yaml_ANCHOR_TOKEN {
+			context = "while scanning an anchor"
+		}
+		yaml_parser_set_scanner_error(parser, context, start_mark,
+			"did not find expected alphabetic or numeric character")
+		return false
+	}
+
+	// Create a token.
+	*token = yaml_token_t{
+		typ:        typ,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		value:      s,
+	}
+
+	return true
+}
+
+/*
+ * Scan a TAG token.
+ */
+
+func yaml_parser_scan_tag(parser *yaml_parser_t, token *yaml_token_t) bool {
+	var handle, suffix []byte
+
+	start_mark := parser.mark
+
+	// Check if the tag is in the canonical form.
+	if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+		return false
+	}
+
+	if parser.buffer[parser.buffer_pos+1] == '<' {
+		// Keep the handle as ''
+
+		// Eat '!<'
+		skip(parser)
+		skip(parser)
+
+		// Consume the tag value.
+		if !yaml_parser_scan_tag_uri(parser, false, nil, start_mark, &suffix) {
+			return false
+		}
+
+		// Check for '>' and eat it.
+		if parser.buffer[parser.buffer_pos] != '>' {
+			yaml_parser_set_scanner_error(parser, "while scanning a tag",
+				start_mark, "did not find the expected '>'")
+			return false
+		}
+
+		skip(parser)
+	} else {
+		// The tag has either the '!suffix' or the '!handle!suffix' form.
+
+		// First, try to scan a handle.
+		if !yaml_parser_scan_tag_handle(parser, false, start_mark, &handle) {
+			return false
+		}
+
+		// Check if it is, indeed, handle.
+		if handle[0] == '!' && len(handle) > 1 && handle[len(handle)-1] == '!' {
+			// Scan the suffix now.
+			if !yaml_parser_scan_tag_uri(parser, false, nil, start_mark, &suffix) {
+				return false
+			}
+		} else {
+			// It wasn't a handle after all.  Scan the rest of the tag.
+			if !yaml_parser_scan_tag_uri(parser, false, handle, start_mark, &suffix) {
+				return false
+			}
+
+			// Set the handle to '!'.
+			handle = []byte{'!'}
+
+			// A special case: the '!' tag.  Set the handle to '' and the
+			// suffix to '!'.
+			if len(suffix) == 0 {
+				handle, suffix = suffix, handle
+			}
+		}
+	}
+
+	// Check the character which ends the tag.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	if !is_blankz(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a tag",
+			start_mark, "did not find expected whitespace or line break")
+		return false
+	}
+
+	end_mark := parser.mark
+
+	// Create a token.
+	*token = yaml_token_t{
+		typ:        yaml_TAG_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		value:      handle,
+		suffix:     suffix,
+	}
+	return true
+}
+
+// Scan a tag handle.
+func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_mark yaml_mark_t, handle *[]byte) bool {
+	// Check the initial '!' character.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	if parser.buffer[parser.buffer_pos] != '!' {
+		yaml_parser_set_scanner_tag_error(parser, directive,
+			start_mark, "did not find expected '!'")
+		return false
+	}
+
+	var s []byte
+
+	// Copy the '!' character.
+	s = read(parser, s)
+
+	// Copy all subsequent alphabetical and numerical characters.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	for is_alpha(parser.buffer, parser.buffer_pos) {
+		s = read(parser, s)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Check if the trailing character is '!' and copy it.
+	if parser.buffer[parser.buffer_pos] == '!' {
+		s = read(parser, s)
+	} else {
+		// It's either the '!' tag or not really a tag handle.  If it's a %TAG
+		// directive, it's an error.  If it's a tag token, it must be a part of URI.
+		if directive && !(s[0] == '!' && s[1] == 0) {
+			yaml_parser_set_scanner_tag_error(parser, directive,
+				start_mark, "did not find expected '!'")
+			return false
+		}
+	}
+
+	*handle = s
+	return true
+}
+
+// Scan a tag.
+func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
+	//size_t length = head ? strlen((char *)head) : 0
+	var s []byte
+
+	// Copy the head if needed.
+	//
+	// Note that we don't copy the leading '!' character.
+	if len(head) > 1 {
+		s = append(s, head[1:]...)
+	}
+
+	// Scan the tag.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	// The set of characters that may appear in URI is as follows:
+	//
+	//      '0'-'9', 'A'-'Z', 'a'-'z', '_', '-', ';', '/', '?', ':', '@', '&',
+	//      '=', '+', '$', ',', '.', '!', '~', '*', '\'', '(', ')', '[', ']',
+	//      '%'.
+	// [Go] Convert this into more reasonable logic.
+	for is_alpha(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == ';' ||
+		parser.buffer[parser.buffer_pos] == '/' || parser.buffer[parser.buffer_pos] == '?' ||
+		parser.buffer[parser.buffer_pos] == ':' || parser.buffer[parser.buffer_pos] == '@' ||
+		parser.buffer[parser.buffer_pos] == '&' || parser.buffer[parser.buffer_pos] == '=' ||
+		parser.buffer[parser.buffer_pos] == '+' || parser.buffer[parser.buffer_pos] == '$' ||
+		parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == '.' ||
+		parser.buffer[parser.buffer_pos] == '!' || parser.buffer[parser.buffer_pos] == '~' ||
+		parser.buffer[parser.buffer_pos] == '*' || parser.buffer[parser.buffer_pos] == '\'' ||
+		parser.buffer[parser.buffer_pos] == '(' || parser.buffer[parser.buffer_pos] == ')' ||
+		parser.buffer[parser.buffer_pos] == '[' || parser.buffer[parser.buffer_pos] == ']' ||
+		parser.buffer[parser.buffer_pos] == '%' {
+		// Check if it is a URI-escape sequence.
+		if parser.buffer[parser.buffer_pos] == '%' {
+			if !yaml_parser_scan_uri_escapes(parser, directive, start_mark, &s) {
+				return false
+			}
+		} else {
+			s = read(parser, s)
+		}
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+
+	// Check if the tag is non-empty.
+	if len(s) == 0 {
+		yaml_parser_set_scanner_tag_error(parser, directive,
+			start_mark, "did not find expected tag URI")
+		return false
+	}
+	*uri = s
+	return true
+}
+
+// Decode an URI-escape sequence corresponding to a single UTF-8 character.
+func yaml_parser_scan_uri_escapes(parser *yaml_parser_t, directive bool, start_mark yaml_mark_t, s *[]byte) bool {
+
+	// Decode the required number of characters.
+	w := 1024
+	for w > 0 {
+		// Check for a URI-escaped octet.
+		if parser.unread < 3 && !yaml_parser_update_buffer(parser, 3) {
+			return false
+		}
+
+		if !(parser.buffer[parser.buffer_pos] == '%' &&
+			is_hex(parser.buffer, parser.buffer_pos+1) &&
+			is_hex(parser.buffer, parser.buffer_pos+2)) {
+			return yaml_parser_set_scanner_tag_error(parser, directive,
+				start_mark, "did not find URI escaped octet")
+		}
+
+		// Get the octet.
+		octet := byte((as_hex(parser.buffer, parser.buffer_pos+1) << 4) + as_hex(parser.buffer, parser.buffer_pos+2))
+
+		// If it is the leading octet, determine the length of the UTF-8 sequence.
+		if w == 1024 {
+			w = width(octet)
+			if w == 0 {
+				return yaml_parser_set_scanner_tag_error(parser, directive,
+					start_mark, "found an incorrect leading UTF-8 octet")
+			}
+		} else {
+			// Check if the trailing octet is correct.
+			if octet&0xC0 != 0x80 {
+				return yaml_parser_set_scanner_tag_error(parser, directive,
+					start_mark, "found an incorrect trailing UTF-8 octet")
+			}
+		}
+
+		// Copy the octet and move the pointers.
+		*s = append(*s, octet)
+		skip(parser)
+		skip(parser)
+		skip(parser)
+		w--
+	}
+	return true
+}
+
+// Scan a block scalar.
+func yaml_parser_scan_block_scalar(parser *yaml_parser_t, token *yaml_token_t, literal bool) bool {
+	// Eat the indicator '|' or '>'.
+	start_mark := parser.mark
+	skip(parser)
+
+	// Scan the additional block scalar indicators.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+
+	// Check for a chomping indicator.
+	var chomping, increment int
+	if parser.buffer[parser.buffer_pos] == '+' || parser.buffer[parser.buffer_pos] == '-' {
+		// Set the chomping method and eat the indicator.
+		if parser.buffer[parser.buffer_pos] == '+' {
+			chomping = +1
+		} else {
+			chomping = -1
+		}
+		skip(parser)
+
+		// Check for an indentation indicator.
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+		if is_digit(parser.buffer, parser.buffer_pos) {
+			// Check that the indentation is greater than 0.
+			if parser.buffer[parser.buffer_pos] == '0' {
+				yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+					start_mark, "found an indentation indicator equal to 0")
+				return false
+			}
+
+			// Get the indentation level and eat the indicator.
+			increment = as_digit(parser.buffer, parser.buffer_pos)
+			skip(parser)
+		}
+
+	} else if is_digit(parser.buffer, parser.buffer_pos) {
+		// Do the same as above, but in the opposite order.
+
+		if parser.buffer[parser.buffer_pos] == '0' {
+			yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+				start_mark, "found an indentation indicator equal to 0")
+			return false
+		}
+		increment = as_digit(parser.buffer, parser.buffer_pos)
+		skip(parser)
+
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+		if parser.buffer[parser.buffer_pos] == '+' || parser.buffer[parser.buffer_pos] == '-' {
+			if parser.buffer[parser.buffer_pos] == '+' {
+				chomping = +1
+			} else {
+				chomping = -1
+			}
+			skip(parser)
+		}
+	}
+
+	// Eat whitespaces and comments to the end of the line.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	for is_blank(parser.buffer, parser.buffer_pos) {
+		skip(parser)
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+	}
+	if parser.buffer[parser.buffer_pos] == '#' {
+		for !is_breakz(parser.buffer, parser.buffer_pos) {
+			skip(parser)
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+	}
+
+	// Check if we are at the end of the line.
+	if !is_breakz(parser.buffer, parser.buffer_pos) {
+		yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+			start_mark, "did not find expected comment or line break")
+		return false
+	}
+
+	// Eat a line break.
+	if is_break(parser.buffer, parser.buffer_pos) {
+		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			return false
+		}
+		skip_line(parser)
+	}
+
+	end_mark := parser.mark
+
+	// Set the indentation level if it was specified.
+	var indent int
+	if increment > 0 {
+		if parser.indent >= 0 {
+			indent = parser.indent + increment
+		} else {
+			indent = increment
+		}
+	}
+
+	// Scan the leading line breaks and determine the indentation level if needed.
+	var s, leading_break, trailing_breaks []byte
+	if !yaml_parser_scan_block_scalar_breaks(parser, &indent, &trailing_breaks, start_mark, &end_mark) {
+		return false
+	}
+
+	// Scan the block scalar content.
+	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+		return false
+	}
+	var leading_blank, trailing_blank bool
+	for parser.mark.column == indent && !is_z(parser.buffer, parser.buffer_pos) {
+		// We are at the beginning of a non-empty line.
+
+		// Is it a trailing whitespace?
+		trailing_blank = is_blank(parser.buffer, parser.buffer_pos)
+
+		// Check if we need to fold the leading line break.
+		if !literal && !leading_blank && !trailing_blank && len(leading_break) > 0 && leading_break[0] == '\n' {
+			// Do we need to join the lines by space?
+			if len(trailing_breaks) == 0 {
+				s = append(s, ' ')
+			}
+		} else {
+			s = append(s, leading_break...)
+		}
+		leading_break = leading_break[:0]
+
+		// Append the remaining line breaks.
+		s = append(s, trailing_breaks...)
+		trailing_breaks = trailing_breaks[:0]
+
+		// Is it a leading whitespace?
+		leading_blank = is_blank(parser.buffer, parser.buffer_pos)
+
+		// Consume the current line.
+		for !is_breakz(parser.buffer, parser.buffer_pos) {
+			s = read(parser, s)
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+
+		// Consume the line break.
+		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			return false
+		}
+
+		leading_break = read_line(parser, leading_break)
+
+		// Eat the following indentation spaces and line breaks.
+		if !yaml_parser_scan_block_scalar_breaks(parser, &indent, &trailing_breaks, start_mark, &end_mark) {
+			return false
+		}
+	}
+
+	// Chomp the tail.
+	if chomping != -1 {
+		s = append(s, leading_break...)
+	}
+	if chomping == 1 {
+		s = append(s, trailing_breaks...)
+	}
+
+	// Create a token.
+	*token = yaml_token_t{
+		typ:        yaml_SCALAR_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		value:      s,
+		style:      yaml_LITERAL_SCALAR_STYLE,
+	}
+	if !literal {
+		token.style = yaml_FOLDED_SCALAR_STYLE
+	}
+	return true
+}
+
+// Scan indentation spaces and line breaks for a block scalar.  Determine the
+// indentation level if needed.
+func yaml_parser_scan_block_scalar_breaks(parser *yaml_parser_t, indent *int, breaks *[]byte, start_mark yaml_mark_t, end_mark *yaml_mark_t) bool {
+	*end_mark = parser.mark
+
+	// Eat the indentation spaces and line breaks.
+	max_indent := 0
+	for {
+		// Eat the indentation spaces.
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+		for (*indent == 0 || parser.mark.column < *indent) && is_space(parser.buffer, parser.buffer_pos) {
+			skip(parser)
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+		if parser.mark.column > max_indent {
+			max_indent = parser.mark.column
+		}
+
+		// Check for a tab character messing the indentation.
+		if (*indent == 0 || parser.mark.column < *indent) && is_tab(parser.buffer, parser.buffer_pos) {
+			return yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
+				start_mark, "found a tab character where an indentation space is expected")
+		}
+
+		// Have we found a non-empty line?
+		if !is_break(parser.buffer, parser.buffer_pos) {
+			break
+		}
+
+		// Consume the line break.
+		if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+			return false
+		}
+		// [Go] Should really be returning breaks instead.
+		*breaks = read_line(parser, *breaks)
+		*end_mark = parser.mark
+	}
+
+	// Determine the indentation level if needed.
+	if *indent == 0 {
+		*indent = max_indent
+		if *indent < parser.indent+1 {
+			*indent = parser.indent + 1
+		}
+		if *indent < 1 {
+			*indent = 1
+		}
+	}
+	return true
+}
+
+// Scan a quoted scalar.
+func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, single bool) bool {
+	// Eat the left quote.
+	start_mark := parser.mark
+	skip(parser)
+
+	// Consume the content of the quoted scalar.
+	var s, leading_break, trailing_breaks, whitespaces []byte
+	for {
+		// Check that there are no document indicators at the beginning of the line.
+		if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+			return false
+		}
+
+		if parser.mark.column == 0 &&
+			((parser.buffer[parser.buffer_pos+0] == '-' &&
+				parser.buffer[parser.buffer_pos+1] == '-' &&
+				parser.buffer[parser.buffer_pos+2] == '-') ||
+				(parser.buffer[parser.buffer_pos+0] == '.' &&
+					parser.buffer[parser.buffer_pos+1] == '.' &&
+					parser.buffer[parser.buffer_pos+2] == '.')) &&
+			is_blankz(parser.buffer, parser.buffer_pos+3) {
+			yaml_parser_set_scanner_error(parser, "while scanning a quoted scalar",
+				start_mark, "found unexpected document indicator")
+			return false
+		}
+
+		// Check for EOF.
+		if is_z(parser.buffer, parser.buffer_pos) {
+			yaml_parser_set_scanner_error(parser, "while scanning a quoted scalar",
+				start_mark, "found unexpected end of stream")
+			return false
+		}
+
+		// Consume non-blank characters.
+		leading_blanks := false
+		for !is_blankz(parser.buffer, parser.buffer_pos) {
+			if single && parser.buffer[parser.buffer_pos] == '\'' && parser.buffer[parser.buffer_pos+1] == '\'' {
+				// Is is an escaped single quote.
+				s = append(s, '\'')
+				skip(parser)
+				skip(parser)
+
+			} else if single && parser.buffer[parser.buffer_pos] == '\'' {
+				// It is a right single quote.
+				break
+			} else if !single && parser.buffer[parser.buffer_pos] == '"' {
+				// It is a right double quote.
+				break
+
+			} else if !single && parser.buffer[parser.buffer_pos] == '\\' && is_break(parser.buffer, parser.buffer_pos+1) {
+				// It is an escaped line break.
+				if parser.unread < 3 && !yaml_parser_update_buffer(parser, 3) {
+					return false
+				}
+				skip(parser)
+				skip_line(parser)
+				leading_blanks = true
+				break
+
+			} else if !single && parser.buffer[parser.buffer_pos] == '\\' {
+				// It is an escape sequence.
+				code_length := 0
+
+				// Check the escape character.
+				switch parser.buffer[parser.buffer_pos+1] {
+				case '0':
+					s = append(s, 0)
+				case 'a':
+					s = append(s, '\x07')
+				case 'b':
+					s = append(s, '\x08')
+				case 't', '\t':
+					s = append(s, '\x09')
+				case 'n':
+					s = append(s, '\x0A')
+				case 'v':
+					s = append(s, '\x0B')
+				case 'f':
+					s = append(s, '\x0C')
+				case 'r':
+					s = append(s, '\x0D')
+				case 'e':
+					s = append(s, '\x1B')
+				case ' ':
+					s = append(s, '\x20')
+				case '"':
+					s = append(s, '"')
+				case '\'':
+					s = append(s, '\'')
+				case '\\':
+					s = append(s, '\\')
+				case 'N': // NEL (#x85)
+					s = append(s, '\xC2')
+					s = append(s, '\x85')
+				case '_': // #xA0
+					s = append(s, '\xC2')
+					s = append(s, '\xA0')
+				case 'L': // LS (#x2028)
+					s = append(s, '\xE2')
+					s = append(s, '\x80')
+					s = append(s, '\xA8')
+				case 'P': // PS (#x2029)
+					s = append(s, '\xE2')
+					s = append(s, '\x80')
+					s = append(s, '\xA9')
+				case 'x':
+					code_length = 2
+				case 'u':
+					code_length = 4
+				case 'U':
+					code_length = 8
+				default:
+					yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+						start_mark, "found unknown escape character")
+					return false
+				}
+
+				skip(parser)
+				skip(parser)
+
+				// Consume an arbitrary escape code.
+				if code_length > 0 {
+					var value int
+
+					// Scan the character value.
+					if parser.unread < code_length && !yaml_parser_update_buffer(parser, code_length) {
+						return false
+					}
+					for k := 0; k < code_length; k++ {
+						if !is_hex(parser.buffer, parser.buffer_pos+k) {
+							yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+								start_mark, "did not find expected hexdecimal number")
+							return false
+						}
+						value = (value << 4) + as_hex(parser.buffer, parser.buffer_pos+k)
+					}
+
+					// Check the value and write the character.
+					if (value >= 0xD800 && value <= 0xDFFF) || value > 0x10FFFF {
+						yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
+							start_mark, "found invalid Unicode character escape code")
+						return false
+					}
+					if value <= 0x7F {
+						s = append(s, byte(value))
+					} else if value <= 0x7FF {
+						s = append(s, byte(0xC0+(value>>6)))
+						s = append(s, byte(0x80+(value&0x3F)))
+					} else if value <= 0xFFFF {
+						s = append(s, byte(0xE0+(value>>12)))
+						s = append(s, byte(0x80+((value>>6)&0x3F)))
+						s = append(s, byte(0x80+(value&0x3F)))
+					} else {
+						s = append(s, byte(0xF0+(value>>18)))
+						s = append(s, byte(0x80+((value>>12)&0x3F)))
+						s = append(s, byte(0x80+((value>>6)&0x3F)))
+						s = append(s, byte(0x80+(value&0x3F)))
+					}
+
+					// Advance the pointer.
+					for k := 0; k < code_length; k++ {
+						skip(parser)
+					}
+				}
+			} else {
+				// It is a non-escaped non-blank character.
+				s = read(parser, s)
+			}
+			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				return false
+			}
+		}
+
+		// Check if we are at the end of the scalar.
+		if single {
+			if parser.buffer[parser.buffer_pos] == '\'' {
+				break
+			}
+		} else {
+			if parser.buffer[parser.buffer_pos] == '"' {
+				break
+			}
+		}
+
+		// Consume blank characters.
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+
+		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
+			if is_blank(parser.buffer, parser.buffer_pos) {
+				// Consume a space or a tab character.
+				if !leading_blanks {
+					whitespaces = read(parser, whitespaces)
+				} else {
+					skip(parser)
+				}
+			} else {
+				if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+					return false
+				}
+
+				// Check if it is a first line break.
+				if !leading_blanks {
+					whitespaces = whitespaces[:0]
+					leading_break = read_line(parser, leading_break)
+					leading_blanks = true
+				} else {
+					trailing_breaks = read_line(parser, trailing_breaks)
+				}
+			}
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+
+		// Join the whitespaces or fold line breaks.
+		if leading_blanks {
+			// Do we need to fold line breaks?
+			if len(leading_break) > 0 && leading_break[0] == '\n' {
+				if len(trailing_breaks) == 0 {
+					s = append(s, ' ')
+				} else {
+					s = append(s, trailing_breaks...)
+				}
+			} else {
+				s = append(s, leading_break...)
+				s = append(s, trailing_breaks...)
+			}
+			trailing_breaks = trailing_breaks[:0]
+			leading_break = leading_break[:0]
+		} else {
+			s = append(s, whitespaces...)
+			whitespaces = whitespaces[:0]
+		}
+	}
+
+	// Eat the right quote.
+	skip(parser)
+	end_mark := parser.mark
+
+	// Create a token.
+	*token = yaml_token_t{
+		typ:        yaml_SCALAR_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		value:      s,
+		style:      yaml_SINGLE_QUOTED_SCALAR_STYLE,
+	}
+	if !single {
+		token.style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+	}
+	return true
+}
+
+// Scan a plain scalar.
+func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) bool {
+
+	var s, leading_break, trailing_breaks, whitespaces []byte
+	var leading_blanks bool
+	var indent = parser.indent + 1
+
+	start_mark := parser.mark
+	end_mark := parser.mark
+
+	// Consume the content of the plain scalar.
+	for {
+		// Check for a document indicator.
+		if parser.unread < 4 && !yaml_parser_update_buffer(parser, 4) {
+			return false
+		}
+		if parser.mark.column == 0 &&
+			((parser.buffer[parser.buffer_pos+0] == '-' &&
+				parser.buffer[parser.buffer_pos+1] == '-' &&
+				parser.buffer[parser.buffer_pos+2] == '-') ||
+				(parser.buffer[parser.buffer_pos+0] == '.' &&
+					parser.buffer[parser.buffer_pos+1] == '.' &&
+					parser.buffer[parser.buffer_pos+2] == '.')) &&
+			is_blankz(parser.buffer, parser.buffer_pos+3) {
+			break
+		}
+
+		// Check for a comment.
+		if parser.buffer[parser.buffer_pos] == '#' {
+			break
+		}
+
+		// Consume non-blank characters.
+		for !is_blankz(parser.buffer, parser.buffer_pos) {
+
+			// Check for 'x:x' in the flow context. TODO: Fix the test "spec-08-13".
+			if parser.flow_level > 0 &&
+				parser.buffer[parser.buffer_pos] == ':' &&
+				!is_blankz(parser.buffer, parser.buffer_pos+1) {
+				yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
+					start_mark, "found unexpected ':'")
+				return false
+			}
+
+			// Check for indicators that may end a plain scalar.
+			if (parser.buffer[parser.buffer_pos] == ':' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
+				(parser.flow_level > 0 &&
+					(parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == ':' ||
+						parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == '[' ||
+						parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
+						parser.buffer[parser.buffer_pos] == '}')) {
+				break
+			}
+
+			// Check if we need to join whitespaces and breaks.
+			if leading_blanks || len(whitespaces) > 0 {
+				if leading_blanks {
+					// Do we need to fold line breaks?
+					if leading_break[0] == '\n' {
+						if len(trailing_breaks) == 0 {
+							s = append(s, ' ')
+						} else {
+							s = append(s, trailing_breaks...)
+						}
+					} else {
+						s = append(s, leading_break...)
+						s = append(s, trailing_breaks...)
+					}
+					trailing_breaks = trailing_breaks[:0]
+					leading_break = leading_break[:0]
+					leading_blanks = false
+				} else {
+					s = append(s, whitespaces...)
+					whitespaces = whitespaces[:0]
+				}
+			}
+
+			// Copy the character.
+			s = read(parser, s)
+
+			end_mark = parser.mark
+			if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+				return false
+			}
+		}
+
+		// Is it the end?
+		if !(is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos)) {
+			break
+		}
+
+		// Consume blank characters.
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+
+		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
+			if is_blank(parser.buffer, parser.buffer_pos) {
+
+				// Check for tab character that abuse indentation.
+				if leading_blanks && parser.mark.column < indent && is_tab(parser.buffer, parser.buffer_pos) {
+					yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
+						start_mark, "found a tab character that violate indentation")
+					return false
+				}
+
+				// Consume a space or a tab character.
+				if !leading_blanks {
+					whitespaces = read(parser, whitespaces)
+				} else {
+					skip(parser)
+				}
+			} else {
+				if parser.unread < 2 && !yaml_parser_update_buffer(parser, 2) {
+					return false
+				}
+
+				// Check if it is a first line break.
+				if !leading_blanks {
+					whitespaces = whitespaces[:0]
+					leading_break = read_line(parser, leading_break)
+					leading_blanks = true
+				} else {
+					trailing_breaks = read_line(parser, trailing_breaks)
+				}
+			}
+			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+				return false
+			}
+		}
+
+		// Check indentation level.
+		if parser.flow_level == 0 && parser.mark.column < indent {
+			break
+		}
+	}
+
+	// Create a token.
+	*token = yaml_token_t{
+		typ:        yaml_SCALAR_TOKEN,
+		start_mark: start_mark,
+		end_mark:   end_mark,
+		value:      s,
+		style:      yaml_PLAIN_SCALAR_STYLE,
+	}
+
+	// Note that we change the 'simple_key_allowed' flag.
+	if leading_blanks {
+		parser.simple_key_allowed = true
+	}
+	return true
+}

--- a/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/vendor/gopkg.in/yaml.v2/sorter.go
@@ -1,0 +1,104 @@
+package yaml
+
+import (
+	"reflect"
+	"unicode"
+)
+
+type keyList []reflect.Value
+
+func (l keyList) Len() int      { return len(l) }
+func (l keyList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l keyList) Less(i, j int) bool {
+	a := l[i]
+	b := l[j]
+	ak := a.Kind()
+	bk := b.Kind()
+	for (ak == reflect.Interface || ak == reflect.Ptr) && !a.IsNil() {
+		a = a.Elem()
+		ak = a.Kind()
+	}
+	for (bk == reflect.Interface || bk == reflect.Ptr) && !b.IsNil() {
+		b = b.Elem()
+		bk = b.Kind()
+	}
+	af, aok := keyFloat(a)
+	bf, bok := keyFloat(b)
+	if aok && bok {
+		if af != bf {
+			return af < bf
+		}
+		if ak != bk {
+			return ak < bk
+		}
+		return numLess(a, b)
+	}
+	if ak != reflect.String || bk != reflect.String {
+		return ak < bk
+	}
+	ar, br := []rune(a.String()), []rune(b.String())
+	for i := 0; i < len(ar) && i < len(br); i++ {
+		if ar[i] == br[i] {
+			continue
+		}
+		al := unicode.IsLetter(ar[i])
+		bl := unicode.IsLetter(br[i])
+		if al && bl {
+			return ar[i] < br[i]
+		}
+		if al || bl {
+			return bl
+		}
+		var ai, bi int
+		var an, bn int64
+		for ai = i; ai < len(ar) && unicode.IsDigit(ar[ai]); ai++ {
+			an = an*10 + int64(ar[ai]-'0')
+		}
+		for bi = i; bi < len(br) && unicode.IsDigit(br[bi]); bi++ {
+			bn = bn*10 + int64(br[bi]-'0')
+		}
+		if an != bn {
+			return an < bn
+		}
+		if ai != bi {
+			return ai < bi
+		}
+		return ar[i] < br[i]
+	}
+	return len(ar) < len(br)
+}
+
+// keyFloat returns a float value for v if it is a number/bool
+// and whether it is a number/bool or not.
+func keyFloat(v reflect.Value) (f float64, ok bool) {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(v.Int()), true
+	case reflect.Float32, reflect.Float64:
+		return v.Float(), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return float64(v.Uint()), true
+	case reflect.Bool:
+		if v.Bool() {
+			return 1, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+// numLess returns whether a < b.
+// a and b must necessarily have the same kind.
+func numLess(a, b reflect.Value) bool {
+	switch a.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return a.Int() < b.Int()
+	case reflect.Float32, reflect.Float64:
+		return a.Float() < b.Float()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return a.Uint() < b.Uint()
+	case reflect.Bool:
+		return !a.Bool() && b.Bool()
+	}
+	panic("not a number")
+}

--- a/vendor/gopkg.in/yaml.v2/suite_test.go
+++ b/vendor/gopkg.in/yaml.v2/suite_test.go
@@ -1,0 +1,12 @@
+package yaml_test
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})

--- a/vendor/gopkg.in/yaml.v2/writerc.go
+++ b/vendor/gopkg.in/yaml.v2/writerc.go
@@ -1,0 +1,89 @@
+package yaml
+
+// Set the writer error and return false.
+func yaml_emitter_set_writer_error(emitter *yaml_emitter_t, problem string) bool {
+	emitter.error = yaml_WRITER_ERROR
+	emitter.problem = problem
+	return false
+}
+
+// Flush the output buffer.
+func yaml_emitter_flush(emitter *yaml_emitter_t) bool {
+	if emitter.write_handler == nil {
+		panic("write handler not set")
+	}
+
+	// Check if the buffer is empty.
+	if emitter.buffer_pos == 0 {
+		return true
+	}
+
+	// If the output encoding is UTF-8, we don't need to recode the buffer.
+	if emitter.encoding == yaml_UTF8_ENCODING {
+		if err := emitter.write_handler(emitter, emitter.buffer[:emitter.buffer_pos]); err != nil {
+			return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
+		}
+		emitter.buffer_pos = 0
+		return true
+	}
+
+	// Recode the buffer into the raw buffer.
+	var low, high int
+	if emitter.encoding == yaml_UTF16LE_ENCODING {
+		low, high = 0, 1
+	} else {
+		high, low = 1, 0
+	}
+
+	pos := 0
+	for pos < emitter.buffer_pos {
+		// See the "reader.c" code for more details on UTF-8 encoding.  Note
+		// that we assume that the buffer contains a valid UTF-8 sequence.
+
+		// Read the next UTF-8 character.
+		octet := emitter.buffer[pos]
+
+		var w int
+		var value rune
+		switch {
+		case octet&0x80 == 0x00:
+			w, value = 1, rune(octet&0x7F)
+		case octet&0xE0 == 0xC0:
+			w, value = 2, rune(octet&0x1F)
+		case octet&0xF0 == 0xE0:
+			w, value = 3, rune(octet&0x0F)
+		case octet&0xF8 == 0xF0:
+			w, value = 4, rune(octet&0x07)
+		}
+		for k := 1; k < w; k++ {
+			octet = emitter.buffer[pos+k]
+			value = (value << 6) + (rune(octet) & 0x3F)
+		}
+		pos += w
+
+		// Write the character.
+		if value < 0x10000 {
+			var b [2]byte
+			b[high] = byte(value >> 8)
+			b[low] = byte(value & 0xFF)
+			emitter.raw_buffer = append(emitter.raw_buffer, b[0], b[1])
+		} else {
+			// Write the character using a surrogate pair (check "reader.c").
+			var b [4]byte
+			value -= 0x10000
+			b[high] = byte(0xD8 + (value >> 18))
+			b[low] = byte((value >> 10) & 0xFF)
+			b[high+2] = byte(0xDC + ((value >> 8) & 0xFF))
+			b[low+2] = byte(value & 0xFF)
+			emitter.raw_buffer = append(emitter.raw_buffer, b[0], b[1], b[2], b[3])
+		}
+	}
+
+	// Write the raw buffer.
+	if err := emitter.write_handler(emitter, emitter.raw_buffer); err != nil {
+		return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
+	}
+	emitter.buffer_pos = 0
+	emitter.raw_buffer = emitter.raw_buffer[:0]
+	return true
+}

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -1,0 +1,346 @@
+// Package yaml implements YAML support for the Go language.
+//
+// Source code and other details for the project are available at GitHub:
+//
+//   https://github.com/go-yaml/yaml
+//
+package yaml
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// MapSlice encodes and decodes as a YAML map.
+// The order of keys is preserved when encoding and decoding.
+type MapSlice []MapItem
+
+// MapItem is an item in a MapSlice.
+type MapItem struct {
+	Key, Value interface{}
+}
+
+// The Unmarshaler interface may be implemented by types to customize their
+// behavior when being unmarshaled from a YAML document. The UnmarshalYAML
+// method receives a function that may be called to unmarshal the original
+// YAML value into a field or variable. It is safe to call the unmarshal
+// function parameter more than once if necessary.
+type Unmarshaler interface {
+	UnmarshalYAML(unmarshal func(interface{}) error) error
+}
+
+// The Marshaler interface may be implemented by types to customize their
+// behavior when being marshaled into a YAML document. The returned value
+// is marshaled in place of the original value implementing Marshaler.
+//
+// If an error is returned by MarshalYAML, the marshaling procedure stops
+// and returns with the provided error.
+type Marshaler interface {
+	MarshalYAML() (interface{}, error)
+}
+
+// Unmarshal decodes the first document found within the in byte slice
+// and assigns decoded values into the out value.
+//
+// Maps and pointers (to a struct, string, int, etc) are accepted as out
+// values. If an internal pointer within a struct is not initialized,
+// the yaml package will initialize it if necessary for unmarshalling
+// the provided data. The out parameter must not be nil.
+//
+// The type of the decoded values should be compatible with the respective
+// values in out. If one or more values cannot be decoded due to a type
+// mismatches, decoding continues partially until the end of the YAML
+// content, and a *yaml.TypeError is returned with details for all
+// missed values.
+//
+// Struct fields are only unmarshalled if they are exported (have an
+// upper case first letter), and are unmarshalled using the field name
+// lowercased as the default key. Custom keys may be defined via the
+// "yaml" name in the field tag: the content preceding the first comma
+// is used as the key, and the following comma-separated options are
+// used to tweak the marshalling process (see Marshal).
+// Conflicting names result in a runtime error.
+//
+// For example:
+//
+//     type T struct {
+//         F int `yaml:"a,omitempty"`
+//         B int
+//     }
+//     var t T
+//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//
+// See the documentation of Marshal for the format of tags and a list of
+// supported tag options.
+//
+func Unmarshal(in []byte, out interface{}) (err error) {
+	defer handleErr(&err)
+	d := newDecoder()
+	p := newParser(in)
+	defer p.destroy()
+	node := p.parse()
+	if node != nil {
+		v := reflect.ValueOf(out)
+		if v.Kind() == reflect.Ptr && !v.IsNil() {
+			v = v.Elem()
+		}
+		d.unmarshal(node, v)
+	}
+	if len(d.terrors) > 0 {
+		return &TypeError{d.terrors}
+	}
+	return nil
+}
+
+// Marshal serializes the value provided into a YAML document. The structure
+// of the generated document will reflect the structure of the value itself.
+// Maps and pointers (to struct, string, int, etc) are accepted as the in value.
+//
+// Struct fields are only unmarshalled if they are exported (have an upper case
+// first letter), and are unmarshalled using the field name lowercased as the
+// default key. Custom keys may be defined via the "yaml" name in the field
+// tag: the content preceding the first comma is used as the key, and the
+// following comma-separated options are used to tweak the marshalling process.
+// Conflicting names result in a runtime error.
+//
+// The field tag format accepted is:
+//
+//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//
+// The following flags are currently supported:
+//
+//     omitempty    Only include the field if it's not set to the zero
+//                  value for the type or to empty slices or maps.
+//                  Does not apply to zero valued structs.
+//
+//     flow         Marshal using a flow style (useful for structs,
+//                  sequences and maps).
+//
+//     inline       Inline the field, which must be a struct or a map,
+//                  causing all of its fields or keys to be processed as if
+//                  they were part of the outer struct. For maps, keys must
+//                  not conflict with the yaml keys of other struct fields.
+//
+// In addition, if the key is "-", the field is ignored.
+//
+// For example:
+//
+//     type T struct {
+//         F int "a,omitempty"
+//         B int
+//     }
+//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
+//
+func Marshal(in interface{}) (out []byte, err error) {
+	defer handleErr(&err)
+	e := newEncoder()
+	defer e.destroy()
+	e.marshal("", reflect.ValueOf(in))
+	e.finish()
+	out = e.out
+	return
+}
+
+func handleErr(err *error) {
+	if v := recover(); v != nil {
+		if e, ok := v.(yamlError); ok {
+			*err = e.err
+		} else {
+			panic(v)
+		}
+	}
+}
+
+type yamlError struct {
+	err error
+}
+
+func fail(err error) {
+	panic(yamlError{err})
+}
+
+func failf(format string, args ...interface{}) {
+	panic(yamlError{fmt.Errorf("yaml: "+format, args...)})
+}
+
+// A TypeError is returned by Unmarshal when one or more fields in
+// the YAML document cannot be properly decoded into the requested
+// types. When this error is returned, the value is still
+// unmarshaled partially.
+type TypeError struct {
+	Errors []string
+}
+
+func (e *TypeError) Error() string {
+	return fmt.Sprintf("yaml: unmarshal errors:\n  %s", strings.Join(e.Errors, "\n  "))
+}
+
+// --------------------------------------------------------------------------
+// Maintain a mapping of keys to structure field indexes
+
+// The code in this section was copied from mgo/bson.
+
+// structInfo holds details for the serialization of fields of
+// a given struct.
+type structInfo struct {
+	FieldsMap  map[string]fieldInfo
+	FieldsList []fieldInfo
+
+	// InlineMap is the number of the field in the struct that
+	// contains an ,inline map, or -1 if there's none.
+	InlineMap int
+}
+
+type fieldInfo struct {
+	Key       string
+	Num       int
+	OmitEmpty bool
+	Flow      bool
+
+	// Inline holds the field index if the field is part of an inlined struct.
+	Inline []int
+}
+
+var structMap = make(map[reflect.Type]*structInfo)
+var fieldMapMutex sync.RWMutex
+
+func getStructInfo(st reflect.Type) (*structInfo, error) {
+	fieldMapMutex.RLock()
+	sinfo, found := structMap[st]
+	fieldMapMutex.RUnlock()
+	if found {
+		return sinfo, nil
+	}
+
+	n := st.NumField()
+	fieldsMap := make(map[string]fieldInfo)
+	fieldsList := make([]fieldInfo, 0, n)
+	inlineMap := -1
+	for i := 0; i != n; i++ {
+		field := st.Field(i)
+		if field.PkgPath != "" {
+			continue // Private field
+		}
+
+		info := fieldInfo{Num: i}
+
+		tag := field.Tag.Get("yaml")
+		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
+			tag = string(field.Tag)
+		}
+		if tag == "-" {
+			continue
+		}
+
+		inline := false
+		fields := strings.Split(tag, ",")
+		if len(fields) > 1 {
+			for _, flag := range fields[1:] {
+				switch flag {
+				case "omitempty":
+					info.OmitEmpty = true
+				case "flow":
+					info.Flow = true
+				case "inline":
+					inline = true
+				default:
+					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
+				}
+			}
+			tag = fields[0]
+		}
+
+		if inline {
+			switch field.Type.Kind() {
+			case reflect.Map:
+				if inlineMap >= 0 {
+					return nil, errors.New("Multiple ,inline maps in struct " + st.String())
+				}
+				if field.Type.Key() != reflect.TypeOf("") {
+					return nil, errors.New("Option ,inline needs a map with string keys in struct " + st.String())
+				}
+				inlineMap = info.Num
+			case reflect.Struct:
+				sinfo, err := getStructInfo(field.Type)
+				if err != nil {
+					return nil, err
+				}
+				for _, finfo := range sinfo.FieldsList {
+					if _, found := fieldsMap[finfo.Key]; found {
+						msg := "Duplicated key '" + finfo.Key + "' in struct " + st.String()
+						return nil, errors.New(msg)
+					}
+					if finfo.Inline == nil {
+						finfo.Inline = []int{i, finfo.Num}
+					} else {
+						finfo.Inline = append([]int{i}, finfo.Inline...)
+					}
+					fieldsMap[finfo.Key] = finfo
+					fieldsList = append(fieldsList, finfo)
+				}
+			default:
+				//return nil, errors.New("Option ,inline needs a struct value or map field")
+				return nil, errors.New("Option ,inline needs a struct value field")
+			}
+			continue
+		}
+
+		if tag != "" {
+			info.Key = tag
+		} else {
+			info.Key = strings.ToLower(field.Name)
+		}
+
+		if _, found = fieldsMap[info.Key]; found {
+			msg := "Duplicated key '" + info.Key + "' in struct " + st.String()
+			return nil, errors.New(msg)
+		}
+
+		fieldsList = append(fieldsList, info)
+		fieldsMap[info.Key] = info
+	}
+
+	sinfo = &structInfo{fieldsMap, fieldsList, inlineMap}
+
+	fieldMapMutex.Lock()
+	structMap[st] = sinfo
+	fieldMapMutex.Unlock()
+	return sinfo, nil
+}
+
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.String:
+		return len(v.String()) == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	case reflect.Slice:
+		return v.Len() == 0
+	case reflect.Map:
+		return v.Len() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Struct:
+		vt := v.Type()
+		for i := v.NumField() - 1; i >= 0; i-- {
+			if vt.Field(i).PkgPath != "" {
+				continue // Private field
+			}
+			if !isZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/vendor/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlh.go
@@ -1,0 +1,716 @@
+package yaml
+
+import (
+	"io"
+)
+
+// The version directive data.
+type yaml_version_directive_t struct {
+	major int8 // The major version number.
+	minor int8 // The minor version number.
+}
+
+// The tag directive data.
+type yaml_tag_directive_t struct {
+	handle []byte // The tag handle.
+	prefix []byte // The tag prefix.
+}
+
+type yaml_encoding_t int
+
+// The stream encoding.
+const (
+	// Let the parser choose the encoding.
+	yaml_ANY_ENCODING yaml_encoding_t = iota
+
+	yaml_UTF8_ENCODING    // The default UTF-8 encoding.
+	yaml_UTF16LE_ENCODING // The UTF-16-LE encoding with BOM.
+	yaml_UTF16BE_ENCODING // The UTF-16-BE encoding with BOM.
+)
+
+type yaml_break_t int
+
+// Line break types.
+const (
+	// Let the parser choose the break type.
+	yaml_ANY_BREAK yaml_break_t = iota
+
+	yaml_CR_BREAK   // Use CR for line breaks (Mac style).
+	yaml_LN_BREAK   // Use LN for line breaks (Unix style).
+	yaml_CRLN_BREAK // Use CR LN for line breaks (DOS style).
+)
+
+type yaml_error_type_t int
+
+// Many bad things could happen with the parser and emitter.
+const (
+	// No error is produced.
+	yaml_NO_ERROR yaml_error_type_t = iota
+
+	yaml_MEMORY_ERROR   // Cannot allocate or reallocate a block of memory.
+	yaml_READER_ERROR   // Cannot read or decode the input stream.
+	yaml_SCANNER_ERROR  // Cannot scan the input stream.
+	yaml_PARSER_ERROR   // Cannot parse the input stream.
+	yaml_COMPOSER_ERROR // Cannot compose a YAML document.
+	yaml_WRITER_ERROR   // Cannot write to the output stream.
+	yaml_EMITTER_ERROR  // Cannot emit a YAML stream.
+)
+
+// The pointer position.
+type yaml_mark_t struct {
+	index  int // The position index.
+	line   int // The position line.
+	column int // The position column.
+}
+
+// Node Styles
+
+type yaml_style_t int8
+
+type yaml_scalar_style_t yaml_style_t
+
+// Scalar styles.
+const (
+	// Let the emitter choose the style.
+	yaml_ANY_SCALAR_STYLE yaml_scalar_style_t = iota
+
+	yaml_PLAIN_SCALAR_STYLE         // The plain scalar style.
+	yaml_SINGLE_QUOTED_SCALAR_STYLE // The single-quoted scalar style.
+	yaml_DOUBLE_QUOTED_SCALAR_STYLE // The double-quoted scalar style.
+	yaml_LITERAL_SCALAR_STYLE       // The literal scalar style.
+	yaml_FOLDED_SCALAR_STYLE        // The folded scalar style.
+)
+
+type yaml_sequence_style_t yaml_style_t
+
+// Sequence styles.
+const (
+	// Let the emitter choose the style.
+	yaml_ANY_SEQUENCE_STYLE yaml_sequence_style_t = iota
+
+	yaml_BLOCK_SEQUENCE_STYLE // The block sequence style.
+	yaml_FLOW_SEQUENCE_STYLE  // The flow sequence style.
+)
+
+type yaml_mapping_style_t yaml_style_t
+
+// Mapping styles.
+const (
+	// Let the emitter choose the style.
+	yaml_ANY_MAPPING_STYLE yaml_mapping_style_t = iota
+
+	yaml_BLOCK_MAPPING_STYLE // The block mapping style.
+	yaml_FLOW_MAPPING_STYLE  // The flow mapping style.
+)
+
+// Tokens
+
+type yaml_token_type_t int
+
+// Token types.
+const (
+	// An empty token.
+	yaml_NO_TOKEN yaml_token_type_t = iota
+
+	yaml_STREAM_START_TOKEN // A STREAM-START token.
+	yaml_STREAM_END_TOKEN   // A STREAM-END token.
+
+	yaml_VERSION_DIRECTIVE_TOKEN // A VERSION-DIRECTIVE token.
+	yaml_TAG_DIRECTIVE_TOKEN     // A TAG-DIRECTIVE token.
+	yaml_DOCUMENT_START_TOKEN    // A DOCUMENT-START token.
+	yaml_DOCUMENT_END_TOKEN      // A DOCUMENT-END token.
+
+	yaml_BLOCK_SEQUENCE_START_TOKEN // A BLOCK-SEQUENCE-START token.
+	yaml_BLOCK_MAPPING_START_TOKEN  // A BLOCK-SEQUENCE-END token.
+	yaml_BLOCK_END_TOKEN            // A BLOCK-END token.
+
+	yaml_FLOW_SEQUENCE_START_TOKEN // A FLOW-SEQUENCE-START token.
+	yaml_FLOW_SEQUENCE_END_TOKEN   // A FLOW-SEQUENCE-END token.
+	yaml_FLOW_MAPPING_START_TOKEN  // A FLOW-MAPPING-START token.
+	yaml_FLOW_MAPPING_END_TOKEN    // A FLOW-MAPPING-END token.
+
+	yaml_BLOCK_ENTRY_TOKEN // A BLOCK-ENTRY token.
+	yaml_FLOW_ENTRY_TOKEN  // A FLOW-ENTRY token.
+	yaml_KEY_TOKEN         // A KEY token.
+	yaml_VALUE_TOKEN       // A VALUE token.
+
+	yaml_ALIAS_TOKEN  // An ALIAS token.
+	yaml_ANCHOR_TOKEN // An ANCHOR token.
+	yaml_TAG_TOKEN    // A TAG token.
+	yaml_SCALAR_TOKEN // A SCALAR token.
+)
+
+func (tt yaml_token_type_t) String() string {
+	switch tt {
+	case yaml_NO_TOKEN:
+		return "yaml_NO_TOKEN"
+	case yaml_STREAM_START_TOKEN:
+		return "yaml_STREAM_START_TOKEN"
+	case yaml_STREAM_END_TOKEN:
+		return "yaml_STREAM_END_TOKEN"
+	case yaml_VERSION_DIRECTIVE_TOKEN:
+		return "yaml_VERSION_DIRECTIVE_TOKEN"
+	case yaml_TAG_DIRECTIVE_TOKEN:
+		return "yaml_TAG_DIRECTIVE_TOKEN"
+	case yaml_DOCUMENT_START_TOKEN:
+		return "yaml_DOCUMENT_START_TOKEN"
+	case yaml_DOCUMENT_END_TOKEN:
+		return "yaml_DOCUMENT_END_TOKEN"
+	case yaml_BLOCK_SEQUENCE_START_TOKEN:
+		return "yaml_BLOCK_SEQUENCE_START_TOKEN"
+	case yaml_BLOCK_MAPPING_START_TOKEN:
+		return "yaml_BLOCK_MAPPING_START_TOKEN"
+	case yaml_BLOCK_END_TOKEN:
+		return "yaml_BLOCK_END_TOKEN"
+	case yaml_FLOW_SEQUENCE_START_TOKEN:
+		return "yaml_FLOW_SEQUENCE_START_TOKEN"
+	case yaml_FLOW_SEQUENCE_END_TOKEN:
+		return "yaml_FLOW_SEQUENCE_END_TOKEN"
+	case yaml_FLOW_MAPPING_START_TOKEN:
+		return "yaml_FLOW_MAPPING_START_TOKEN"
+	case yaml_FLOW_MAPPING_END_TOKEN:
+		return "yaml_FLOW_MAPPING_END_TOKEN"
+	case yaml_BLOCK_ENTRY_TOKEN:
+		return "yaml_BLOCK_ENTRY_TOKEN"
+	case yaml_FLOW_ENTRY_TOKEN:
+		return "yaml_FLOW_ENTRY_TOKEN"
+	case yaml_KEY_TOKEN:
+		return "yaml_KEY_TOKEN"
+	case yaml_VALUE_TOKEN:
+		return "yaml_VALUE_TOKEN"
+	case yaml_ALIAS_TOKEN:
+		return "yaml_ALIAS_TOKEN"
+	case yaml_ANCHOR_TOKEN:
+		return "yaml_ANCHOR_TOKEN"
+	case yaml_TAG_TOKEN:
+		return "yaml_TAG_TOKEN"
+	case yaml_SCALAR_TOKEN:
+		return "yaml_SCALAR_TOKEN"
+	}
+	return "<unknown token>"
+}
+
+// The token structure.
+type yaml_token_t struct {
+	// The token type.
+	typ yaml_token_type_t
+
+	// The start/end of the token.
+	start_mark, end_mark yaml_mark_t
+
+	// The stream encoding (for yaml_STREAM_START_TOKEN).
+	encoding yaml_encoding_t
+
+	// The alias/anchor/scalar value or tag/tag directive handle
+	// (for yaml_ALIAS_TOKEN, yaml_ANCHOR_TOKEN, yaml_SCALAR_TOKEN, yaml_TAG_TOKEN, yaml_TAG_DIRECTIVE_TOKEN).
+	value []byte
+
+	// The tag suffix (for yaml_TAG_TOKEN).
+	suffix []byte
+
+	// The tag directive prefix (for yaml_TAG_DIRECTIVE_TOKEN).
+	prefix []byte
+
+	// The scalar style (for yaml_SCALAR_TOKEN).
+	style yaml_scalar_style_t
+
+	// The version directive major/minor (for yaml_VERSION_DIRECTIVE_TOKEN).
+	major, minor int8
+}
+
+// Events
+
+type yaml_event_type_t int8
+
+// Event types.
+const (
+	// An empty event.
+	yaml_NO_EVENT yaml_event_type_t = iota
+
+	yaml_STREAM_START_EVENT   // A STREAM-START event.
+	yaml_STREAM_END_EVENT     // A STREAM-END event.
+	yaml_DOCUMENT_START_EVENT // A DOCUMENT-START event.
+	yaml_DOCUMENT_END_EVENT   // A DOCUMENT-END event.
+	yaml_ALIAS_EVENT          // An ALIAS event.
+	yaml_SCALAR_EVENT         // A SCALAR event.
+	yaml_SEQUENCE_START_EVENT // A SEQUENCE-START event.
+	yaml_SEQUENCE_END_EVENT   // A SEQUENCE-END event.
+	yaml_MAPPING_START_EVENT  // A MAPPING-START event.
+	yaml_MAPPING_END_EVENT    // A MAPPING-END event.
+)
+
+// The event structure.
+type yaml_event_t struct {
+
+	// The event type.
+	typ yaml_event_type_t
+
+	// The start and end of the event.
+	start_mark, end_mark yaml_mark_t
+
+	// The document encoding (for yaml_STREAM_START_EVENT).
+	encoding yaml_encoding_t
+
+	// The version directive (for yaml_DOCUMENT_START_EVENT).
+	version_directive *yaml_version_directive_t
+
+	// The list of tag directives (for yaml_DOCUMENT_START_EVENT).
+	tag_directives []yaml_tag_directive_t
+
+	// The anchor (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT, yaml_ALIAS_EVENT).
+	anchor []byte
+
+	// The tag (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT).
+	tag []byte
+
+	// The scalar value (for yaml_SCALAR_EVENT).
+	value []byte
+
+	// Is the document start/end indicator implicit, or the tag optional?
+	// (for yaml_DOCUMENT_START_EVENT, yaml_DOCUMENT_END_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT, yaml_SCALAR_EVENT).
+	implicit bool
+
+	// Is the tag optional for any non-plain style? (for yaml_SCALAR_EVENT).
+	quoted_implicit bool
+
+	// The style (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT).
+	style yaml_style_t
+}
+
+func (e *yaml_event_t) scalar_style() yaml_scalar_style_t     { return yaml_scalar_style_t(e.style) }
+func (e *yaml_event_t) sequence_style() yaml_sequence_style_t { return yaml_sequence_style_t(e.style) }
+func (e *yaml_event_t) mapping_style() yaml_mapping_style_t   { return yaml_mapping_style_t(e.style) }
+
+// Nodes
+
+const (
+	yaml_NULL_TAG      = "tag:yaml.org,2002:null"      // The tag !!null with the only possible value: null.
+	yaml_BOOL_TAG      = "tag:yaml.org,2002:bool"      // The tag !!bool with the values: true and false.
+	yaml_STR_TAG       = "tag:yaml.org,2002:str"       // The tag !!str for string values.
+	yaml_INT_TAG       = "tag:yaml.org,2002:int"       // The tag !!int for integer values.
+	yaml_FLOAT_TAG     = "tag:yaml.org,2002:float"     // The tag !!float for float values.
+	yaml_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp" // The tag !!timestamp for date and time values.
+
+	yaml_SEQ_TAG = "tag:yaml.org,2002:seq" // The tag !!seq is used to denote sequences.
+	yaml_MAP_TAG = "tag:yaml.org,2002:map" // The tag !!map is used to denote mapping.
+
+	// Not in original libyaml.
+	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
+	yaml_MERGE_TAG  = "tag:yaml.org,2002:merge"
+
+	yaml_DEFAULT_SCALAR_TAG   = yaml_STR_TAG // The default scalar tag is !!str.
+	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG // The default sequence tag is !!seq.
+	yaml_DEFAULT_MAPPING_TAG  = yaml_MAP_TAG // The default mapping tag is !!map.
+)
+
+type yaml_node_type_t int
+
+// Node types.
+const (
+	// An empty node.
+	yaml_NO_NODE yaml_node_type_t = iota
+
+	yaml_SCALAR_NODE   // A scalar node.
+	yaml_SEQUENCE_NODE // A sequence node.
+	yaml_MAPPING_NODE  // A mapping node.
+)
+
+// An element of a sequence node.
+type yaml_node_item_t int
+
+// An element of a mapping node.
+type yaml_node_pair_t struct {
+	key   int // The key of the element.
+	value int // The value of the element.
+}
+
+// The node structure.
+type yaml_node_t struct {
+	typ yaml_node_type_t // The node type.
+	tag []byte           // The node tag.
+
+	// The node data.
+
+	// The scalar parameters (for yaml_SCALAR_NODE).
+	scalar struct {
+		value  []byte              // The scalar value.
+		length int                 // The length of the scalar value.
+		style  yaml_scalar_style_t // The scalar style.
+	}
+
+	// The sequence parameters (for YAML_SEQUENCE_NODE).
+	sequence struct {
+		items_data []yaml_node_item_t    // The stack of sequence items.
+		style      yaml_sequence_style_t // The sequence style.
+	}
+
+	// The mapping parameters (for yaml_MAPPING_NODE).
+	mapping struct {
+		pairs_data  []yaml_node_pair_t   // The stack of mapping pairs (key, value).
+		pairs_start *yaml_node_pair_t    // The beginning of the stack.
+		pairs_end   *yaml_node_pair_t    // The end of the stack.
+		pairs_top   *yaml_node_pair_t    // The top of the stack.
+		style       yaml_mapping_style_t // The mapping style.
+	}
+
+	start_mark yaml_mark_t // The beginning of the node.
+	end_mark   yaml_mark_t // The end of the node.
+
+}
+
+// The document structure.
+type yaml_document_t struct {
+
+	// The document nodes.
+	nodes []yaml_node_t
+
+	// The version directive.
+	version_directive *yaml_version_directive_t
+
+	// The list of tag directives.
+	tag_directives_data  []yaml_tag_directive_t
+	tag_directives_start int // The beginning of the tag directives list.
+	tag_directives_end   int // The end of the tag directives list.
+
+	start_implicit int // Is the document start indicator implicit?
+	end_implicit   int // Is the document end indicator implicit?
+
+	// The start/end of the document.
+	start_mark, end_mark yaml_mark_t
+}
+
+// The prototype of a read handler.
+//
+// The read handler is called when the parser needs to read more bytes from the
+// source. The handler should write not more than size bytes to the buffer.
+// The number of written bytes should be set to the size_read variable.
+//
+// [in,out]   data        A pointer to an application data specified by
+//                        yaml_parser_set_input().
+// [out]      buffer      The buffer to write the data from the source.
+// [in]       size        The size of the buffer.
+// [out]      size_read   The actual number of bytes read from the source.
+//
+// On success, the handler should return 1.  If the handler failed,
+// the returned value should be 0. On EOF, the handler should set the
+// size_read to 0 and return 1.
+type yaml_read_handler_t func(parser *yaml_parser_t, buffer []byte) (n int, err error)
+
+// This structure holds information about a potential simple key.
+type yaml_simple_key_t struct {
+	possible     bool        // Is a simple key possible?
+	required     bool        // Is a simple key required?
+	token_number int         // The number of the token.
+	mark         yaml_mark_t // The position mark.
+}
+
+// The states of the parser.
+type yaml_parser_state_t int
+
+const (
+	yaml_PARSE_STREAM_START_STATE yaml_parser_state_t = iota
+
+	yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE           // Expect the beginning of an implicit document.
+	yaml_PARSE_DOCUMENT_START_STATE                    // Expect DOCUMENT-START.
+	yaml_PARSE_DOCUMENT_CONTENT_STATE                  // Expect the content of a document.
+	yaml_PARSE_DOCUMENT_END_STATE                      // Expect DOCUMENT-END.
+	yaml_PARSE_BLOCK_NODE_STATE                        // Expect a block node.
+	yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE // Expect a block node or indentless sequence.
+	yaml_PARSE_FLOW_NODE_STATE                         // Expect a flow node.
+	yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE        // Expect the first entry of a block sequence.
+	yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE              // Expect an entry of a block sequence.
+	yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE         // Expect an entry of an indentless sequence.
+	yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE           // Expect the first key of a block mapping.
+	yaml_PARSE_BLOCK_MAPPING_KEY_STATE                 // Expect a block mapping key.
+	yaml_PARSE_BLOCK_MAPPING_VALUE_STATE               // Expect a block mapping value.
+	yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE         // Expect the first entry of a flow sequence.
+	yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE               // Expect an entry of a flow sequence.
+	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE   // Expect a key of an ordered mapping.
+	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE // Expect a value of an ordered mapping.
+	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE   // Expect the and of an ordered mapping entry.
+	yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE            // Expect the first key of a flow mapping.
+	yaml_PARSE_FLOW_MAPPING_KEY_STATE                  // Expect a key of a flow mapping.
+	yaml_PARSE_FLOW_MAPPING_VALUE_STATE                // Expect a value of a flow mapping.
+	yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE          // Expect an empty value of a flow mapping.
+	yaml_PARSE_END_STATE                               // Expect nothing.
+)
+
+func (ps yaml_parser_state_t) String() string {
+	switch ps {
+	case yaml_PARSE_STREAM_START_STATE:
+		return "yaml_PARSE_STREAM_START_STATE"
+	case yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE:
+		return "yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE"
+	case yaml_PARSE_DOCUMENT_START_STATE:
+		return "yaml_PARSE_DOCUMENT_START_STATE"
+	case yaml_PARSE_DOCUMENT_CONTENT_STATE:
+		return "yaml_PARSE_DOCUMENT_CONTENT_STATE"
+	case yaml_PARSE_DOCUMENT_END_STATE:
+		return "yaml_PARSE_DOCUMENT_END_STATE"
+	case yaml_PARSE_BLOCK_NODE_STATE:
+		return "yaml_PARSE_BLOCK_NODE_STATE"
+	case yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
+		return "yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE"
+	case yaml_PARSE_FLOW_NODE_STATE:
+		return "yaml_PARSE_FLOW_NODE_STATE"
+	case yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
+		return "yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE"
+	case yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE:
+		return "yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE"
+	case yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE:
+		return "yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE"
+	case yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE:
+		return "yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE"
+	case yaml_PARSE_BLOCK_MAPPING_KEY_STATE:
+		return "yaml_PARSE_BLOCK_MAPPING_KEY_STATE"
+	case yaml_PARSE_BLOCK_MAPPING_VALUE_STATE:
+		return "yaml_PARSE_BLOCK_MAPPING_VALUE_STATE"
+	case yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE:
+		return "yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE"
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE:
+		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE"
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE:
+		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE"
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE:
+		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE"
+	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE:
+		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE"
+	case yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE:
+		return "yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE"
+	case yaml_PARSE_FLOW_MAPPING_KEY_STATE:
+		return "yaml_PARSE_FLOW_MAPPING_KEY_STATE"
+	case yaml_PARSE_FLOW_MAPPING_VALUE_STATE:
+		return "yaml_PARSE_FLOW_MAPPING_VALUE_STATE"
+	case yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE:
+		return "yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE"
+	case yaml_PARSE_END_STATE:
+		return "yaml_PARSE_END_STATE"
+	}
+	return "<unknown parser state>"
+}
+
+// This structure holds aliases data.
+type yaml_alias_data_t struct {
+	anchor []byte      // The anchor.
+	index  int         // The node id.
+	mark   yaml_mark_t // The anchor mark.
+}
+
+// The parser structure.
+//
+// All members are internal. Manage the structure using the
+// yaml_parser_ family of functions.
+type yaml_parser_t struct {
+
+	// Error handling
+
+	error yaml_error_type_t // Error type.
+
+	problem string // Error description.
+
+	// The byte about which the problem occured.
+	problem_offset int
+	problem_value  int
+	problem_mark   yaml_mark_t
+
+	// The error context.
+	context      string
+	context_mark yaml_mark_t
+
+	// Reader stuff
+
+	read_handler yaml_read_handler_t // Read handler.
+
+	input_file io.Reader // File input data.
+	input      []byte    // String input data.
+	input_pos  int
+
+	eof bool // EOF flag
+
+	buffer     []byte // The working buffer.
+	buffer_pos int    // The current position of the buffer.
+
+	unread int // The number of unread characters in the buffer.
+
+	raw_buffer     []byte // The raw buffer.
+	raw_buffer_pos int    // The current position of the buffer.
+
+	encoding yaml_encoding_t // The input encoding.
+
+	offset int         // The offset of the current position (in bytes).
+	mark   yaml_mark_t // The mark of the current position.
+
+	// Scanner stuff
+
+	stream_start_produced bool // Have we started to scan the input stream?
+	stream_end_produced   bool // Have we reached the end of the input stream?
+
+	flow_level int // The number of unclosed '[' and '{' indicators.
+
+	tokens          []yaml_token_t // The tokens queue.
+	tokens_head     int            // The head of the tokens queue.
+	tokens_parsed   int            // The number of tokens fetched from the queue.
+	token_available bool           // Does the tokens queue contain a token ready for dequeueing.
+
+	indent  int   // The current indentation level.
+	indents []int // The indentation levels stack.
+
+	simple_key_allowed bool                // May a simple key occur at the current position?
+	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+
+	// Parser stuff
+
+	state          yaml_parser_state_t    // The current parser state.
+	states         []yaml_parser_state_t  // The parser states stack.
+	marks          []yaml_mark_t          // The stack of marks.
+	tag_directives []yaml_tag_directive_t // The list of TAG directives.
+
+	// Dumper stuff
+
+	aliases []yaml_alias_data_t // The alias data.
+
+	document *yaml_document_t // The currently parsed document.
+}
+
+// Emitter Definitions
+
+// The prototype of a write handler.
+//
+// The write handler is called when the emitter needs to flush the accumulated
+// characters to the output.  The handler should write @a size bytes of the
+// @a buffer to the output.
+//
+// @param[in,out]   data        A pointer to an application data specified by
+//                              yaml_emitter_set_output().
+// @param[in]       buffer      The buffer with bytes to be written.
+// @param[in]       size        The size of the buffer.
+//
+// @returns On success, the handler should return @c 1.  If the handler failed,
+// the returned value should be @c 0.
+//
+type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
+
+type yaml_emitter_state_t int
+
+// The emitter states.
+const (
+	// Expect STREAM-START.
+	yaml_EMIT_STREAM_START_STATE yaml_emitter_state_t = iota
+
+	yaml_EMIT_FIRST_DOCUMENT_START_STATE       // Expect the first DOCUMENT-START or STREAM-END.
+	yaml_EMIT_DOCUMENT_START_STATE             // Expect DOCUMENT-START or STREAM-END.
+	yaml_EMIT_DOCUMENT_CONTENT_STATE           // Expect the content of a document.
+	yaml_EMIT_DOCUMENT_END_STATE               // Expect DOCUMENT-END.
+	yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE   // Expect the first item of a flow sequence.
+	yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE         // Expect an item of a flow sequence.
+	yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE     // Expect the first key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_KEY_STATE           // Expect a key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE  // Expect a value for a simple key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_VALUE_STATE         // Expect a value of a flow mapping.
+	yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE  // Expect the first item of a block sequence.
+	yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE        // Expect an item of a block sequence.
+	yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE    // Expect the first key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_KEY_STATE          // Expect the key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE // Expect a value for a simple key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_VALUE_STATE        // Expect a value of a block mapping.
+	yaml_EMIT_END_STATE                        // Expect nothing.
+)
+
+// The emitter structure.
+//
+// All members are internal.  Manage the structure using the @c yaml_emitter_
+// family of functions.
+type yaml_emitter_t struct {
+
+	// Error handling
+
+	error   yaml_error_type_t // Error type.
+	problem string            // Error description.
+
+	// Writer stuff
+
+	write_handler yaml_write_handler_t // Write handler.
+
+	output_buffer *[]byte   // String output data.
+	output_file   io.Writer // File output data.
+
+	buffer     []byte // The working buffer.
+	buffer_pos int    // The current position of the buffer.
+
+	raw_buffer     []byte // The raw buffer.
+	raw_buffer_pos int    // The current position of the buffer.
+
+	encoding yaml_encoding_t // The stream encoding.
+
+	// Emitter stuff
+
+	canonical   bool         // If the output is in the canonical style?
+	best_indent int          // The number of indentation spaces.
+	best_width  int          // The preferred width of the output lines.
+	unicode     bool         // Allow unescaped non-ASCII characters?
+	line_break  yaml_break_t // The preferred line break.
+
+	state  yaml_emitter_state_t   // The current emitter state.
+	states []yaml_emitter_state_t // The stack of states.
+
+	events      []yaml_event_t // The event queue.
+	events_head int            // The head of the event queue.
+
+	indents []int // The stack of indentation levels.
+
+	tag_directives []yaml_tag_directive_t // The list of tag directives.
+
+	indent int // The current indentation level.
+
+	flow_level int // The current flow level.
+
+	root_context       bool // Is it the document root context?
+	sequence_context   bool // Is it a sequence context?
+	mapping_context    bool // Is it a mapping context?
+	simple_key_context bool // Is it a simple mapping key context?
+
+	line       int  // The current line.
+	column     int  // The current column.
+	whitespace bool // If the last character was a whitespace?
+	indention  bool // If the last character was an indentation character (' ', '-', '?', ':')?
+	open_ended bool // If an explicit document end is required?
+
+	// Anchor analysis.
+	anchor_data struct {
+		anchor []byte // The anchor value.
+		alias  bool   // Is it an alias?
+	}
+
+	// Tag analysis.
+	tag_data struct {
+		handle []byte // The tag handle.
+		suffix []byte // The tag suffix.
+	}
+
+	// Scalar analysis.
+	scalar_data struct {
+		value                 []byte              // The scalar value.
+		multiline             bool                // Does the scalar contain line breaks?
+		flow_plain_allowed    bool                // Can the scalar be expessed in the flow plain style?
+		block_plain_allowed   bool                // Can the scalar be expressed in the block plain style?
+		single_quoted_allowed bool                // Can the scalar be expressed in the single quoted style?
+		block_allowed         bool                // Can the scalar be expressed in the literal or folded styles?
+		style                 yaml_scalar_style_t // The output style.
+	}
+
+	// Dumper stuff
+
+	opened bool // If the stream was already opened?
+	closed bool // If the stream was already closed?
+
+	// The information associated with the document nodes.
+	anchors *struct {
+		references int  // The number of references.
+		anchor     int  // The anchor id.
+		serialized bool // If the node has been emitted?
+	}
+
+	last_anchor_id int // The last assigned anchor id.
+
+	document *yaml_document_t // The currently emitted document.
+}

--- a/vendor/gopkg.in/yaml.v2/yamlprivateh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlprivateh.go
@@ -1,0 +1,173 @@
+package yaml
+
+const (
+	// The size of the input raw buffer.
+	input_raw_buffer_size = 512
+
+	// The size of the input buffer.
+	// It should be possible to decode the whole raw buffer.
+	input_buffer_size = input_raw_buffer_size * 3
+
+	// The size of the output buffer.
+	output_buffer_size = 128
+
+	// The size of the output raw buffer.
+	// It should be possible to encode the whole output buffer.
+	output_raw_buffer_size = (output_buffer_size*2 + 2)
+
+	// The size of other stacks and queues.
+	initial_stack_size  = 16
+	initial_queue_size  = 16
+	initial_string_size = 16
+)
+
+// Check if the character at the specified position is an alphabetical
+// character, a digit, '_', or '-'.
+func is_alpha(b []byte, i int) bool {
+	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'Z' || b[i] >= 'a' && b[i] <= 'z' || b[i] == '_' || b[i] == '-'
+}
+
+// Check if the character at the specified position is a digit.
+func is_digit(b []byte, i int) bool {
+	return b[i] >= '0' && b[i] <= '9'
+}
+
+// Get the value of a digit.
+func as_digit(b []byte, i int) int {
+	return int(b[i]) - '0'
+}
+
+// Check if the character at the specified position is a hex-digit.
+func is_hex(b []byte, i int) bool {
+	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'F' || b[i] >= 'a' && b[i] <= 'f'
+}
+
+// Get the value of a hex-digit.
+func as_hex(b []byte, i int) int {
+	bi := b[i]
+	if bi >= 'A' && bi <= 'F' {
+		return int(bi) - 'A' + 10
+	}
+	if bi >= 'a' && bi <= 'f' {
+		return int(bi) - 'a' + 10
+	}
+	return int(bi) - '0'
+}
+
+// Check if the character is ASCII.
+func is_ascii(b []byte, i int) bool {
+	return b[i] <= 0x7F
+}
+
+// Check if the character at the start of the buffer can be printed unescaped.
+func is_printable(b []byte, i int) bool {
+	return ((b[i] == 0x0A) || // . == #x0A
+		(b[i] >= 0x20 && b[i] <= 0x7E) || // #x20 <= . <= #x7E
+		(b[i] == 0xC2 && b[i+1] >= 0xA0) || // #0xA0 <= . <= #xD7FF
+		(b[i] > 0xC2 && b[i] < 0xED) ||
+		(b[i] == 0xED && b[i+1] < 0xA0) ||
+		(b[i] == 0xEE) ||
+		(b[i] == 0xEF && // #xE000 <= . <= #xFFFD
+			!(b[i+1] == 0xBB && b[i+2] == 0xBF) && // && . != #xFEFF
+			!(b[i+1] == 0xBF && (b[i+2] == 0xBE || b[i+2] == 0xBF))))
+}
+
+// Check if the character at the specified position is NUL.
+func is_z(b []byte, i int) bool {
+	return b[i] == 0x00
+}
+
+// Check if the beginning of the buffer is a BOM.
+func is_bom(b []byte, i int) bool {
+	return b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF
+}
+
+// Check if the character at the specified position is space.
+func is_space(b []byte, i int) bool {
+	return b[i] == ' '
+}
+
+// Check if the character at the specified position is tab.
+func is_tab(b []byte, i int) bool {
+	return b[i] == '\t'
+}
+
+// Check if the character at the specified position is blank (space or tab).
+func is_blank(b []byte, i int) bool {
+	//return is_space(b, i) || is_tab(b, i)
+	return b[i] == ' ' || b[i] == '\t'
+}
+
+// Check if the character at the specified position is a line break.
+func is_break(b []byte, i int) bool {
+	return (b[i] == '\r' || // CR (#xD)
+		b[i] == '\n' || // LF (#xA)
+		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9) // PS (#x2029)
+}
+
+func is_crlf(b []byte, i int) bool {
+	return b[i] == '\r' && b[i+1] == '\n'
+}
+
+// Check if the character is a line break or NUL.
+func is_breakz(b []byte, i int) bool {
+	//return is_break(b, i) || is_z(b, i)
+	return (        // is_break:
+	b[i] == '\r' || // CR (#xD)
+		b[i] == '\n' || // LF (#xA)
+		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9 || // PS (#x2029)
+		// is_z:
+		b[i] == 0)
+}
+
+// Check if the character is a line break, space, or NUL.
+func is_spacez(b []byte, i int) bool {
+	//return is_space(b, i) || is_breakz(b, i)
+	return ( // is_space:
+	b[i] == ' ' ||
+		// is_breakz:
+		b[i] == '\r' || // CR (#xD)
+		b[i] == '\n' || // LF (#xA)
+		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9 || // PS (#x2029)
+		b[i] == 0)
+}
+
+// Check if the character is a line break, space, tab, or NUL.
+func is_blankz(b []byte, i int) bool {
+	//return is_blank(b, i) || is_breakz(b, i)
+	return ( // is_blank:
+	b[i] == ' ' || b[i] == '\t' ||
+		// is_breakz:
+		b[i] == '\r' || // CR (#xD)
+		b[i] == '\n' || // LF (#xA)
+		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
+		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9 || // PS (#x2029)
+		b[i] == 0)
+}
+
+// Determine the width of the character.
+func width(b byte) int {
+	// Don't replace these by a switch without first
+	// confirming that it is being inlined.
+	if b&0x80 == 0x00 {
+		return 1
+	}
+	if b&0xE0 == 0xC0 {
+		return 2
+	}
+	if b&0xF0 == 0xE0 {
+		return 3
+	}
+	if b&0xF8 == 0xF0 {
+		return 4
+	}
+	return 0
+
+}


### PR DESCRIPTION
This is a suggestion to make glide "go installable" by copying in the dependencies directly to vendor directory. I like the submodule vendoring used by glide, but in order to be "go installable" glide will need to copy in the files, the burden of bootstrapping I guess.  

For developers using glide the install will look something like:

* install go, with two extra things requires that most should already be doing
  * export GO15VENDOREXPERIMENT=1
  * export PATH=$PATH:$GOPATH/bin
* go install github.com/Masterminds/glide

For glide developers, they need to have the vendor experiment enabled. When deps need to be updated just run `make bootsrap` to recopy in the latest deps into the vendor directory.

The pros are, consistency with other tools like golint and the deps are actually locked, the current makefile does not guarantee this. 

I didn't see any references to this issue in open or closed issues and prs so do not know if it's been suggested before. I'm curious what you guys think about this. 

Still todo:
* [ ] Remove some other commands from the makefile
* [ ] Update the readme