### PR TITLE
Fixes #371: Warn when name/location mismatch

### DIFF
--- a/action/ensure.go
+++ b/action/ensure.go
@@ -51,6 +51,8 @@ func EnsureConfig() *cfg.Config {
 			if name != conf.Name {
 				msg.Warn("The name listed in the config file (%s) does not match the current location (%s)", conf.Name, name)
 			}
+		} else {
+			msg.Warn("Problem finding the config file path (%s) relative to the current directory (%s): %s", b, cwd, err)
 		}
 	}
 

--- a/action/ensure.go
+++ b/action/ensure.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/glide/cfg"
 	"github.com/Masterminds/glide/msg"
 	gpath "github.com/Masterminds/glide/path"
+	"github.com/Masterminds/glide/util"
 )
 
 // EnsureConfig loads and returns a config file.
@@ -31,6 +33,25 @@ func EnsureConfig() *cfg.Config {
 	if err != nil {
 		msg.ExitCode(3)
 		msg.Die("Failed to parse %s: %s", yamlpath, err)
+	}
+
+	b := filepath.Dir(yamlpath)
+	buildContext, err := util.GetBuildContext()
+	if err != nil {
+		msg.Die("Failed to build an import context while ensuring config: %s", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		msg.Err("Unable to get the current working directory")
+	} else {
+		// Determining a package name requires a relative path
+		b, err = filepath.Rel(b, cwd)
+		if err == nil {
+			name := buildContext.PackageName(b)
+			if name != conf.Name {
+				msg.Warn("The name listed in the config file (%s) does not match the current location (%s)", conf.Name, name)
+			}
+		}
 	}
 
 	return conf

--- a/util/util.go
+++ b/util/util.go
@@ -254,7 +254,7 @@ func (b *BuildCtxt) PackageName(base string) string {
 		// There may not be any top level Go source files but the project may
 		// still be within the GOPATH.
 		if strings.HasPrefix(base, b.GOPATH) {
-			p := strings.TrimPrefix(base, b.GOPATH)
+			p := strings.TrimPrefix(base, filepath.Join(b.GOPATH, "src"))
 			return strings.Trim(p, string(os.PathSeparator))
 		}
 	}


### PR DESCRIPTION
When the package in the glide.yaml does not match the current
location in the GOPATH warn the users.