### PR TITLE
check for exact match instead of string prefix for #182

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -98,7 +98,7 @@ var remotePackageCache = make(map[string]bool)
 
 func checkRemotePackageCache(pkg string) (string, bool) {
 	for k := range remotePackageCache {
-		if strings.HasPrefix(pkg, k) {
+		if k == pkg {
 			return k, true
 		}
 	}


### PR DESCRIPTION
this should avoid truncating packages in cases when one package is a substring of another one (without being a "subpackage") - for example, "foobarxyz.com/user/lib" and "foobarxyz.com/user/lib2"