### PR TITLE
[RFC] Explicitly define in glide.lock if base package is a dependency.

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -496,6 +496,9 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 	for e := queue.Front(); e != nil; e = e.Next() {
 		t := r.stripv(e.Value.(string))
 		root, sp := util.NormalizeName(t)
+		if sp == "" {
+			sp = "."
+		}
 
 		// Skip ignored packages
 		if r.Config.HasIgnore(e.Value.(string)) {
@@ -506,16 +509,14 @@ func (r *Resolver) resolveImports(queue *list.List) ([]string, error) {
 		// TODO(mattfarina): Need to eventually support devImport
 		existing := r.Config.Imports.Get(root)
 		if existing != nil {
-			if sp != "" && !existing.HasSubpackage(sp) {
+			if !existing.HasSubpackage(sp) {
 				existing.Subpackages = append(existing.Subpackages, sp)
 			}
 		} else {
 			newDep := &cfg.Dependency{
 				Name: root,
 			}
-			if sp != "" {
-				newDep.Subpackages = []string{sp}
-			}
+			newDep.Subpackages = []string{sp}
 
 			r.Config.Imports = append(r.Config.Imports, newDep)
 		}
@@ -582,20 +583,21 @@ func (r *Resolver) resolveList(queue *list.List) ([]string, error) {
 	for e := queue.Front(); e != nil; e = e.Next() {
 		t := strings.TrimPrefix(e.Value.(string), r.VendorDir+string(os.PathSeparator))
 		root, sp := util.NormalizeName(t)
+		if sp == "" {
+			sp = "."
+		}
 
 		// TODO(mattfarina): Need to eventually support devImport
 		existing := r.Config.Imports.Get(root)
 		if existing != nil {
-			if sp != "" && !existing.HasSubpackage(sp) {
+			if !existing.HasSubpackage(sp) {
 				existing.Subpackages = append(existing.Subpackages, sp)
 			}
 		} else {
 			newDep := &cfg.Dependency{
 				Name: root,
 			}
-			if sp != "" {
-				newDep.Subpackages = []string{sp}
-			}
+			newDep.Subpackages = []string{sp}
 
 			r.Config.Imports = append(r.Config.Imports, newDep)
 		}


### PR DESCRIPTION
Working on https://github.com/sgotti/glide-vc I noticed that, using the glide.lock file, it's not possible to determine if a base package with some subpackages is itself a project dependency.

For example, given:

```
- name: github.com/sgotti/project01    
  version: b16f2e739216b746bda87fb5b677fa672f09afb7
  subpackages:                                     
  - subpackage01
```

I'm not able to determine if only `github.com/sgotti/project01/subpackages01` or also `github.com/sgotti/project01` are needed packages.

One of the idea that came to my mind was to explicitly add "." to the subpackages if the base package is a dependency. This is what the actual PR does to trigger an initial discussion.

This of course will make the lock file slightly more verbose since every package will have a subpackage section. An improvement to make it less verbose will be to add "." only if there're other subpackages (so if only the base package is needed, no subpackage with just "." will be added).
