### PR TITLE
Print the path a recursive deps file was found in

### DIFF
--- a/gb/gb.go
+++ b/gb/gb.go
@@ -24,7 +24,7 @@ func Parse(dir string) ([]*cfg.Dependency, error) {
 		return []*cfg.Dependency{}, nil
 	}
 
-	msg.Info("Found GB manifest file.\n")
+	msg.Info("Found GB manifest file in %s\n", dir)
 	buf := []*cfg.Dependency{}
 	file, err := os.Open(path)
 	if err != nil {

--- a/godep/godep.go
+++ b/godep/godep.go
@@ -52,7 +52,7 @@ func Parse(dir string) ([]*cfg.Dependency, error) {
 	if _, err := os.Stat(path); err != nil {
 		return []*cfg.Dependency{}, nil
 	}
-	msg.Info("Found Godeps.json file.\n")
+	msg.Info("Found Godeps.json file in %s\n", dir)
 
 	buf := []*cfg.Dependency{}
 

--- a/gom/gom.go
+++ b/gom/gom.go
@@ -24,7 +24,7 @@ func Parse(dir string) ([]*cfg.Dependency, error) {
 		return []*cfg.Dependency{}, nil
 	}
 
-	msg.Info("Found Gomfile.\n")
+	msg.Info("Found Gomfile in %s\n", dir)
 	buf := []*cfg.Dependency{}
 
 	goms, err := parseGomfile(path)

--- a/gpm/gpm.go
+++ b/gpm/gpm.go
@@ -29,7 +29,7 @@ func Parse(dir string) ([]*cfg.Dependency, error) {
 		msg.Info("Godeps is a directory. This is probably a Godep project.\n")
 		return []*cfg.Dependency{}, nil
 	}
-	msg.Info("Found Godeps file.\n")
+	msg.Info("Found Godeps file in %s\n", dir)
 
 	buf := []*cfg.Dependency{}
 


### PR DESCRIPTION
This is imperfect - it says:

```
Found Godeps.json file in /home/thockin/tmp/glide/src/k8s.io/kubernetes/vendor/github.com/opencontainers/runc
```

when it would be better to say:

```
Found Godeps.json file in vendor/github.com/opencontainers/runc
```

or:

```
Found Godeps.json file in k8s.io/kubernetes/vendor/github.com/opencontainers/runc
```

or:

```
Found Godeps.json file in vendored github.com/opencontainers/runc
```

Better fixes would be welcome instead of this, but this is better than nothing.