### PR TITLE
make glide work without use go vendor

### DIFF
--- a/action/get.go
+++ b/action/get.go
@@ -74,6 +74,8 @@ func Get(names []string, installer *repo.Installer, insecure, skipRecursive bool
 	} else {
 		msg.Warn("Skipping lockfile generation because full dependency tree is not being calculated")
 	}
+
+	installer.Cleanup()
 }
 
 func writeLock(conf, confcopy *cfg.Config, base string) {

--- a/action/init.go
+++ b/action/init.go
@@ -31,7 +31,7 @@ func CheckGoVendor() {
 			}
 		}
 		if len(_vendor) == 0 {
-			_vendor = gopath[0] + _vendorSuffix
+			_vendor = gopath[0]
 		}
 		if len(_vendor) == 0 {
 			msg.Warn("no '*%s' found.", _vendorSuffix)

--- a/action/init.go
+++ b/action/init.go
@@ -31,10 +31,13 @@ func CheckGoVendor() {
 			}
 		}
 		if len(_vendor) == 0 {
-			msg.Warn("no *%s GOPATH found.", _vendorSuffix)
+			_vendor = gopath[0] + _vendorSuffix
+		}
+		if len(_vendor) == 0 {
+			msg.Warn("no '*%s' found.", _vendorSuffix)
 			os.Exit(1)
 		} else {
-			msg.Info("found *%s GOPATH: %v", _vendorSuffix, _vendor)
+			msg.Info("using '*%s': %v", _vendorSuffix, _vendor)
 			gpath.UseGoVendor = false
 			gpath.GoPathVendorDir = filepath.Join(_vendor, "src")
 		}

--- a/action/init.go
+++ b/action/init.go
@@ -1,11 +1,42 @@
 package action
 
 import (
+	"strings"
+	"path/filepath"
+	"os"
+	"go/build"
+
+	"github.com/Masterminds/glide/msg"
 	gpath "github.com/Masterminds/glide/path"
 )
+
+const _vendorSuffix = string(filepath.Separator) + "_vendor"
 
 // Init initializes the action subsystem for handling one or more subesequent actions.
 func Init(yaml, home string) {
 	gpath.GlideFile = yaml
 	gpath.HomeDir = home
+}
+
+func CheckGoVendor() {
+	supportGoVendor := EnsureGoVendor()
+	if !supportGoVendor {
+		// if there is a *_vendorSuffix GOPATH, keep work with it
+		gopath := filepath.SplitList(build.Default.GOPATH)
+		var _vendor string
+		for _, p := range gopath {
+			if strings.HasSuffix(filepath.Clean(p), _vendorSuffix) {
+				_vendor = p
+				break
+			}
+		}
+		if len(_vendor) == 0 {
+			msg.Warn("no *%s GOPATH found.", _vendorSuffix)
+			os.Exit(1)
+		} else {
+			msg.Info("found *%s GOPATH: %v", _vendorSuffix, _vendor)
+			gpath.UseGoVendor = false
+			gpath.GoPathVendorDir = filepath.Join(_vendor, "src")
+		}
+	}
 }

--- a/action/install.go
+++ b/action/install.go
@@ -56,6 +56,8 @@ func Install(installer *repo.Installer) {
 	if installer.UpdateVendored {
 		repo.VendoredCleanup(newConf)
 	}
+
+	installer.Cleanup()
 }
 
 // LoadLockfile loads the contents of a glide.lock file.

--- a/action/update.go
+++ b/action/update.go
@@ -87,4 +87,6 @@ func Update(installer *repo.Installer, skipRecursive bool) {
 	} else {
 		msg.Warn("Skipping lockfile generation because full dependency tree is not being calculated")
 	}
+
+	installer.Cleanup()
 }

--- a/glide.go
+++ b/glide.go
@@ -536,7 +536,8 @@ func startup(c *cli.Context) error {
 	action.NoColor(c.Bool("no-color"))
 	action.Quiet(c.Bool("quiet"))
 	action.Init(c.String("yaml"), c.String("home"))
-	action.EnsureGoVendor()
+//	action.EnsureGoVendor()
+	action.CheckGoVendor()
 	return nil
 }
 

--- a/path/path.go
+++ b/path/path.go
@@ -15,6 +15,10 @@ import (
 // DefaultGlideFile is the default name for the glide.yaml file.
 const DefaultGlideFile = "glide.yaml"
 
+var UseGoVendor = true
+
+var GoPathVendorDir string
+
 // VendorDir is the name of the directory that holds vendored dependencies.
 //
 // As of Go 1.5, this is always vendor.

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -47,6 +47,9 @@ type Installer struct {
 	// of every file of every package, rather than only following imported
 	// packages.
 	ResolveAllFiles bool
+
+	// KeepVendorSymlink when gpath.UseGoVendor == false
+	KeepVendorSymlink bool
 }
 
 // VendorPath returns the path to the location to put vendor packages
@@ -189,6 +192,16 @@ func (i *Installer) Update(conf *cfg.Config) error {
 	err = ConcurrentUpdate(conf.Imports, vpath, i)
 
 	return err
+}
+
+// do some cleanup things after install/update/get command.
+func (i *Installer) Cleanup() {
+	if !gpath.UseGoVendor && !i.KeepVendorSymlink {
+		msg.Debug("Remove symlink %s", gpath.VendorDir)
+		if err := os.Remove(gpath.VendorDir); err != nil {
+			msg.Err("Could not remove symlink %s: %s", gpath.VendorDir, err)
+		}
+	}
 }
 
 // List resolves the complete dependency tree and returns a list of dependencies.


### PR DESCRIPTION
I used glide and think it's great!
but it REQUIRES the use of GO VENDOR feature, 
and some of my tool chain,  such as gocode, goclipse,  doesn't support go vendor well.

So I think it well be greate if glide can work without use the go vendor feature (just similar the lower version of it does).
for the minimalist modification, I just do

1. Check if go vendor feature is enabled, if it's not, do my tricks as fellow. (I just Comment out the `os.Exit(1)` statement from `EnsureGoVendor`.)
2. make "vendor" as a symlink to the "src" directory of some GOPATH, in my case, it's the first GOPATH which ends with "/_vendor". I use gopath because I want the "_vendor" directory be out of the my source tree.
3. delete the "vendor" symlink after "install/update/get" command, so I will not confused for it.

I disabled "GO15VENDOREXPERIMENT" feature, and tested the code from my ubuntu PC,  it looks works well.
if the "GO15VENDOREXPERIMENT" feature is enabled, every thing works as the original logic,

I think the change not only DOSE NOT hurt people who use the go vendor featured,
but also helps people, like me, who do not use the go vendor feature very much.
so I created this pull request, and loyal hope glide could work without go vendor in the future,
best in a more elegant way.