### PR TITLE
Track updated packages to avoid dup work

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -48,6 +48,17 @@ type Config struct {
 	// DevImports contains the test or other development imports for a project.
 	// See the Dependency type for more details on how this is recorded.
 	DevImports Dependencies `yaml:"devimport,omitempty"`
+
+	// Updated tracks which packages have already been updated, so we don't
+	// duplicate work.
+	Updated map[string]bool `yaml:"-"`
+}
+
+// NewConfig allocates a Config structure with all fields properly initialized.
+func NewConfig() *Config {
+	cfg := &Config{}
+	cfg.Updated = map[string]bool{}
+	return cfg
 }
 
 // A transitive representation of a dependency for importing and exporting to yaml.
@@ -64,7 +75,7 @@ type cf struct {
 
 // ConfigFromYaml returns an instance of Config from YAML
 func ConfigFromYaml(yml []byte) (*Config, error) {
-	cfg := &Config{}
+	cfg := NewConfig()
 	err := yaml.Unmarshal([]byte(yml), &cfg)
 	return cfg, err
 }
@@ -156,7 +167,7 @@ func (c *Config) HasIgnore(name string) bool {
 
 // Clone performs a deep clone of the Config instance
 func (c *Config) Clone() *Config {
-	n := &Config{}
+	n := NewConfig()
 	n.Name = c.Name
 	n.Description = c.Description
 	n.Home = c.Home
@@ -165,6 +176,9 @@ func (c *Config) Clone() *Config {
 	n.Ignore = c.Ignore
 	n.Imports = c.Imports.Clone()
 	n.DevImports = c.DevImports.Clone()
+	for k, v := range c.Updated {
+		n.Updated[k] = v
+	}
 	return n
 }
 

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VcsUpdate updates to a particular checkout based on the VCS setting.
-func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGopath, force, updateVendored bool) error {
+func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGopath, force, updateVendored bool, updated map[string]bool) error {
 
 	// If the dependency has already been pinned we can skip it. This is a
 	// faster path so we don't need to resolve it again.
@@ -29,6 +29,12 @@ func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGo
 		msg.Debug("Dependency %s has already been pinned. Fetching updates skipped.", dep.Name)
 		return nil
 	}
+
+	if updated[dep.Name] {
+		msg.Debug("%s was already updated, skipping.\n", dep.Name)
+		return nil
+	}
+	updated[dep.Name] = true
 
 	msg.Info("Fetching updates for %s.\n", dep.Name)
 


### PR DESCRIPTION
Fixes #308 

I am not really happy with this, but I thought it was a better start to avoid passing around a whole additional argument to all the actions.  Better ideas welcome.