### PR TITLE
Only skip directories when rewriting godeps

### DIFF
--- a/godep/strip/strip.go
+++ b/godep/strip/strip.go
@@ -82,11 +82,11 @@ func stripGodepWorkspaceHandler(path string, info os.FileInfo, err error) error 
 
 func rewriteGodepfilesHandler(path string, info os.FileInfo, err error) error {
 	name := info.Name()
-	if name == "testdata" || name == "vendor" {
-		return filepath.SkipDir
-	}
 
 	if info.IsDir() {
+		if name == "testdata" || name == "vendor" {
+			return filepath.SkipDir
+		}
 		return nil
 	}
 


### PR DESCRIPTION
This fixes an issue where if a repository has a file named "vendor", glide would crash. This scenario could be encountered because a repo symlinks "vendor" to "Godeps/_workspace/src".

Possibly related: https://github.com/golang/go/issues/16280