### PR TITLE
Use correct ampersand to append parameters to querystring

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -70,7 +70,7 @@ func getRootFromGoGet(pkg string) string {
 	if u.RawQuery == "" {
 		u.RawQuery = "go-get=1"
 	} else {
-		u.RawQuery = u.RawQuery + "+go-get=1"
+		u.RawQuery = u.RawQuery + "&go-get=1"
 	}
 	checkURL := u.String()
 	resp, err := http.Get(checkURL)


### PR DESCRIPTION
Is this correct? e.g. `+` instead of `&` on the querystring?

Also I wonder where are the upstream specs for this feature