### PR TITLE
fix for #483

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -27,7 +27,7 @@ The `x`, `X`, and `*` characters can be used as a wildcard character. This works
 
 * `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
 * `>= 1.2.x` is equivalent to `>= 1.2.0`
-* `<= 2.x` is equivalent to `<= 3`
+* `<= 2.x` is equivalent to `< 3`
 * `*` is equivalent to `>= 0.0.0`
 
 ## Tilde Range Comparisons (Patch)


### PR DESCRIPTION
Per #483, "<= 2.x is equivalent to <= 3" should actually be "< 3" since
3.0 does not satisfy `<= 2.x`.