### PR TITLE
add ability to read symlink basedirs

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -166,6 +166,13 @@ func NewResolver(basedir string) (*Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	basedir, err = checkForBasedirSymlink(basedir)
+
+	if err != nil {
+		return nil, err
+	}
+
 	vdir := filepath.Join(basedir, "vendor")
 
 	buildContext, err := util.GetBuildContext()
@@ -939,4 +946,21 @@ func srcDir(fi os.FileInfo) bool {
 	}
 
 	return true
+}
+
+// checkForBasedirSymlink checks to see if the given basedir is actually a
+// symlink. In the case that it is a symlink, the symlink is read and returned.
+// If the basedir is not a symlink, the provided basedir argument is simply
+// returned back to the caller.
+func checkForBasedirSymlink(basedir string) (string, error) {
+	fi, err := os.Lstat(basedir)
+	if err != nil {
+		return "", err
+	}
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return os.Readlink(basedir)
+	}
+
+	return basedir, nil
 }


### PR DESCRIPTION
Imagine the following scenario: A user has a Go project. This directory is sitting in an arbitrary location in their file system and the user would like to keep it there. However, they need it to work with Go tooling, so they symlink it into an appropriate location in their GOPATH, e.g. `$GOPATH/src/github.com/user1/myproject`. The user then decides they's like to start using glide, so they cd to `$GOPATH/src/github.com/user1/myproject` and run `glide create` to generate their initial `glide.yaml` file. The result is the creation of empty `glide.yaml` file. Sad times.

What's happening is that the `basedir` given to `NewResolver` is actually a symlink. This in turn causes an issue in the `ResolveLocal` function. The `if !fi.IsDir()` check fails since the basedir isn't actually a directory, it's a symlink.

Let's add a check to the `NewResolver` function. After getting the absolute path of the provided `basedir`, let's check to see if it's a symlink. If it is, read the symlink and use that as the basedir instead. If not, proceed as normal.