### PR TITLE
Resolve Test Imports

### DIFF
--- a/action/config_wizard.go
+++ b/action/config_wizard.go
@@ -51,6 +51,11 @@ func ConfigWizard(base string) {
 			deps = append(deps, dep)
 		}
 	}
+	for _, dep := range conf.DevImports {
+		if wizardLookInto(dep) {
+			deps = append(deps, dep)
+		}
+	}
 
 	msg.Info("Gathering information on each dependency")
 	msg.Info("--> This may take a moment. Especially on a codebase with many dependencies")

--- a/action/create.go
+++ b/action/create.go
@@ -108,6 +108,9 @@ func guessDeps(base string, skipImport bool) *cfg.Config {
 		msg.Die("Error creating a dependency resolver: %s", err)
 	}
 
+	// When creating resolve the test dependencies as well as the application ones.
+	r.ResolveTest = true
+
 	h := &dependency.DefaultMissingPackageHandler{Missing: []string{}, Gopath: []string{}}
 	r.Handler = h
 

--- a/action/get.go
+++ b/action/get.go
@@ -217,7 +217,7 @@ func addPkgsToConfig(conf *cfg.Config, names []string, insecure, nonInteract, te
 		if dep.Reference != "" {
 			msg.Info("--> Adding %s to your configuration with the version %s", dep.Name, dep.Reference)
 		} else {
-			msg.Info("--> Adding %s to your configuration %s", dep.Name)
+			msg.Info("--> Adding %s to your configuration", dep.Name)
 		}
 
 		if testDeps {

--- a/action/get.go
+++ b/action/get.go
@@ -43,7 +43,7 @@ func Get(names []string, installer *repo.Installer, insecure, skipRecursive, str
 	// Fetch the new packages. Can't resolve versions via installer.Update if
 	// get is called while the vendor/ directory is empty so we checkout
 	// everything.
-	err = installer.Checkout(conf, false)
+	err = installer.Checkout(conf)
 	if err != nil {
 		msg.Die("Failed to checkout packages: %s", err)
 	}
@@ -68,7 +68,7 @@ func Get(names []string, installer *repo.Installer, insecure, skipRecursive, str
 	}
 
 	// Set Reference
-	if err := repo.SetReference(confcopy); err != nil {
+	if err := repo.SetReference(confcopy, installer.ResolveTest); err != nil {
 		msg.Err("Failed to set references: %s", err)
 	}
 
@@ -112,7 +112,7 @@ func writeLock(conf, confcopy *cfg.Config, base string) {
 	if err != nil {
 		msg.Die("Failed to generate config hash. Unable to generate lock file.")
 	}
-	lock := cfg.NewLockfile(confcopy.Imports, hash)
+	lock := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
 	if err := lock.WriteFile(filepath.Join(base, gpath.LockFile)); err != nil {
 		msg.Die("Failed to write glide lock file: %s", err)
 	}

--- a/action/get_test.go
+++ b/action/get_test.go
@@ -24,7 +24,7 @@ func TestAddPkgsToConfig(t *testing.T) {
 		"github.com/Masterminds/semver",
 	}
 
-	addPkgsToConfig(conf, names, false, true)
+	addPkgsToConfig(conf, names, false, true, false)
 
 	if !conf.HasDependency("github.com/Masterminds/semver") {
 		t.Error("addPkgsToConfig failed to add github.com/Masterminds/semver")

--- a/action/install.go
+++ b/action/install.go
@@ -53,7 +53,7 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 	msg.Info("Setting references.")
 
 	// Set reference
-	if err := repo.SetReference(newConf); err != nil {
+	if err := repo.SetReference(newConf, installer.ResolveTest); err != nil {
 		msg.Err("Failed to set references: %s (Skip to cleanup)", err)
 	}
 

--- a/action/list.go
+++ b/action/list.go
@@ -28,7 +28,7 @@ func List(basedir string, deep bool, format string) {
 	h := &dependency.DefaultMissingPackageHandler{Missing: []string{}, Gopath: []string{}}
 	r.Handler = h
 
-	localPkgs, err := r.ResolveLocal(deep)
+	localPkgs, _, err := r.ResolveLocal(deep)
 	if err != nil {
 		msg.Die("Error listing dependencies: %s", err)
 	}

--- a/action/remove.go
+++ b/action/remove.go
@@ -27,7 +27,7 @@ func Remove(packages []string, inst *repo.Installer) {
 
 	confcopy.Imports = inst.List(confcopy)
 
-	if err := repo.SetReference(confcopy); err != nil {
+	if err := repo.SetReference(confcopy, inst.ResolveTest); err != nil {
 		msg.Err("Failed to set references: %s", err)
 	}
 

--- a/action/update.go
+++ b/action/update.go
@@ -30,13 +30,13 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 	}
 
 	// Try to check out the initial dependencies.
-	if err := installer.Checkout(conf, false); err != nil {
+	if err := installer.Checkout(conf); err != nil {
 		msg.Die("Failed to do initial checkout of config: %s", err)
 	}
 
 	// Set the versions for the initial dependencies so that resolved dependencies
 	// are rooted in the correct version of the base.
-	if err := repo.SetReference(conf); err != nil {
+	if err := repo.SetReference(conf, installer.ResolveTest); err != nil {
 		msg.Die("Failed to set initial config references: %s", err)
 	}
 
@@ -51,15 +51,11 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 			msg.Die("Could not update packages: %s", err)
 		}
 
-		// TODO: There is no support here for importing Godeps, GPM, and GB files.
-		// I think that all we really need to do now is hunt for these files, and then
-		// roll their version numbers into the config file.
-
 		// Set references. There may be no remaining references to set since the
 		// installer set them as it went to make sure it parsed the right imports
 		// from the right version of the package.
 		msg.Info("Setting references for remaining imports")
-		if err := repo.SetReference(confcopy); err != nil {
+		if err := repo.SetReference(confcopy, installer.ResolveTest); err != nil {
 			msg.Err("Failed to set references: %s (Skip to cleanup)", err)
 		}
 	}
@@ -90,7 +86,7 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 		if err != nil {
 			msg.Die("Failed to generate config hash. Unable to generate lock file.")
 		}
-		lock := cfg.NewLockfile(confcopy.Imports, hash)
+		lock := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
 		wl := true
 		if gpath.HasLock(base) {
 			yml, err := ioutil.ReadFile(filepath.Join(base, gpath.LockFile))

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -51,7 +51,7 @@ type Config struct {
 
 	// DevImports contains the test or other development imports for a project.
 	// See the Dependency type for more details on how this is recorded.
-	DevImports Dependencies `yaml:"devimport,omitempty"`
+	DevImports Dependencies `yaml:"testImport,omitempty"`
 }
 
 // A transitive representation of a dependency for importing and exporting to yaml.
@@ -64,7 +64,7 @@ type cf struct {
 	Ignore      []string     `yaml:"ignore,omitempty"`
 	Exclude     []string     `yaml:"excludeDirs,omitempty"`
 	Imports     Dependencies `yaml:"import"`
-	DevImports  Dependencies `yaml:"devimport,omitempty"`
+	DevImports  Dependencies `yaml:"testImport,omitempty"`
 }
 
 // ConfigFromYaml returns an instance of Config from YAML

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -298,6 +298,16 @@ func (d Dependencies) Get(name string) *Dependency {
 	return nil
 }
 
+// Has checks if a dependency is on a list of dependencies such as import or devimport
+func (d Dependencies) Has(name string) bool {
+	for _, dep := range d {
+		if dep.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // Clone performs a deep clone of Dependencies
 func (d Dependencies) Clone() Dependencies {
 	n := make(Dependencies, 0, len(d))

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -308,6 +308,23 @@ func (d Dependencies) Has(name string) bool {
 	return false
 }
 
+// Remove removes a dependency from a list of dependencies
+func (d Dependencies) Remove(name string) Dependencies {
+	found := -1
+	for i, dep := range d {
+		if dep.Name == name {
+			found = i
+		}
+	}
+
+	if found >= 0 {
+		copy(d[found:], d[found+1:])
+		d[len(d)-1] = nil
+		return d[:len(d)-1]
+	}
+	return d
+}
+
 // Clone performs a deep clone of Dependencies
 func (d Dependencies) Clone() Dependencies {
 	n := make(Dependencies, 0, len(d))

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -131,11 +131,12 @@ func (l *Lock) Clone() *Lock {
 }
 
 // NewLockfile is used to create an instance of Lockfile.
-func NewLockfile(ds Dependencies, hash string) *Lockfile {
+func NewLockfile(ds, tds Dependencies, hash string) *Lockfile {
 	lf := &Lockfile{
-		Hash:    hash,
-		Updated: time.Now(),
-		Imports: make([]*Lock, len(ds)),
+		Hash:       hash,
+		Updated:    time.Now(),
+		Imports:    make([]*Lock, len(ds)),
+		DevImports: make([]*Lock, len(tds)),
 	}
 
 	for i := 0; i < len(ds); i++ {
@@ -151,6 +152,20 @@ func NewLockfile(ds Dependencies, hash string) *Lockfile {
 	}
 
 	sort.Sort(lf.Imports)
+
+	for i := 0; i < len(tds); i++ {
+		lf.DevImports[i] = &Lock{
+			Name:        tds[i].Name,
+			Version:     tds[i].Pin,
+			Repository:  tds[i].Repository,
+			VcsType:     tds[i].VcsType,
+			Subpackages: tds[i].Subpackages,
+			Arch:        tds[i].Arch,
+			Os:          tds[i].Os,
+		}
+	}
+
+	sort.Sort(lf.DevImports)
 
 	return lf
 }

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -15,7 +15,7 @@ type Lockfile struct {
 	Hash       string    `yaml:"hash"`
 	Updated    time.Time `yaml:"updated"`
 	Imports    Locks     `yaml:"imports"`
-	DevImports Locks     `yaml:"devImports"`
+	DevImports Locks     `yaml:"testImports"`
 }
 
 // LockfileFromYaml returns an instance of Lockfile from YAML

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -464,7 +464,6 @@ func (r *Resolver) resolveImports(queue *list.List, testDeps, addTest bool) ([]s
 			continue
 		}
 		r.VersionHandler.Process(dep)
-
 		// Here, we want to import the package and see what imports it has.
 		msg.Debug("Trying to open %s", vdep)
 		var imps []string
@@ -859,8 +858,14 @@ func (r *Resolver) imports(pkg string, testDeps, addTest bool) ([]string, error)
 func sliceToQueue(deps []*cfg.Dependency, basepath string) *list.List {
 	l := list.New()
 	for _, e := range deps {
-		msg.Debug("Adding local Import %s to queue", e.Name)
-		l.PushBack(filepath.Join(basepath, filepath.FromSlash(e.Name)))
+		for _, v := range e.Subpackages {
+			ip := e.Name
+			if v != "." && v != "" {
+				ip = ip + "/" + v
+			}
+			msg.Debug("Adding local Import %s to queue", ip)
+			l.PushBack(filepath.Join(basepath, filepath.FromSlash(ip)))
+		}
 	}
 	return l
 }

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -2,7 +2,6 @@ package dependency
 
 import (
 	"container/list"
-	"fmt"
 	"runtime"
 	//"go/build"
 	"os"
@@ -865,7 +864,6 @@ func sliceToQueue(deps []*cfg.Dependency, basepath string) *list.List {
 				if v != "." && v != "" {
 					ip = ip + "/" + v
 				}
-				fmt.Println(ip)
 				msg.Debug("Adding local Import %s to queue", ip)
 				l.PushBack(filepath.Join(basepath, filepath.FromSlash(ip)))
 			}

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -2,6 +2,7 @@ package dependency
 
 import (
 	"container/list"
+	"fmt"
 	"runtime"
 	//"go/build"
 	"os"
@@ -858,14 +859,21 @@ func (r *Resolver) imports(pkg string, testDeps, addTest bool) ([]string, error)
 func sliceToQueue(deps []*cfg.Dependency, basepath string) *list.List {
 	l := list.New()
 	for _, e := range deps {
-		for _, v := range e.Subpackages {
-			ip := e.Name
-			if v != "." && v != "" {
-				ip = ip + "/" + v
+		if len(e.Subpackages) > 0 {
+			for _, v := range e.Subpackages {
+				ip := e.Name
+				if v != "." && v != "" {
+					ip = ip + "/" + v
+				}
+				fmt.Println(ip)
+				msg.Debug("Adding local Import %s to queue", ip)
+				l.PushBack(filepath.Join(basepath, filepath.FromSlash(ip)))
 			}
-			msg.Debug("Adding local Import %s to queue", ip)
-			l.PushBack(filepath.Join(basepath, filepath.FromSlash(ip)))
+		} else {
+			msg.Debug("Adding local Import %s to queue", e.Name)
+			l.PushBack(filepath.Join(basepath, filepath.FromSlash(e.Name)))
 		}
+
 	}
 	return l
 }

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -215,18 +215,18 @@ func NewResolver(basedir string) (*Resolver, error) {
 // If basepath is set to $GOPATH, this will start from that package's root there.
 // If basepath is set to a project's vendor path, the scanning will begin from
 // there.
-// func (r *Resolver) Resolve(pkg, basepath string) ([]string, error) {
-// 	target := filepath.Join(basepath, filepath.FromSlash(pkg))
-// 	//msg.Debug("Scanning %s", target)
-// 	l := list.New()
-// 	l.PushBack(target)
-//
-// 	// In this mode, walk the entire tree.
-// 	if r.ResolveAllFiles {
-// 		return r.resolveList(l, false, false)
-// 	}
-// 	return r.resolveImports(l, false, false)
-// }
+func (r *Resolver) Resolve(pkg, basepath string) ([]string, error) {
+	target := filepath.Join(basepath, filepath.FromSlash(pkg))
+	//msg.Debug("Scanning %s", target)
+	l := list.New()
+	l.PushBack(target)
+
+	// In this mode, walk the entire tree.
+	if r.ResolveAllFiles {
+		return r.resolveList(l, false, false)
+	}
+	return r.resolveImports(l, false, false)
+}
 
 // dirHasPrefix tests whether the directory dir begins with prefix.
 func dirHasPrefix(dir, prefix string) bool {

--- a/dependency/resolver_test.go
+++ b/dependency/resolver_test.go
@@ -15,7 +15,7 @@ func TestResolveLocalShallow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	l, err := r.ResolveLocal(false)
+	l, _, err := r.ResolveLocal(false)
 	if err != nil {
 		t.Fatalf("Failed to resolve: %s", err)
 	}
@@ -47,7 +47,7 @@ func TestResolveLocalDeep(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	l, err := r.ResolveLocal(true)
+	l, _, err := r.ResolveLocal(true)
 	if err != nil {
 		t.Fatalf("Failed to resolve: %s", err)
 	}

--- a/dependency/resolver_test.go
+++ b/dependency/resolver_test.go
@@ -91,7 +91,7 @@ func TestResolveAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("No new resolver: %s", err)
 	}
-	l, err := r.ResolveAll(deps)
+	l, err := r.ResolveAll(deps, false)
 	if err != nil {
 		t.Fatalf("Failed to resolve: %s", err)
 	}

--- a/docs/glide.yaml.md
+++ b/docs/glide.yaml.md
@@ -44,4 +44,4 @@ These elements are:
     - `subpackages`: A record of packages being used within a repository. This does not include all packages within a repository but rather those being used.
     - `os`: A list of operating systems used for filtering. If set it will compare the current runtime OS to the one specified and only fetch the dependency if there is a match. If not set filtering is skipped. The names are the same used in build flags and `GOOS` environment variable.
     - `arch`: A list of architectures used for filtering. If set it will compare the current runtime architecture to the one specified and only fetch the dependency if there is a match. If not set filtering is skipped. The names are the same used in build flags and `GOARCH` environment variable.
-- `devImport`: A list of development packages. Each package has the same details as those listed under import.
+- `testImport`: A list of packages used in tests that are not already listed in `import`. Each package has the same details as those listed under import.

--- a/glide.go
+++ b/glide.go
@@ -203,6 +203,10 @@ func commands() []cli.Command {
    folder.`,
 			Flags: []cli.Flag{
 				cli.BoolFlag{
+					Name:  "test",
+					Usage: "Add test dependencies.",
+				},
+				cli.BoolFlag{
 					Name:  "insecure",
 					Usage: "Use http:// rather than https:// to retrieve pacakges.",
 				},
@@ -280,7 +284,7 @@ func commands() []cli.Command {
 				inst.ResolveTest = !c.Bool("skip-test")
 				packages := []string(c.Args())
 				insecure := c.Bool("insecure")
-				action.Get(packages, inst, insecure, c.Bool("no-recursive"), c.Bool("strip-vcs"), c.Bool("strip-vendor"), c.Bool("non-interactive"))
+				action.Get(packages, inst, insecure, c.Bool("no-recursive"), c.Bool("strip-vcs"), c.Bool("strip-vendor"), c.Bool("non-interactive"), c.Bool("test"))
 			},
 		},
 		{

--- a/glide.go
+++ b/glide.go
@@ -250,6 +250,10 @@ func commands() []cli.Command {
 					Name:  "non-interactive",
 					Usage: "Disable interactive prompts.",
 				},
+				cli.BoolFlag{
+					Name:  "skip-test",
+					Usage: "Resolve dependencies in test files.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				if c.Bool("strip-vendor") && !c.Bool("strip-vcs") {
@@ -273,6 +277,7 @@ func commands() []cli.Command {
 				inst.UseCacheGopath = c.Bool("cache-gopath")
 				inst.UpdateVendored = c.Bool("update-vendored")
 				inst.ResolveAllFiles = c.Bool("all-dependencies")
+				inst.ResolveTest = !c.Bool("skip-test")
 				packages := []string(c.Args())
 				insecure := c.Bool("insecure")
 				action.Get(packages, inst, insecure, c.Bool("no-recursive"), c.Bool("strip-vcs"), c.Bool("strip-vendor"), c.Bool("non-interactive"))
@@ -456,6 +461,10 @@ Example:
 					Name:  "strip-vendor, v",
 					Usage: "Removes nested vendor and Godeps/_workspace directories. Requires --strip-vcs.",
 				},
+				cli.BoolFlag{
+					Name:  "skip-test",
+					Usage: "Resolve dependencies in test files.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				if c.Bool("strip-vendor") && !c.Bool("strip-vcs") {
@@ -470,6 +479,7 @@ Example:
 				installer.UpdateVendored = c.Bool("update-vendored")
 				installer.Home = c.GlobalString("home")
 				installer.DeleteUnused = c.Bool("delete")
+				installer.ResolveTest = !c.Bool("skip-test")
 
 				action.Install(installer, c.Bool("strip-vcs"), c.Bool("strip-vendor"))
 			},

--- a/glide.go
+++ b/glide.go
@@ -563,6 +563,10 @@ Example:
 					Name:  "strip-vendor, v",
 					Usage: "Removes nested vendor and Godeps/_workspace directories. Requires --strip-vcs.",
 				},
+				cli.BoolFlag{
+					Name:  "skip-test",
+					Usage: "Resolve dependencies in test files.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				if c.Bool("strip-vendor") && !c.Bool("strip-vcs") {
@@ -583,6 +587,7 @@ Example:
 				installer.ResolveAllFiles = c.Bool("all-dependencies")
 				installer.Home = c.GlobalString("home")
 				installer.DeleteUnused = c.Bool("delete")
+				installer.ResolveTest = !c.Bool("skip-test")
 
 				action.Update(installer, c.Bool("no-recursive"), c.Bool("strip-vcs"), c.Bool("strip-vendor"))
 			},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ebc39e5b2036ba2235316f2897fb9f2e696c6a7d5389416812722cc8ed3dfa21
-updated: 2016-05-05T09:44:44.751721442-04:00
+updated: 2016-06-10T16:27:29.24243625-04:00
 imports:
 - name: github.com/codegangsta/cli
   version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
@@ -9,4 +9,4 @@ imports:
   version: 7af28b64c5ec41b1558f5514fd938379822c237c
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
-devImports: []
+testImports: []

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -225,7 +225,7 @@ func (i *Installer) Update(conf *cfg.Config) error {
 			}
 			if d == nil {
 				nd := &cfg.Dependency{
-					Name: n,
+					Name: rt,
 				}
 				if sub != "" {
 					nd.Subpackages = []string{sub}

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -124,6 +124,8 @@ func (i *Installer) Install(lock *cfg.Lockfile, conf *cfg.Config) (*cfg.Config, 
 		return newConf, nil
 	}
 
+	msg.Info("Downloading dependencies. Please wait...")
+
 	ConcurrentUpdate(newConf.Imports, cwd, i, newConf)
 	ConcurrentUpdate(newConf.DevImports, cwd, i, newConf)
 	return newConf, nil
@@ -136,6 +138,8 @@ func (i *Installer) Install(lock *cfg.Lockfile, conf *cfg.Config) (*cfg.Config, 
 func (i *Installer) Checkout(conf *cfg.Config) error {
 
 	dest := i.VendorPath()
+
+	msg.Info("Downloading dependencies. Please wait...")
 
 	if err := ConcurrentUpdate(conf.Imports, dest, i, conf); err != nil {
 		return err
@@ -254,6 +258,8 @@ func (i *Installer) Update(conf *cfg.Config) error {
 		}
 	}
 
+	msg.Info("Downloading dependencies. Please wait...")
+
 	err = ConcurrentUpdate(conf.Imports, vpath, i, conf)
 	if err != nil {
 		return err
@@ -318,8 +324,6 @@ func ConcurrentUpdate(deps []*cfg.Dependency, cwd string, i *Installer, c *cfg.C
 	var wg sync.WaitGroup
 	var lock sync.Mutex
 	var returnErr error
-
-	msg.Info("Downloading dependencies. Please wait...")
 
 	for ii := 0; ii < concurrentWorkers; ii++ {
 		go func(ch <-chan *cfg.Dependency) {

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -202,16 +202,17 @@ func (i *Installer) Update(conf *cfg.Config) error {
 	for _, v := range imps {
 		n := res.Stripv(v)
 		rt, sub := util.NormalizeName(n)
+		if sub != "" {
+			sub = "."
+		}
 		d := conf.Imports.Get(rt)
 		if d == nil {
 			nd := &cfg.Dependency{
-				Name: rt,
-			}
-			if sub != "" {
-				nd.Subpackages = []string{sub}
+				Name:        rt,
+				Subpackages: []string{sub},
 			}
 			conf.Imports = append(conf.Imports, nd)
-		} else if sub != "" && !d.HasSubpackage(sub) {
+		} else if !d.HasSubpackage(sub) {
 			d.Subpackages = append(d.Subpackages, sub)
 		}
 	}
@@ -219,19 +220,20 @@ func (i *Installer) Update(conf *cfg.Config) error {
 		for _, v := range timps {
 			n := res.Stripv(v)
 			rt, sub := util.NormalizeName(n)
+			if sub != "" {
+				sub = "."
+			}
 			d := conf.Imports.Get(rt)
 			if d == nil {
 				d = conf.DevImports.Get(rt)
 			}
 			if d == nil {
 				nd := &cfg.Dependency{
-					Name: rt,
-				}
-				if sub != "" {
-					nd.Subpackages = []string{sub}
+					Name:        rt,
+					Subpackages: []string{sub},
 				}
 				conf.DevImports = append(conf.DevImports, nd)
-			} else if sub != "" && !d.HasSubpackage(sub) {
+			} else if !d.HasSubpackage(sub) {
 				d.Subpackages = append(d.Subpackages, sub)
 			}
 		}

--- a/repo/set_reference.go
+++ b/repo/set_reference.go
@@ -10,14 +10,14 @@ import (
 
 // SetReference is a command to set the VCS reference (commit id, tag, etc) for
 // a project.
-func SetReference(conf *cfg.Config) error {
+func SetReference(conf *cfg.Config, resolveTest bool) error {
 
 	cwd, err := gpath.Vendor()
 	if err != nil {
 		return err
 	}
 
-	if len(conf.Imports) == 0 {
+	if len(conf.Imports) == 0 && len(conf.DevImports) == 0 {
 		msg.Info("No references set.\n")
 		return nil
 	}
@@ -46,6 +46,15 @@ func SetReference(conf *cfg.Config) error {
 		if !conf.HasIgnore(dep.Name) {
 			wg.Add(1)
 			in <- dep
+		}
+	}
+
+	if resolveTest {
+		for _, dep := range conf.DevImports {
+			if !conf.HasIgnore(dep.Name) {
+				wg.Add(1)
+				in <- dep
+			}
 		}
 	}
 

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -36,7 +36,7 @@ func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGo
 	}
 	updated.Add(dep.Name)
 
-	msg.Info("Fetching updates for %s.", dep.Name)
+	msg.Info("--> Fetching updates for %s.", dep.Name)
 
 	if filterArchOs(dep) {
 		msg.Info("%s is not used for %s/%s.\n", dep.Name, runtime.GOOS, runtime.GOARCH)
@@ -207,7 +207,7 @@ func VcsVersion(dep *cfg.Dependency, vend string) error {
 		// If there is a ^ prefix we assume it's a semver constraint rather than
 		// part of the git/VCS commit id.
 		if repo.IsReference(ver) && !strings.HasPrefix(ver, "^") {
-			msg.Info("Setting version for %s to %s.\n", dep.Name, ver)
+			msg.Info("--> Setting version for %s to %s.\n", dep.Name, ver)
 		} else {
 
 			// Create the constraing first to make sure it's valid before
@@ -242,9 +242,9 @@ func VcsVersion(dep *cfg.Dependency, vend string) error {
 				}
 			}
 			if found {
-				msg.Info("Detected semantic version. Setting version for %s to %s.\n", dep.Name, ver)
+				msg.Info("--> Detected semantic version. Setting version for %s to %s.", dep.Name, ver)
 			} else {
-				msg.Warn("Unable to find semantic version for constraint %s %s\n", dep.Name, ver)
+				msg.Warn("--> Unable to find semantic version for constraint %s %s", dep.Name, ver)
 			}
 		}
 		if err := repo.UpdateVersion(ver); err != nil {

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -36,7 +36,7 @@ func VcsUpdate(dep *cfg.Dependency, dest, home string, cache, cacheGopath, useGo
 	}
 	updated.Add(dep.Name)
 
-	msg.Info("Fetching updates for %s.\n", dep.Name)
+	msg.Info("Fetching updates for %s.", dep.Name)
 
 	if filterArchOs(dep) {
 		msg.Info("%s is not used for %s/%s.\n", dep.Name, runtime.GOOS, runtime.GOARCH)

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -59,7 +59,7 @@ func walkDeps(b *util.BuildCtxt, base, myName string) []string {
 			// declared. This is often because of an example with a package
 			// or main but +build ignore as a build tag. In that case we
 			// try to brute force the packages with a slower scan.
-			imps, err = dependency.IterativeScan(path)
+			imps, _, err = dependency.IterativeScan(path)
 			if err != nil {
 				msg.Err("Error walking dependencies for %s: %s", path, err)
 				return err


### PR DESCRIPTION
This is ready to be tested. `glide init` finds test dependencies. `glide update` resolves their tree, unless flag opts-out, and `glide install` will install them (unless opt-out flag is used).

Note, test dependencies in vendor/ are not handled. Just those in local codebase.