### PR TITLE
Fix NormalizeName for subpackage of unknown host

### DIFF
--- a/util/normalizename_test.go
+++ b/util/normalizename_test.go
@@ -31,11 +31,18 @@ func TestNormalizeName(t *testing.T) {
 			extra: "",
 		},
 		{
+			input: "otherurl/example/root/sub",
+			root:  "otherurl/example/root",
+			extra: "sub",
+		},
+		{
 			input: "net",
 			root:  "net",
 			extra: "",
 		},
 	}
+	remotePackageCache["otherurl/example/root"] = "otherurl/example/root"
+
 	for _, test := range packages {
 		root, extra := NormalizeName(test.input)
 		if root != test.root {

--- a/util/util.go
+++ b/util/util.go
@@ -110,7 +110,7 @@ var remotePackageCache = make(map[string]string)
 
 func checkRemotePackageCache(pkg string) (string, bool) {
 	for k, v := range remotePackageCache {
-		if pkg == k {
+		if pkg == k || strings.HasPrefix(pkg, k + "/") {
 			return v, true
 		}
 	}
@@ -290,7 +290,7 @@ func GetBuildContext() (*BuildCtxt, error) {
 		out, err := exec.Command(goExecutable, "env", "GOROOT").Output()
 		if goRoot = strings.TrimSpace(string(out)); len(goRoot) == 0 || err != nil {
 			return nil, fmt.Errorf("Please set the $GOROOT environment " +
-				"variable to use this command\n")
+			"variable to use this command\n")
 		}
 		buildContext.GOROOT = goRoot
 	}


### PR DESCRIPTION
When import unknown host package with sub, glide show following error.

when,
```
import:
- package: otherurl/example/root
  repo: git@otherurl:example/root.git
  vcs: git
  subpackages:
  - sub
```
then,
```
[INFO]  Downloading dependencies. Please wait...
[INFO]  --> Fetching updates for otherurl/example/root/sub.
[WARN]  otherurl/example/root/sub appears to be a vendored package. Unable to update. Consider the '--update-vendored' flag.
[ERROR] Failed to set version on otherurl/example/root/sub to : Cannot detect VCS
```

Because `getRootFromGoGet(pkg string) string` method get `https://otherurl/example/root/sub` and it failed.

But, fetching root is success and cached in `remotePackageCache`, so compare prefix to cached packages.

Does this resolve #469 ?