### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ glide.exe
 *.sublime-workspace
 dist/
 .DS_Store
+.idea


### PR DESCRIPTION
I'd like to start contributing glide, however I use IntelliJ as my IDE. IntelliJ creates a `.idea` directory in the root directory of whatever project you're working in. It's really not useful to share this directory across multiple developers so I'd like to add it to the `.gitignore`, that way I don't accidentally include it in future commits.