### PR TITLE
Fixed #275, #285: Empty package location causes errors

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -400,7 +400,7 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 			msg.Debug("Using Iterative Scanning for %s", dep)
 			imps, err = IterativeScan(vdep)
 			if err != nil {
-				msg.Err("Error scanning %s: %s", dep, err)
+				msg.Err("Iterative scanning error %s: %s", dep, err)
 				continue
 			}
 		} else if err != nil {

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -55,6 +55,17 @@ func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGo
 		_, err = v.DetectVcsFromFS(dest)
 		if updateVendored == false && empty == false && err == v.ErrCannotDetectVCS {
 			msg.Warn("%s appears to be a vendored package. Unable to update. Consider the '--update-vendored' flag.\n", dep.Name)
+		} else if updateVendored == false && empty == true && err == v.ErrCannotDetectVCS {
+			msg.Warn("%s is an empty directory. Fetching a new copy of the dependency.", dep.Name)
+			msg.Debug("Removing empty directory %s", dest)
+			err := os.RemoveAll(dest)
+			if err != nil {
+				return err
+			}
+			if err = VcsGet(dep, dest, home, cache, cacheGopath, useGopath); err != nil {
+				msg.Warn("Unable to checkout %s\n", dep.Name)
+				return err
+			}
 		} else {
 
 			if updateVendored == true && empty == false && err == v.ErrCannotDetectVCS {


### PR DESCRIPTION
This happens when the directory exists for a root repo location but
it contains no files. Glide thinks it exists but it's a broken
location.

The fix here detetects the problem and fetches a fresh copy of
the package.