### PR TITLE
extract guessImportDeps function

### DIFF
--- a/action/create.go
+++ b/action/create.go
@@ -73,29 +73,7 @@ func guessDeps(base string, skipImport bool) *cfg.Config {
 
 	// Attempt to import from other package managers.
 	if !skipImport {
-		msg.Info("Attempting to import from other package managers (use --skip-import to skip)")
-		deps := []*cfg.Dependency{}
-		absBase, err := filepath.Abs(base)
-		if err != nil {
-			msg.Die("Failed to resolve location of %s: %s", base, err)
-		}
-
-		if d, ok := guessImportGodep(absBase); ok {
-			msg.Info("Importing Godep configuration")
-			msg.Warn("Godep uses commit id versions. Consider using Semantic Versions with Glide")
-			deps = d
-		} else if d, ok := guessImportGPM(absBase); ok {
-			msg.Info("Importing GPM configuration")
-			deps = d
-		} else if d, ok := guessImportGB(absBase); ok {
-			msg.Info("Importing GB configuration")
-			deps = d
-		}
-
-		for _, i := range deps {
-			msg.Info("Found imported reference to %s\n", i.Name)
-			config.Imports = append(config.Imports, i)
-		}
+		guessImportDeps(base, config)
 	}
 
 	// Resolve dependencies by looking at the tree.
@@ -145,6 +123,32 @@ func guessDeps(base string, skipImport bool) *cfg.Config {
 	}
 
 	return config
+}
+
+func guessImportDeps(base string, config *cfg.Config) {
+	msg.Info("Attempting to import from other package managers (use --skip-import to skip)")
+	deps := []*cfg.Dependency{}
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		msg.Die("Failed to resolve location of %s: %s", base, err)
+	}
+
+	if d, ok := guessImportGodep(absBase); ok {
+		msg.Info("Importing Godep configuration")
+		msg.Warn("Godep uses commit id versions. Consider using Semantic Versions with Glide")
+		deps = d
+	} else if d, ok := guessImportGPM(absBase); ok {
+		msg.Info("Importing GPM configuration")
+		deps = d
+	} else if d, ok := guessImportGB(absBase); ok {
+		msg.Info("Importing GB configuration")
+		deps = d
+	}
+
+	for _, i := range deps {
+		msg.Info("Found imported reference to %s\n", i.Name)
+		config.Imports = append(config.Imports, i)
+	}
 }
 
 func guessImportGodep(dir string) ([]*cfg.Dependency, bool) {


### PR DESCRIPTION
`guessDeps` is a rather long function (and there is a comment at the top acknowledging so). Let's try to extract to some of the functionality out of it to make it easier to read. This groups all of the Import related dependency guessing into a single function called `guestImportDeps` and moves that logic out of the `guessDeps` functions, making things more concise in `guessDeps`.

My long term plan is to keep refactoring this file until it's easier to test. This is a nice step in the direction of making this file more testable.