### PR TITLE
Sort subpackages for glide.yaml and glide.lock

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/glide/util"
@@ -567,6 +568,7 @@ func stringArrayDeDupe(s []string, items ...string) []string {
 			s = append(s, item)
 		}
 	}
+	sort.Strings(s)
 	return s
 }
 

--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -34,6 +34,18 @@ func (lf *Lockfile) Marshal() ([]byte, error) {
 	return yml, nil
 }
 
+// MarshalYAML is a hook for gopkg.in/yaml.v2.
+// It sorts import subpackages lexicographically for reproducibility.
+func (lf *Lockfile) MarshalYAML() (interface{}, error) {
+	for _, imp := range lf.Imports {
+		sort.Strings(imp.Subpackages)
+	}
+	for _, imp := range lf.DevImports {
+		sort.Strings(imp.Subpackages)
+	}
+	return lf, nil
+}
+
 // WriteFile writes a Glide lock file.
 //
 // This is a convenience function that marshals the YAML and then writes it to

--- a/cfg/lock_test.go
+++ b/cfg/lock_test.go
@@ -2,6 +2,7 @@ package cfg
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -30,5 +31,82 @@ func TestSortLocks(t *testing.T) {
 		ls[2].Name != "github.com/Masterminds/cookoo" ||
 		ls[3].Name != "github.com/Masterminds/structable" {
 		t.Error("Sorting of dependencies failed")
+	}
+}
+
+const inputSubpkgYaml = `
+imports:
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - plugin/equal
+  - sortkeys
+  - plugin/face
+  - plugin/gostring
+  - vanity
+  - plugin/grpc
+  - plugin/marshalto
+  - plugin/populate
+  - plugin/oneofcheck
+  - plugin/size
+  - plugin/stringer
+  - plugin/defaultcheck
+  - plugin/embedcheck
+  - plugin/description
+  - plugin/enumstringer
+  - gogoproto
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/plugin
+  - vanity/command
+  - protoc-gen-gogo/descriptor
+  - proto
+`
+const expectSubpkgYaml = `
+imports:
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - gogoproto
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/grpc
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
+  - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/plugin
+  - sortkeys
+  - vanity
+  - vanity/command
+`
+
+func TestSortSubpackages(t *testing.T) {
+	lf, err := LockfileFromYaml([]byte(inputSubpkgYaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := lf.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), expectSubpkgYaml) {
+		t.Errorf("Expected %q\nto contain\n%q")
 	}
 }


### PR DESCRIPTION
This alters the YAML marshaling to sort import and devimport subpackage
sections.

Closes #521