### PR TITLE
Add support for Go 1.6 and Go Dev to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: go
 # against tip which has the features.
 go:
   - 1.5
+  - 1.6
+  - tip
 
 # Setting sudo access to false will let Travis CI use containers rather than
 # VMs to run the tests. For more details see:


### PR DESCRIPTION
This adds build support for both Go 1.6 and Go "tip"

If there is a way to make errors on tip non-fatal, we should do that.