### PR TITLE
glide list: support json output format

### DIFF
--- a/action/list_test.go
+++ b/action/list_test.go
@@ -1,21 +1,9 @@
 package action
 
-import (
-	"bytes"
-	"testing"
-
-	"github.com/Masterminds/glide/msg"
-)
+import "testing"
 
 func TestList(t *testing.T) {
-	var buf bytes.Buffer
-	old := msg.Default.Stdout
-	msg.Default.PanicOnDie = true
-	msg.Default.Stdout = &buf
-	List("../", false)
-	if buf.Len() < 5 {
-		t.Error("Expected some data to be found.")
+	if len(List("../", false).Installed) < 1 {
+		t.Error("Expected some packages to be found")
 	}
-	// TODO: We should capture and test output.
-	msg.Default.Stdout = old
 }


### PR DESCRIPTION
Sort of addresses #256. Might be worth having a format which spits out a newline delimited list, without the "INSTALLED/MISSING/GOPATH packages" headers.