### PR TITLE
Make shared funcs for lockfile usage

### DIFF
--- a/action/install.go
+++ b/action/install.go
@@ -1,7 +1,6 @@
 package action
 
 import (
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/Masterminds/glide/cache"
@@ -31,9 +30,16 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 		return
 	}
 	// Load lockfile
-	lock, err := LoadLockfile(base, conf)
+	lock, err := cfg.ReadLockFile(filepath.Join(base, gpath.LockFile))
 	if err != nil {
 		msg.Die("Could not load lockfile.")
+	}
+	// Verify lockfile hasn't changed
+	hash, err := conf.Hash()
+	if err != nil {
+		msg.Die("Could not load lockfile.")
+	} else if hash != lock.Hash {
+		msg.Warn("Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'")
 	}
 
 	// Delete unused packages
@@ -76,29 +82,4 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 			msg.Err("Unable to strip vendor directories: %s", err)
 		}
 	}
-}
-
-// LoadLockfile loads the contents of a glide.lock file.
-//
-// TODO: This should go in another package.
-func LoadLockfile(base string, conf *cfg.Config) (*cfg.Lockfile, error) {
-	yml, err := ioutil.ReadFile(filepath.Join(base, gpath.LockFile))
-	if err != nil {
-		return nil, err
-	}
-	lock, err := cfg.LockfileFromYaml(yml)
-	if err != nil {
-		return nil, err
-	}
-
-	hash, err := conf.Hash()
-	if err != nil {
-		return nil, err
-	}
-
-	if hash != lock.Hash {
-		msg.Warn("Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'")
-	}
-
-	return lock, nil
 }

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -390,6 +390,19 @@ type dep struct {
 	Os          []string `yaml:"os,omitempty"`
 }
 
+// DependencyFromLock converts a Lock to a Dependency
+func DependencyFromLock(lock *Lock) *Dependency {
+	return &Dependency{
+		Name:        lock.Name,
+		Reference:   lock.Version,
+		Repository:  lock.Repository,
+		VcsType:     lock.VcsType,
+		Subpackages: lock.Subpackages,
+		Arch:        lock.Arch,
+		Os:          lock.Os,
+	}
+}
+
 // UnmarshalYAML is a hook for gopkg.in/yaml.v2 in the unmarshaling process
 func (d *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	newDep := &dep{}

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -72,6 +72,19 @@ func (lf *Lockfile) Fingerprint() ([32]byte, error) {
 	return sha256.Sum256(yml), nil
 }
 
+// ReadLockFile loads the contents of a glide.lock file.
+func ReadLockFile(lockpath string) (*Lockfile, error) {
+	yml, err := ioutil.ReadFile(lockpath)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := LockfileFromYaml(yml)
+	if err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
 // Locks is a slice of locked dependencies.
 type Locks []*Lock
 

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -130,6 +130,19 @@ func (l *Lock) Clone() *Lock {
 	}
 }
 
+// LockFromDependency converts a Dependency to a Lock
+func LockFromDependency(dep *Dependency) *Lock {
+	return &Lock{
+		Name:        dep.Name,
+		Version:     dep.Pin,
+		Repository:  dep.Repository,
+		VcsType:     dep.VcsType,
+		Subpackages: dep.Subpackages,
+		Arch:        dep.Arch,
+		Os:          dep.Os,
+	}
+}
+
 // NewLockfile is used to create an instance of Lockfile.
 func NewLockfile(ds, tds Dependencies, hash string) *Lockfile {
 	lf := &Lockfile{
@@ -140,29 +153,13 @@ func NewLockfile(ds, tds Dependencies, hash string) *Lockfile {
 	}
 
 	for i := 0; i < len(ds); i++ {
-		lf.Imports[i] = &Lock{
-			Name:        ds[i].Name,
-			Version:     ds[i].Pin,
-			Repository:  ds[i].Repository,
-			VcsType:     ds[i].VcsType,
-			Subpackages: ds[i].Subpackages,
-			Arch:        ds[i].Arch,
-			Os:          ds[i].Os,
-		}
+		lf.Imports[i] = LockFromDependency(ds[i])
 	}
 
 	sort.Sort(lf.Imports)
 
 	for i := 0; i < len(tds); i++ {
-		lf.DevImports[i] = &Lock{
-			Name:        tds[i].Name,
-			Version:     tds[i].Pin,
-			Repository:  tds[i].Repository,
-			VcsType:     tds[i].VcsType,
-			Subpackages: tds[i].Subpackages,
-			Arch:        tds[i].Arch,
-			Os:          tds[i].Os,
-		}
+		lf.DevImports[i] = LockFromDependency(tds[i])
 	}
 
 	sort.Sort(lf.DevImports)
@@ -180,15 +177,8 @@ func LockfileFromMap(ds map[string]*Dependency, hash string) *Lockfile {
 
 	i := 0
 	for name, dep := range ds {
-		lf.Imports[i] = &Lock{
-			Name:        name,
-			Version:     dep.Pin,
-			Repository:  dep.Repository,
-			VcsType:     dep.VcsType,
-			Subpackages: dep.Subpackages,
-			Arch:        dep.Arch,
-			Os:          dep.Os,
-		}
+		lf.Imports[i] = LockFromDependency(dep)
+		lf.Imports[i].Name = name
 		i++
 	}
 

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -93,28 +93,12 @@ func (i *Installer) Install(lock *cfg.Lockfile, conf *cfg.Config) (*cfg.Config, 
 
 	newConf.Imports = make(cfg.Dependencies, len(lock.Imports))
 	for k, v := range lock.Imports {
-		newConf.Imports[k] = &cfg.Dependency{
-			Name:        v.Name,
-			Reference:   v.Version,
-			Repository:  v.Repository,
-			VcsType:     v.VcsType,
-			Subpackages: v.Subpackages,
-			Arch:        v.Arch,
-			Os:          v.Os,
-		}
+		newConf.Imports[k] = cfg.DependencyFromLock(v)
 	}
 
 	newConf.DevImports = make(cfg.Dependencies, len(lock.DevImports))
 	for k, v := range lock.DevImports {
-		newConf.DevImports[k] = &cfg.Dependency{
-			Name:        v.Name,
-			Reference:   v.Version,
-			Repository:  v.Repository,
-			VcsType:     v.VcsType,
-			Subpackages: v.Subpackages,
-			Arch:        v.Arch,
-			Os:          v.Os,
-		}
+		newConf.DevImports[k] = cfg.DependencyFromLock(v)
 	}
 
 	newConf.DeDupe()


### PR DESCRIPTION
Lightly refactor some lockfile logic into shared functions, so callers inside & outside glide do things the same way.

Personally I need this to create a glide plugin (as requested in PR #266), for which I need to read the lockfile, and turn those `Lock` structs into `Dependency` structs. These helper funcs will ensure that if anything changes in glide, my (and others') plugin will keep up.

(Also moving the `LoadLockfile` func has been a `TODO` in the code for a while)