### PR TITLE
Add `brew` command to aid creating homebrew formulas

### DIFF
--- a/action/brew.go
+++ b/action/brew.go
@@ -1,0 +1,88 @@
+package action
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Masterminds/glide/cfg"
+	"github.com/Masterminds/glide/msg"
+	gpath "github.com/Masterminds/glide/path"
+)
+
+// Brew converts dependencies to Homebrew resources and prints them, using
+// the Lockfile.
+//
+// Params:
+//  - basedir (string): Path to root of project to convert to brew resources
+func Brew() {
+	base := "."
+	// Ensure GOPATH
+	EnsureGopath()
+	EnsureVendorDir()
+	conf := EnsureConfig()
+
+	// Lockfile exists
+	if !gpath.HasLock(base) {
+		msg.Die("Lock file (glide.lock) does not exist.")
+	}
+	// Load lockfile
+	lock, err := cfg.ReadLockFile(filepath.Join(base, gpath.LockFile))
+	if err != nil {
+		msg.Die("Could not load lockfile.")
+	}
+	// Verify lockfile hasn't changed
+	hash, err := conf.Hash()
+	if err != nil {
+		msg.Die("Could not load lockfile.")
+	} else if hash != lock.Hash {
+		msg.Warn("Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'")
+	}
+
+	for _, lock := range lock.Imports {
+		resource, err := BrewResourceFromLock(lock)
+		if err != nil {
+			msg.Die("Failed to convert a dependency: %v", err)
+		}
+
+		msg.Puts("%s\n\n", resource)
+	}
+}
+
+// BrewResource represents a Homebrew resource definition for a Go dependency.
+// See: http://www.rubydoc.info/github/Homebrew/homebrew/master/Resource/Go
+type BrewResource struct {
+	Name             string
+	URL              string
+	Revision         string
+	DownloadStrategy string
+}
+
+// BrewResourceFromLock converts a Glide Lock to a BrewResource
+func BrewResourceFromLock(lock *cfg.Lock) (*BrewResource, error) {
+	// Get repo info about the locked dependency and convert to homebrew's
+	// resource attributes
+	dep := cfg.DependencyFromLock(lock)
+
+	repo, err := dep.GetRepo("")
+	if err != nil {
+		return nil, err
+	}
+
+	br := BrewResource{
+		Name:             dep.Name,
+		URL:              repo.Remote(),
+		Revision:         lock.Version,
+		DownloadStrategy: string(repo.Vcs()),
+	}
+
+	return &br, nil
+}
+
+// String serializes a BrewResource into Homebrew's syntax, for inclusion in a
+// formula.
+func (br *BrewResource) String() string {
+	//return fmt.Sprintf("resource \"%s\" do\n%s\nend", br.Name, "")
+	return fmt.Sprintf(`go_resource "%s" do
+  url "%s", :using => :%s, :revision => "%s"
+end`, br.Name, br.URL, br.DownloadStrategy, br.Revision)
+}

--- a/action/brew_test.go
+++ b/action/brew_test.go
@@ -1,0 +1,52 @@
+package action
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/glide/msg"
+)
+
+func TestBrew(t *testing.T) {
+	// Capture stdout, revert when done
+	var buf bytes.Buffer
+	originalStdout := msg.Default.Stdout
+	msg.Default.PanicOnDie = true
+	msg.Default.Stdout = &buf
+	defer func() {
+		msg.Default.Stdout = originalStdout
+	}()
+
+	// Change to testdata dir for the duration of the test, and return when done
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Failed to get current directory: %s", err)
+	}
+	if err := os.Chdir("../testdata/brew"); err != nil {
+		t.Errorf("Failed to change directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("Failed to change back to original directory (%s): %s", originalDir, err)
+		}
+	}()
+
+	Brew()
+
+	// There should be exactly two resource blocks
+	if strings.Count(buf.String(), "go_resource") != 2 {
+		t.Error("Brew conversion created wrong number of resources")
+	}
+
+	// Resources should be named after the package path that will be vendored
+	if !strings.Contains(buf.String(), `go_resource "github.com/Masterminds/semver"`) || !strings.Contains(buf.String(), `go_resource "a/different/path"`) {
+		t.Error("Failed to name resources correctly")
+	}
+
+	// But both use the same repo, so there should be two of those
+	if strings.Count(buf.String(), "https://github.com/Masterminds/semver") != 2 {
+		t.Error("Faileded to set repo in resource correctly")
+	}
+}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -343,6 +343,19 @@ type dep struct {
 	Os          []string `yaml:"os,omitempty"`
 }
 
