### PR TITLE
Resolve the imports being used

### DIFF
--- a/action/list.go
+++ b/action/list.go
@@ -32,13 +32,14 @@ func List(basedir string, deep bool) {
 		msg.Die("Error listing dependencies: %s", err)
 	}
 
+	msg.Info("Sorting...")
 	sort.Strings(sortable)
 
 	msg.Puts("INSTALLED packages:")
 	for _, k := range sortable {
 		v, err := filepath.Rel(basedir, k)
 		if err != nil {
-			msg.Warn("Failed to Rel path: %s", err)
+			//msg.Warn("Failed to Rel path: %s", err)
 			v = k
 		}
 		msg.Puts("\t%s", v)

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -356,6 +356,7 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 			if ok, err := r.Handler.NotFound(dep); ok {
 				r.alreadyQ[dep] = true
 				queue.PushBack(r.vpath(dep))
+				r.VersionHandler.SetVersion(dep)
 			} else if err != nil {
 				msg.Warn("Error looking for %s: %s", dep, err)
 			} else {

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -354,12 +354,14 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 				if _, ok := r.alreadyQ[imp]; !ok {
 					r.alreadyQ[imp] = true
 					queue.PushBack(r.vpath(imp))
+					r.VersionHandler.SetVersion(imp)
 				}
 			case LocUnknown:
 				msg.Debug("Missing %s. Trying to resolve.", imp)
 				if ok, err := r.Handler.NotFound(imp); ok {
 					r.alreadyQ[imp] = true
 					queue.PushBack(r.vpath(imp))
+					r.VersionHandler.SetVersion(imp)
 				} else if err != nil {
 					msg.Warn("Error looking for %s: %s", imp, err)
 				} else {
@@ -367,12 +369,11 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 				}
 			case LocGopath:
 				msg.Info("Found on GOPATH, not vendor: %s", imp)
-				// FIXME: This is not right. We need to get the result of
-				// OnGopath and decide what to do.
-				r.Handler.OnGopath(imp)
 				if _, ok := r.alreadyQ[imp]; !ok {
+					r.Handler.OnGopath(imp)
 					r.alreadyQ[imp] = true
 					queue.PushBack(imp)
+					r.VersionHandler.SetVersion(imp)
 				}
 			}
 		}

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -288,6 +288,8 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 	for e := queue.Front(); e != nil; e = e.Next() {
 		dep := e.Value.(string)
 
+		r.alreadyQ[dep] = true
+
 		// Skip ignored packages
 		t := strings.TrimPrefix(dep, r.VendorDir+string(os.PathSeparator))
 		if r.Config.HasIgnore(t) {
@@ -312,7 +314,10 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 			switch pi.Loc {
 			case LocVendor:
 				msg.Info("Already vendored: %s", imp)
-				queue.PushBack(imp)
+				if _, ok := r.alreadyQ[imp]; !ok {
+					r.alreadyQ[imp] = true
+					queue.PushBack(imp)
+				}
 			case LocUnknown:
 				msg.Info("Not found: %s (2)", imp)
 				// FIXME: respond to NotFound
@@ -321,7 +326,10 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 				msg.Info("Found on GOPATH, not vendor: %s", imp)
 				// FIXME: respond to NotFound
 				r.Handler.OnGopath(imp)
-				queue.PushBack(imp)
+				if _, ok := r.alreadyQ[imp]; !ok {
+					r.alreadyQ[imp] = true
+					queue.PushBack(imp)
+				}
 			}
 		}
 

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -299,7 +299,10 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 		// Here, we want to import the package and see what imports it has.
 		pkg, err := r.BuildContext.ImportDir(dep, 0)
 		if err != nil {
-			msg.Error("Failed to import %s: %s", dep, err)
+			msg.Error("Not Found %s (1)", dep)
+
+			// FIXME: respond to NotFound
+			r.Handler.NotFound(t)
 			continue
 			//return nil, err
 		}
@@ -309,10 +312,16 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 			switch pi.Loc {
 			case LocVendor:
 				msg.Info("Already vendored: %s", imp)
+				queue.PushBack(imp)
 			case LocUnknown:
-				msg.Info("Not found: %s", imp)
+				msg.Info("Not found: %s (2)", imp)
+				// FIXME: respond to NotFound
+				r.Handler.NotFound(imp)
 			case LocGopath:
 				msg.Info("Found on GOPATH, not vendor: %s", imp)
+				// FIXME: respond to NotFound
+				r.Handler.OnGopath(imp)
+				queue.PushBack(imp)
 			}
 		}
 

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -280,6 +280,16 @@ func (r *Resolver) ResolveLocal(deep bool) ([]string, error) {
 // an error is returned.
 func (r *Resolver) ResolveAll(deps []*cfg.Dependency) ([]string, error) {
 	queue := sliceToQueue(deps, r.VendorDir)
+
+	loc, err := r.ResolveLocal(false)
+	if err != nil {
+		return []string{}, err
+	}
+	for _, l := range loc {
+		msg.Debug("Adding local mport %s to queue", l)
+		queue.PushBack(l)
+	}
+
 	//return r.resolveList(queue)
 	return r.resolveImports(queue)
 }
@@ -361,6 +371,7 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 			case LocVendor:
 				msg.Info("In vendor: %s", imp)
 				if _, ok := r.alreadyQ[imp]; !ok {
+					msg.Debug("Marking %s to be scanned.", imp)
 					r.alreadyQ[imp] = true
 					queue.PushBack(r.vpath(imp))
 					r.VersionHandler.SetVersion(imp)

--- a/dependency/resolver_test.go
+++ b/dependency/resolver_test.go
@@ -72,6 +72,10 @@ func TestResolve(t *testing.T) {
 	if len(l) != 1 {
 		t.Errorf("Expected 1 dep, got %d: %s", len(l), l[0])
 	}
+
+	if strings.HasSuffix("github.com/codegangsta/cli", l[0]) {
+		t.Errorf("Unexpected package name: %s", l[0])
+	}
 }
 
 func TestResolveAll(t *testing.T) {

--- a/dependency/resolver_test.go
+++ b/dependency/resolver_test.go
@@ -73,7 +73,7 @@ func TestResolve(t *testing.T) {
 		t.Errorf("Expected 1 dep, got %d: %s", len(l), l[0])
 	}
 
-	if strings.HasSuffix("github.com/codegangsta/cli", l[0]) {
+	if !strings.HasSuffix("github.com/codegangsta/cli", l[0]) {
 		t.Errorf("Unexpected package name: %s", l[0])
 	}
 }

--- a/glide.go
+++ b/glide.go
@@ -171,6 +171,10 @@ func commands() []cli.Command {
 					Usage: "If there was a change in the repo or VCS switch to new one. Warning, changes will be lost.",
 				},
 				cli.BoolFlag{
+					Name:  "all-dependencies",
+					Usage: "This will resolve all dependencies for all packages, not just those directly used.",
+				},
+				cli.BoolFlag{
 					Name:  "update-vendored, u",
 					Usage: "Update vendored packages (without local VCS repo). Warning, changes will be lost.",
 				},
@@ -194,11 +198,12 @@ func commands() []cli.Command {
 				}
 
 				inst := &repo.Installer{
-					Force:          c.Bool("force"),
-					UseCache:       c.Bool("cache"),
-					UseGopath:      c.Bool("use-gopath"),
-					UseCacheGopath: c.Bool("cache-gopath"),
-					UpdateVendored: c.Bool("update-vendored"),
+					Force:           c.Bool("force"),
+					UseCache:        c.Bool("cache"),
+					UseGopath:       c.Bool("use-gopath"),
+					UseCacheGopath:  c.Bool("cache-gopath"),
+					UpdateVendored:  c.Bool("update-vendored"),
+					ResolveAllFiles: c.Bool("all-dependencies"),
 				}
 				packages := []string(c.Args())
 				insecure := c.Bool("insecure")
@@ -425,6 +430,10 @@ Example:
 					Usage: "If there was a change in the repo or VCS switch to new one. Warning, changes will be lost.",
 				},
 				cli.BoolFlag{
+					Name:  "all-dependencies",
+					Usage: "This will resolve all dependencies for all packages, not just those directly used.",
+				},
+				cli.BoolFlag{
 					Name:  "update-vendored, u",
 					Usage: "Update vendored packages (without local VCS repo). Warning, changes will be lost.",
 				},
@@ -447,13 +456,14 @@ Example:
 			},
 			Action: func(c *cli.Context) {
 				installer := &repo.Installer{
-					DeleteUnused:   c.Bool("deleteOptIn"),
-					UpdateVendored: c.Bool("update-vendored"),
-					Force:          c.Bool("force"),
-					UseCache:       c.Bool("cache"),
-					UseCacheGopath: c.Bool("cache-gopath"),
-					UseGopath:      c.Bool("use-gopath"),
-					Home:           gpath.Home(),
+					DeleteUnused:    c.Bool("deleteOptIn"),
+					UpdateVendored:  c.Bool("update-vendored"),
+					ResolveAllFiles: c.Bool("all-dependencies"),
+					Force:           c.Bool("force"),
+					UseCache:        c.Bool("cache"),
+					UseCacheGopath:  c.Bool("cache-gopath"),
+					UseGopath:       c.Bool("use-gopath"),
+					Home:            gpath.Home(),
 				}
 
 				action.Update(installer, c.Bool("no-recursive"))
@@ -474,7 +484,7 @@ Example:
 		},
 		{
 			Name:  "list",
-			Usage: "List prints all dependencies that Glide could discover.",
+			Usage: "List prints all dependencies that the present code references.",
 			Description: `List scans your code and lists all of the packages that are used.
 
 			It does not use the glide.yaml. Instead, it inspects the code to determine what packages are

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -316,6 +316,7 @@ func (m *MissingPackageHandler) NotFound(pkg string) (bool, error) {
 	// This package may have been placed on the list to look for when it wasn't
 	// downloaded but it has since been downloaded before coming to this entry.
 	if _, err := os.Stat(dest); err == nil {
+		msg.Debug("Found %s", dest)
 		return true, nil
 	}
 

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -238,6 +238,8 @@ func ConcurrentUpdate(deps []*cfg.Dependency, cwd string, i *Installer) error {
 	var lock sync.Mutex
 	var returnErr error
 
+	msg.Info("Downloading dependencies. Please wait...")
+
 	for ii := 0; ii < concurrentWorkers; ii++ {
 		go func(ch <-chan *cfg.Dependency) {
 			for {
@@ -268,7 +270,6 @@ func ConcurrentUpdate(deps []*cfg.Dependency, cwd string, i *Installer) error {
 		in <- dep
 	}
 
-	msg.Info("Downloading dependencies. Please wait...")
 	wg.Wait()
 
 	// Close goroutines setting the version

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -30,7 +30,7 @@ func VcsUpdate(dep *cfg.Dependency, vend string, inst *Installer) error {
 		return nil
 	}
 
-	msg.Info("Fetching updates for %s.\n", dep.Name)
+	msg.Info("- Fetching updates for %s.\n", dep.Name)
 
 	if filterArchOs(dep) {
 		msg.Info("%s is not used for %s/%s.\n", dep.Name, runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
This walks the import tree rather than the file system to find the imports to download.

Nice work @technosophos 

I think there are two things still to do:

- [x] Remove some of the message output that should be debug instead.
- [x] Glide has the ability to walk the file system and the import path. Choosing could be a command line switch (which could be useful in development).
