### PR TITLE
Correctly normalize Windows package paths.

### DIFF
--- a/util/normalizename_test.go
+++ b/util/normalizename_test.go
@@ -7,6 +7,7 @@ import (
 func TestNormalizeName(t *testing.T) {
 	packages := map[string]string{
 		"github.com/Masterminds/cookoo/web/io/foo": "github.com/Masterminds/cookoo",
+		`github.com\Masterminds\cookoo\web\io\foo`: "github.com/Masterminds/cookoo",
 		"golang.org/x/crypto/ssh":                  "golang.org/x/crypto",
 		"incomplete/example":                       "incomplete/example",
 		"net":                                      "net",

--- a/util/normalizename_test.go
+++ b/util/normalizename_test.go
@@ -5,18 +5,44 @@ import (
 )
 
 func TestNormalizeName(t *testing.T) {
-	packages := map[string]string{
-		"github.com/Masterminds/cookoo/web/io/foo": "github.com/Masterminds/cookoo",
-		`github.com\Masterminds\cookoo\web\io\foo`: "github.com/Masterminds/cookoo",
-		"golang.org/x/crypto/ssh":                  "golang.org/x/crypto",
-		"incomplete/example":                       "incomplete/example",
-		"net":                                      "net",
+	packages := []struct {
+		input string
+		root  string
+		extra string
+	}{
+		{
+			input: "github.com/Masterminds/cookoo/web/io/foo",
+			root:  "github.com/Masterminds/cookoo",
+			extra: "web/io/foo",
+		},
+		{
+			input: `github.com\Masterminds\cookoo\web\io\foo`,
+			root:  "github.com/Masterminds/cookoo",
+			extra: "web/io/foo",
+		},
+		{
+			input: "golang.org/x/crypto/ssh",
+			root:  "golang.org/x/crypto",
+			extra: "ssh",
+		},
+		{
+			input: "incomplete/example",
+			root:  "incomplete/example",
+			extra: "",
+		},
+		{
+			input: "net",
+			root:  "net",
+			extra: "",
+		},
 	}
-	for start, expected := range packages {
-		if finish, extra := NormalizeName(start); expected != finish {
-			t.Errorf("Expected '%s', got '%s'", expected, finish)
-		} else if start != finish && start != finish+"/"+extra {
-			t.Errorf("Expected %s to end with %s", finish, extra)
+	for _, test := range packages {
+		root, extra := NormalizeName(test.input)
+		switch {
+		case root != test.root:
+			t.Errorf("%s: Expected root '%s', got '%s'", test.input, test.root, root)
+		case extra != test.extra:
+			t.Errorf("%s: Expected extra '%s', got '%s'", test.input, test.extra, extra)
 		}
 	}
 }

--- a/util/normalizename_test.go
+++ b/util/normalizename_test.go
@@ -38,10 +38,10 @@ func TestNormalizeName(t *testing.T) {
 	}
 	for _, test := range packages {
 		root, extra := NormalizeName(test.input)
-		switch {
-		case root != test.root:
+		if root != test.root {
 			t.Errorf("%s: Expected root '%s', got '%s'", test.input, test.root, root)
-		case extra != test.extra:
+		}
+		if extra != test.extra {
 			t.Errorf("%s: Expected extra '%s', got '%s'", test.input, test.extra, extra)
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -311,6 +311,7 @@ func NormalizeName(name string) (string, string) {
 		}
 	}
 
+	name = filepath.ToSlash(name)
 	root := GetRootFromPackage(name)
 	extra := strings.TrimPrefix(name, root)
 	if len(extra) > 0 && extra != "/" {

--- a/util/util.go
+++ b/util/util.go
@@ -30,11 +30,7 @@ func init() {
 }
 
 func toSlash(v string) string {
-	v = strings.Replace(v, "\\", "/", -1)
-	if os.PathSeparator != '\\' && os.PathSeparator != '/' {
-		v = strings.Replace(v, string(os.PathSeparator), "/", -1)
-	}
-	return v
+	return strings.Replace(v, "\\", "/", -1)
 }
 
 // GetRootFromPackage retrives the top level package from a name.

--- a/util/util.go
+++ b/util/util.go
@@ -29,13 +29,21 @@ func init() {
 	}
 }
 
+func toSlash(v string) string {
+	v = strings.Replace(v, "\\", "/", -1)
+	if os.PathSeparator != '\\' && os.PathSeparator != '/' {
+		v = strings.Replace(v, string(os.PathSeparator), "/", -1)
+	}
+	return v
+}
+
 // GetRootFromPackage retrives the top level package from a name.
 //
 // From a package name find the root repo. For example,
 // the package github.com/Masterminds/cookoo/io has a root repo
 // at github.com/Masterminds/cookoo
 func GetRootFromPackage(pkg string) string {
-	pkg = filepath.ToSlash(pkg)
+	pkg = toSlash(pkg)
 	for _, v := range vcsList {
 		m := v.regex.FindStringSubmatch(pkg)
 		if m == nil {
@@ -307,11 +315,11 @@ func NormalizeName(name string) (string, string) {
 	if err == nil {
 		p := filepath.Join(b.GOROOT, "src", name)
 		if _, err := os.Stat(p); err == nil {
-			return filepath.ToSlash(name), ""
+			return toSlash(name), ""
 		}
 	}
 
-	name = filepath.ToSlash(name)
+	name = toSlash(name)
 	root := GetRootFromPackage(name)
 	extra := strings.TrimPrefix(name, root)
 	if len(extra) > 0 && extra != "/" {


### PR DESCRIPTION
When the name passed to util.NormalizeName contains backslashes from a
Windows filepath, the backslashes must be first converted to forward
slashes (used by all package names, including on Windows).  This fixes
the strings.TrimPrefix call used to strip the repo root from the
subpackage.

As a result of this, subpackages in lockfiles are written identically
on Windows as other Unix platforms and no duplicate subpackages are
introduced.

Fixes #389.