### PR TITLE
export GO15VENDOREXPERIMENT only on 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To build from source you can:
 1. Clone this repository into `$GOPATH/src/github.com/Masterminds/glide` and
    change directory into it
 2. Ensure that the environment variable GO15VENDOREXPERIMENT is set, for
-   example by running `export GO15VENDOREXPERIMENT=1`
+   example by running `export GO15VENDOREXPERIMENT=1` when using GO 1.5. Go 1.6 release makes vendoring behaviour the default.
 3. Run `make build`
 
 This will leave you with `./glide`, which you can put in your `$PATH` if


### PR DESCRIPTION
I am not entirely sure if this is the correct explanation in the context of this project but https://github.com/golang/go/wiki/PackageManagementTools suggests that `GO15VENDOREXPERIMENT` is for 1.5 Go release. 1.6 release makes the vendoring the default behavior.