### PR TITLE
Generate lockfile when not vendoring recursively

### DIFF
--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -105,11 +105,6 @@ func WriteYaml(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrup
 //	- lockfile: A *cfg.Lockfile to render.
 // 	- out (io.Writer): An output stream to write to. Default is os.Stdout.
 func WriteLock(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
-	skip := p.Get("skip", false).(bool)
-	if skip {
-		return false, nil
-	}
-
 	lockfile := p.Get("lockfile", nil).(*cfg.Lockfile)
 
 	Info("Writing glide.lock file")

--- a/glide.go
+++ b/glide.go
@@ -560,6 +560,7 @@ func routes(reg *cookoo.Registry, cxt cookoo.Context) {
 		Using("cache").From("cxt:useCache").
 		Using("cacheGopath").From("cxt:cacheGopath").
 		Using("useGopath").From("cxt:useGopath").
+		Using("skip").From("cxt:skipFlatten").
 		Does(cmd.VendoredCleanUp, "_").
 		Using("conf").From("cxt:flattened").
 		Using("update").From("cxt:updateVendoredDeps").


### PR DESCRIPTION
The pin command has been removed, so lockfiles are useful for pinning
packages even if we are not vendoring recursively. This helps using a
simple `glide get` command as an alternative to doing a `glide get`
followed by manual pinning in glide.yaml.
