### PR TITLE
Make 'already set' be a debug message

### DIFF
--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -140,7 +140,7 @@ func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGo
 				// branch it's a tag or commit id so we can skip
 				// performing an update.
 				if version == dep.Reference && !ib {
-					msg.Info("%s is already set to version %s. Skipping update.", dep.Name, dep.Reference)
+					msg.Debug("%s is already set to version %s. Skipping update.", dep.Name, dep.Reference)
 					return nil
 				}
 			}


### PR DESCRIPTION
This is a big reduction in non-useful noise when running.