### PR TITLE
Fix indentation of example glide.yaml

### DIFF
--- a/docs/glide.yaml.md
+++ b/docs/glide.yaml.md
@@ -9,9 +9,9 @@ The `glide.yaml` file contains information about the project and the dependent p
     - name: Matt Butcher
       email: technosophos@gmail.com
       homepage: http://technosophos.com
-      - name: Matt Farina
-        email: matt@mattfarina.com
-        homepage: https://www.mattfarina.com
+    - name: Matt Farina
+      email: matt@mattfarina.com
+      homepage: https://www.mattfarina.com
     ignore:
     - appengine
     excludeDirs:


### PR DESCRIPTION
Make the indentation level for both `owners` the same.