### PR TITLE
Updating to VCS 1.6.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 3a5b11283c409c77e79505c08a39550a966d62fb0896f4355c10d699482840a3
-updated: 2016-04-18T09:49:03.335458835-04:00
+hash: 78e2fef6acf410a5c01231739017e3b0fe7762e815bf1a9b1e577ed5af1d5693
+updated: 2016-04-27T11:53:07.688047146-04:00
 imports:
 - name: github.com/codegangsta/cli
   version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
 - name: github.com/Masterminds/semver
   version: 808ed7761c233af2de3f9729a041d68c62527f3a
 - name: github.com/Masterminds/vcs
-  version: fa85cceafacd29c84a8aa6e68967bb9f1754e5e3
+  version: f6cc1e9e7389eea70d925c03eea2d6f8670f5109
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,8 @@ owners:
 import:
 - package: gopkg.in/yaml.v2
 - package: github.com/Masterminds/vcs
-  version: ^1.6.0
+  version: ^1.6.1
 - package: github.com/codegangsta/cli
+  version: ^1.14.0
 - package: github.com/Masterminds/semver
   version: ^1.0.0

--- a/vendor/github.com/Masterminds/vcs/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/vcs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.6.1 (2016-04-27)
+
+- Fixed #30: tags from commit should not have ^{} appended (seen in git)
+- Fixed #29: isDetachedHead fails with non-english locales (git)
+- Fixed #33: Access denied and not found http errors causing xml parsing errors
+
 # 1.6.0 (2016-04-18)
 
 - Issue #26: Added Init method to initialize a repo at the local location

--- a/vendor/github.com/Masterminds/vcs/vcs_remote_lookup_test.go
+++ b/vendor/github.com/Masterminds/vcs/vcs_remote_lookup_test.go
@@ -13,6 +13,8 @@ func TestVCSLookup(t *testing.T) {
 		"https://github.com/masterminds":                                   {work: false, t: Git},
 		"https://github.com/Masterminds/VCSTestRepo":                       {work: true, t: Git},
 		"https://bitbucket.org/mattfarina/testhgrepo":                      {work: true, t: Hg},
+		"https://bitbucket.org/mattfarina/repo-does-not-exist":             {work: false, t: Hg},
+		"https://bitbucket.org/mattfarina/private-repo-for-vcs-testing":    {work: false, t: Hg},
 		"https://launchpad.net/govcstestbzrrepo/trunk":                     {work: true, t: Bzr},
 		"https://launchpad.net/~mattfarina/+junk/mygovcstestbzrrepo":       {work: true, t: Bzr},
 		"https://launchpad.net/~mattfarina/+junk/mygovcstestbzrrepo/trunk": {work: true, t: Bzr},
@@ -54,6 +56,10 @@ func TestVCSLookup(t *testing.T) {
 
 		if err != nil && c.work == true {
 			t.Errorf("Error detecting VCS from URL(%s): %s", u, err)
+		}
+
+		if err != nil && err != ErrCannotDetectVCS && c.work == false {
+			t.Errorf("Unexpected error returned (%s): %s", u, err)
 		}
 
 		if c.work == true && ty != c.t {


### PR DESCRIPTION
Note, codegangsta/cli is set to use releases (which were recently
pushed). This ended up causing no change to cli as Glide was
already using the same commit.