### PR TITLE
Log an error if stripping version control data fails

### DIFF
--- a/action/get.go
+++ b/action/get.go
@@ -95,7 +95,10 @@ func Get(names []string, installer *repo.Installer, insecure, skipRecursive, str
 
 	if strip {
 		msg.Info("Removing version control data from vendor directory...")
-		gpath.StripVcs()
+		err := gpath.StripVcs()
+		if err != nil {
+			msg.Err("Unable to strip version control data: %s", err)
+		}
 	}
 
 	if stripVendor {

--- a/action/install.go
+++ b/action/install.go
@@ -72,7 +72,10 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 
 	if strip {
 		msg.Info("Removing version control data from vendor directory...")
-		gpath.StripVcs()
+		err := gpath.StripVcs()
+		if err != nil {
+			msg.Err("Unable to strip version control data: %s", err)
+		}
 	}
 
 	if stripVendor {

--- a/action/update.go
+++ b/action/update.go
@@ -117,7 +117,10 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 
 	if strip {
 		msg.Info("Removing version control data from vendor directory...")
-		gpath.StripVcs()
+		err := gpath.StripVcs()
+		if err != nil {
+			msg.Err("Unable to strip version control data: %s", err)
+		}
 	}
 
 	if stripVendor {


### PR DESCRIPTION
Fixes #499 by logging any error that occurs when stripping version control data from dependencies.