### PR TITLE
Glide install skips fetch when it is up to date

### DIFF
--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -203,14 +203,14 @@ func VcsVersion(dep *cfg.Dependency, vend string) error {
 		}
 
 		ver := dep.Reference
-		// Referenes in Git can begin with a ^ which is similar to semver.
+		// References in Git can begin with a ^ which is similar to semver.
 		// If there is a ^ prefix we assume it's a semver constraint rather than
 		// part of the git/VCS commit id.
 		if repo.IsReference(ver) && !strings.HasPrefix(ver, "^") {
 			msg.Info("--> Setting version for %s to %s.\n", dep.Name, ver)
 		} else {
 
-			// Create the constraing first to make sure it's valid before
+			// Create the constraint first to make sure it's valid before
 			// working on the repo.
 			constraint, err := semver.NewConstraint(ver)
 


### PR DESCRIPTION
For 'glide install', this lazily computes whether the existing vendor
checkouts are already at the right commit. If they are, those deps are
skipped during the concurrent update.

This is safe to do in install because the dependency graph is already
computed, so there should never be a case where the glide.lock file does
not contain a negotiable dependency graph.