+// DependencyFromLock converts a Lock to a Dependency
+func DependencyFromLock(lock *Lock) *Dependency {
+	return &Dependency{
+		Name:        lock.Name,
+		Reference:   lock.Version,
+		Repository:  lock.Repository,
+		VcsType:     lock.VcsType,
+		Subpackages: lock.Subpackages,
+		Arch:        lock.Arch,
+		Os:          lock.Os,
+	}
+}
+
 // UnmarshalYAML is a hook for gopkg.in/yaml.v2 in the unmarshaling process
 func (d *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	newDep := &dep{}

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -45,6 +45,19 @@ func (lf *Lockfile) WriteFile(lockpath string) error {
 	return ioutil.WriteFile(lockpath, o, 0666)
 }
 
+// ReadLockFile loads the contents of a glide.lock file.
+func ReadLockFile(lockpath string) (*Lockfile, error) {
+	yml, err := ioutil.ReadFile(lockpath)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := LockfileFromYaml(yml)
+	if err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
 // Locks is a slice of locked dependencies.
 type Locks []*Lock
 

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -81,6 +81,19 @@ type Lock struct {
 	Os          []string `yaml:"os,omitempty"`
 }
 
+// LockFromDependency converts a Dependency to a Lock
+func LockFromDependency(dep *Dependency) *Lock {
+	return &Lock{
+		Name:        dep.Name,
+		Version:     dep.Pin,
+		Repository:  dep.Repository,
+		VcsType:     dep.VcsType,
+		Subpackages: dep.Subpackages,
+		Arch:        dep.Arch,
+		Os:          dep.Os,
+	}
+}
+
 // NewLockfile is used to create an instance of Lockfile.
 func NewLockfile(ds Dependencies, hash string) *Lockfile {
 	lf := &Lockfile{
@@ -90,15 +103,7 @@ func NewLockfile(ds Dependencies, hash string) *Lockfile {
 	}
 
 	for i := 0; i < len(ds); i++ {
-		lf.Imports[i] = &Lock{
-			Name:        ds[i].Name,
-			Version:     ds[i].Pin,
-			Repository:  ds[i].Repository,
-			VcsType:     ds[i].VcsType,
-			Subpackages: ds[i].Subpackages,
-			Arch:        ds[i].Arch,
-			Os:          ds[i].Os,
-		}
+		lf.Imports[i] = LockFromDependency(ds[i])
 	}
 
 	sort.Sort(lf.Imports)
@@ -116,15 +121,8 @@ func LockfileFromMap(ds map[string]*Dependency, hash string) *Lockfile {
 
 	i := 0
 	for name, dep := range ds {
-		lf.Imports[i] = &Lock{
-			Name:        name,
-			Version:     dep.Pin,
-			Repository:  dep.Repository,
-			VcsType:     dep.VcsType,
-			Subpackages: dep.Subpackages,
-			Arch:        dep.Arch,
-			Os:          dep.Os,
-		}
+		lf.Imports[i] = LockFromDependency(dep)
+		lf.Imports[i].Name = name
 		i++
 	}
 

--- a/glide.go
+++ b/glide.go
@@ -510,6 +510,18 @@ Example:
 			},
 		},
 		{
+			Name:  "brew",
+			Usage: "Brew prints dependencies converted to Homebrew resources.",
+			Description: `Brew converts dependencies from glides format to Homebrew's resource format and
+			prints them, for inclusion in a Homebrew formula.
+
+			It uses the glide.lock file, so all sub dependencies are also included.
+			`,
+			Action: func(c *cli.Context) {
+				action.Brew()
+			},
+		},
+		{
 			Name:  "about",
 			Usage: "Learn about Glide",
 			Action: func(c *cli.Context) {

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -78,28 +78,12 @@ func (i *Installer) Install(lock *cfg.Lockfile, conf *cfg.Config) (*cfg.Config, 
 
 	newConf.Imports = make(cfg.Dependencies, len(lock.Imports))
 	for k, v := range lock.Imports {
-		newConf.Imports[k] = &cfg.Dependency{
-			Name:        v.Name,
-			Reference:   v.Version,
-			Repository:  v.Repository,
-			VcsType:     v.VcsType,
-			Subpackages: v.Subpackages,
-			Arch:        v.Arch,
-			Os:          v.Os,
-		}
+		newConf.Imports[k] = cfg.DependencyFromLock(v)
 	}
 
 	newConf.DevImports = make(cfg.Dependencies, len(lock.DevImports))
 	for k, v := range lock.DevImports {
-		newConf.DevImports[k] = &cfg.Dependency{
-			Name:        v.Name,
-			Reference:   v.Version,
-			Repository:  v.Repository,
-			VcsType:     v.VcsType,
-			Subpackages: v.Subpackages,
-			Arch:        v.Arch,
-			Os:          v.Os,
-		}
+		newConf.DevImports[k] = cfg.DependencyFromLock(v)
 	}
 
 	newConf.DeDupe()

--- a/testdata/brew/glide.lock
+++ b/testdata/brew/glide.lock
@@ -1,0 +1,10 @@
+hash: 8c11b6eb9430a06acee21ff6d05558656bad03f303785c6c43f2f4e19f7ce088
+updated: 2016-02-17T17:55:50.599339531-05:00
+imports:
+- name: a/different/path
+  version: 6333b7bd29aad1d79898ff568fd90a8aa533ae82
+  repo: https://github.com/Masterminds/semver.git
+  vcs: git
+- name: github.com/Masterminds/semver
+  version: c4f7ef0702f269161a60489ccbbc9f1241ad1265
+devImports: []


### PR DESCRIPTION
Manually creating Homebrew "resource" definitions for a formula is pretty tedious and error prone, especially keeping them correctly updated over time. This change adds `glide brew` to convert the lockfile to homebrew resource definitions.

I also factored out some of the logic I needed into the `cfg` package, but I kept those changes in two separate commits, for clarity.