### PR TITLE
fix issue #166 -  preserve Subpackages in sliceToQueue

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -688,11 +688,18 @@ func (r *Resolver) imports(pkg string) ([]string, error) {
 }
 
 // sliceToQueue is a special-purpose function for unwrapping a slice of
-// dependencies into a queue of fully qualified paths.
+// dependencies into a queue of fully qualified paths.  If subpackages
+// are present, each subpackage is resolved into its own full path.
 func sliceToQueue(deps []*cfg.Dependency, basepath string) *list.List {
 	l := list.New()
 	for _, e := range deps {
-		l.PushBack(filepath.Join(basepath, filepath.FromSlash(e.Name)))
+		if len(e.Subpackages) == 0 {
+			l.PushBack(filepath.Join(basepath, filepath.FromSlash(e.Name)))
+		} else {
+			for _, spkg := range e.Subpackages {
+				l.PushBack(filepath.Join(basepath, filepath.FromSlash(e.Name), spkg))
+			}
+		}
 	}
 	return l
 }


### PR DESCRIPTION
#166 in particular https://github.com/Masterminds/glide/issues/166#issuecomment-184689515

Currently sliceToQueue function looks only at the Name in cfg.Dependency and disregards the possible presence of Subpackages.  This leads to the "over-greedy" fetching of dependencies of the root package even if only a subpackage is used, as described in the issue.

I added tests for sliceToQueue on Dependency both with and without subpackages.  The new test  TestSliceToQueueWithSubpackages fails with the current master version:
```
--- FAIL: TestSliceToQueueWithSubpackages (0.00s)
	resolver_test.go:133: Wrong value as queue head: want /Users/dsavints/go/src/github.com/Masterminds/glide/vendor/golang.org/x/crypto/ssh, got /Users/dsavints/go/src/github.com/Masterminds/glide/vendor/golang.org/x/crypto
FAIL
```
The new TestSliceToQueueWithMultSubpackages fails on master as well:
```
 --- FAIL: TestSliceToQueueWithMultSubpackages (0.00s)
	resolver_test.go:149: Wrong number of queue items: want 2, got 1
```
both pass with the suggested fix.  Also verified on the https://github.com/dmitris/deptest4glide test case (pulls only github.com/dmitris/deptesthuge/deptestsmall and not all the massive dependencies of github.com/dmitris/deptesthuge).

@technosophos 