### PR TITLE
Added support for custom Go executable name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
+GLIDE_GO_EXECUTABLE ?= go
 VERSION := $(shell git describe --tags)
 DIST_DIRS := find * -type d -exec
 
 build:
-	go build -o glide -ldflags "-X main.version=${VERSION}" glide.go
+	${GLIDE_GO_EXECUTABLE} build -o glide -ldflags "-X main.version=${VERSION}" glide.go
 
 install: build
 	install -d ${DESTDIR}/usr/local/bin/
 	install -m 755 ./glide ${DESTDIR}/usr/local/bin/glide
 
 test:
-	go test . ./gb ./path ./action ./tree ./util ./godep ./godep/strip ./gpm ./cfg ./dependency ./importer ./msg ./repo
+	${GLIDE_GO_EXECUTABLE} test . ./gb ./path ./action ./tree ./util ./godep ./godep/strip ./gpm ./cfg ./dependency ./importer ./msg ./repo
 
 clean:
 	rm -f ./glide.test
@@ -17,7 +18,7 @@ clean:
 	rm -rf ./dist
 
 bootstrap-dist:
-	go get -u github.com/mitchellh/gox
+	${GLIDE_GO_EXECUTABLE} get -u github.com/mitchellh/gox
 
 build-all:
 	gox -verbose \

--- a/action/ensure.go
+++ b/action/ensure.go
@@ -67,7 +67,7 @@ func EnsureCacheDir() {
 // EnsureGoVendor ensures that the Go version is correct.
 func EnsureGoVendor() {
 	// 6l was removed in 1.5, when vendoring was introduced.
-	cmd := exec.Command("go", "tool", "6l")
+	cmd := exec.Command(goExecutable(), "tool", "6l")
 	if _, err := cmd.CombinedOutput(); err == nil {
 		msg.Warn("You must install the Go 1.5 or greater toolchain to work with Glide.\n")
 		os.Exit(1)
@@ -75,13 +75,13 @@ func EnsureGoVendor() {
 
 	// Check if this is go15, which requires GO15VENDOREXPERIMENT
 	// Any release after go15 does not require that env var.
-	cmd = exec.Command("go", "version")
+	cmd = exec.Command(goExecutable(), "version")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		msg.Err("Error getting version: %s.\n", err)
 		os.Exit(1)
 	} else if strings.HasPrefix(string(out), "go version 1.5") {
 		// This works with 1.5 and 1.6.
-		cmd = exec.Command("go", "env", "GO15VENDOREXPERIMENT")
+		cmd = exec.Command(goExecutable(), "env", "GO15VENDOREXPERIMENT")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			msg.Err("Error looking for $GOVENDOREXPERIMENT: %s.\n", err)
 			os.Exit(1)
@@ -146,4 +146,19 @@ func EnsureGopath() string {
 	msg.Info("As of Glide 0.5/Go 1.5, this is required.\n")
 	msg.Die("Wihtout src, cannot continue.")
 	return ""
+}
+
+
+// goExecutable checks for a set environment variable of GLIDE_GO_EXECUTABLE
+// for the go executable name. The Google App Engine SDK ships with a python
+// wrapper called goapp
+//
+// Example usage: GLIDE_GO_EXECUTABLE=goapp glide install
+func goExecutable() string {
+	goExecutable := os.Getenv("GLIDE_GO_EXECUTABLE")
+	if len(goExecutable) <= 0 {
+		goExecutable = "go"
+	}
+
+	return goExecutable
 }

--- a/action/rebuild.go
+++ b/action/rebuild.go
@@ -92,9 +92,10 @@ func buildPath(path string) error {
 	msg.Info("Running go build %s\n", path)
 	// . in a filepath.Join is removed so it needs to be prepended separately.
 	p := "." + string(filepath.Separator) + filepath.Join("vendor", path)
-	out, err := exec.Command("go", "install", p).CombinedOutput()
+	out, err := exec.Command(goExecutable(), "install", p).CombinedOutput()
 	if err != nil {
 		msg.Warn("Failed to run 'go install' for %s: %s", path, string(out))
 	}
 	return err
 }
+

--- a/util/util.go
+++ b/util/util.go
@@ -279,7 +279,11 @@ func GetBuildContext() (*BuildCtxt, error) {
 	}
 
 	if goRoot := os.Getenv("GOROOT"); len(goRoot) == 0 {
-		out, err := exec.Command("go", "env", "GOROOT").Output()
+		goExecutable := os.Getenv("GLIDE_GO_EXECUTABLE")
+		if len(goExecutable) <= 0 {
+			goExecutable = "go"
+		}
+		out, err := exec.Command(goExecutable, "env", "GOROOT").Output()
 		if goRoot = strings.TrimSpace(string(out)); len(goRoot) == 0 || err != nil {
 			return nil, fmt.Errorf("Please set the $GOROOT environment " +
 				"variable to use this command\n")


### PR DESCRIPTION
The Google App Engine SDK ships with a python wrapper called goapp instead of the regular go executable.

Usage example:
`GLIDE_GO_EXECUTABLE=goapp glide install`

Current workaround is to install both go and go-app-engine-64 packages.