### PR TITLE
Fixed update: remove ignored dependencies

### DIFF
--- a/action/update.go
+++ b/action/update.go
@@ -104,5 +104,4 @@ func removeIgnoredImports(conf *cfg.Config) {
 			}
 		}
 	}
-	return
 }


### PR DESCRIPTION
Without this change, ignored dependencies are written to glide.lock.  This is problematic for local sub-package imports, for which a VCS cannot be determined.  When explicitly ignoring local sub-packages, glide.lock should not include them.