### PR TITLE
Adds golang.org to vcsList

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -215,6 +215,10 @@ var vcsList = []*vcsInfo{
 		pattern: `^(?P<rootpkg>hub\.jazz\.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
 	},
 	{
+		host:    "golang.org",
+		pattern: `^(?P<rootpkg>golang\.org/x/[A-Za-z0-9_.\-]+)(/?[A-Za-z0-9_.\-]+)*$`,
+	},
+	{
 		host:    "go.googlesource.com",
 		pattern: `^(?P<rootpkg>go\.googlesource\.com/[A-Za-z0-9_.\-]+/?)$`,
 	},

--- a/util/util.go
+++ b/util/util.go
@@ -216,7 +216,7 @@ var vcsList = []*vcsInfo{
 	},
 	{
 		host:    "golang.org",
-		pattern: `^(?P<rootpkg>golang\.org/x/[A-Za-z0-9_.\-]+)(/?[A-Za-z0-9_.\-]+)*$`,
+		pattern: `^(?P<rootpkg>golang\.org/x/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
 	},
 	{
 		host:    "go.googlesource.com",


### PR DESCRIPTION
@mattfarina I have trouble to access golang.org in my network environment, so I use aliasing for it.

For example:
```yaml
- package: golang.org/x/net
  repo: https://github.com/golang/net.git
```

However, it doesn't work well with subpackages:
```
[WARN] golang.org/x/net/context appears to be a vendored package. Unable to update. Consider the '--update-vendored' flag.
[WARN] Unable to set version on golang.org/x/net/context to . Err: Cannot detect VCS
```

`glide` didn't realize that the root package of `golang.org/x/net/context` was `golang.org/x/net` which has been downloaded.

Explicitly adding golang.org into vcsList can fix this problem. I would be appreciated if you could accept this PR.