### PR TITLE
Vendor only the subpackage(s) dependencies

### DIFF
--- a/glide.go
+++ b/glide.go
@@ -186,6 +186,10 @@ func commands() []cli.Command {
 					Name:  "use-gopath",
 					Usage: "Copy dependencies from the GOPATH if they exist there.",
 				},
+				cli.BoolFlag{
+					Name:  "specific-subpackages",
+					Usage: "When subpackages are specified, scan only for their dependencies instead of those of the full project.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				if len(c.Args()) < 1 {
@@ -194,11 +198,12 @@ func commands() []cli.Command {
 				}
 
 				inst := &repo.Installer{
-					Force:          c.Bool("force"),
-					UseCache:       c.Bool("cache"),
-					UseGopath:      c.Bool("use-gopath"),
-					UseCacheGopath: c.Bool("cache-gopath"),
-					UpdateVendored: c.Bool("update-vendored"),
+					Force:               c.Bool("force"),
+					UseCache:            c.Bool("cache"),
+					UseGopath:           c.Bool("use-gopath"),
+					UseCacheGopath:      c.Bool("cache-gopath"),
+					UpdateVendored:      c.Bool("update-vendored"),
+					SpecificSubpackages: c.Bool("specific-subpackages"),
 				}
 				packages := []string(c.Args())
 				insecure := c.Bool("insecure")
@@ -444,16 +449,21 @@ Example:
 					Name:  "use-gopath",
 					Usage: "Copy dependencies from the GOPATH if they exist there.",
 				},
+				cli.BoolFlag{
+					Name:  "specific-subpackages",
+					Usage: "When subpackages are specified, scan only for their dependencies instead of those of the full project.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				installer := &repo.Installer{
-					DeleteUnused:   c.Bool("deleteOptIn"),
-					UpdateVendored: c.Bool("update-vendored"),
-					Force:          c.Bool("force"),
-					UseCache:       c.Bool("cache"),
-					UseCacheGopath: c.Bool("cache-gopath"),
-					UseGopath:      c.Bool("use-gopath"),
-					Home:           gpath.Home(),
+					DeleteUnused:        c.Bool("deleteOptIn"),
+					UpdateVendored:      c.Bool("update-vendored"),
+					Force:               c.Bool("force"),
+					UseCache:            c.Bool("cache"),
+					UseCacheGopath:      c.Bool("cache-gopath"),
+					UseGopath:           c.Bool("use-gopath"),
+					Home:                gpath.Home(),
+					SpecificSubpackages: c.Bool("specific-subpackages"),
 				}
 
 				action.Update(installer, c.Bool("no-recursive"))

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -47,6 +47,10 @@ type Installer struct {
 	// imported pacakgage references this pacakage it does not need to be
 	// downloaded and searched out again.
 	RootPackage string
+
+	// When subpackages are specified, scan only for their dependencies instead
+	// of those of the full project.
+	SpecificSubpackages bool
 }
 
 // VendorPath returns the path to the location to put vendor packages
@@ -170,6 +174,7 @@ func (i *Installer) Update(conf *cfg.Config) error {
 	if err != nil {
 		msg.Die("Failed to create a resolver: %s", err)
 	}
+	res.SpecificSubpackages = i.SpecificSubpackages
 	res.Config = conf
 	res.Handler = m
 	res.VersionHandler = v


### PR DESCRIPTION
Implements #166 

WIP, not for merging as is.

Using @davecgh 's [test](https://github.com/Masterminds/glide/issues/166#issuecomment-168332303), with the current code in this PR I get:
```
$ tree -d vendor
vendor
└── github.com
    └── syndtr
        └── goleveldb
            ├── leveldb
            │   ├── cache
            │   ├── comparer
            │   ├── errors
            │   ├── filter
            │   ├── iterator
            │   ├── journal
            │   ├── memdb
            │   ├── opt
            │   ├── storage
            │   ├── table
            │   ├── testutil
            │   └── util
            └── manualtest
                ├── dbstress
                └── filelock

19 directories
```