### PR TITLE
Fixed #529: --delete flag deletes and redownloads transitive deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   This skips unnecessary network requests (thanks @hori-ryota)
 
 ## Fixed
+- #529: --delete flag deleted and re-downloaded transitive dependencies
 - #535: Resolve vendor directory symlinks (thanks @Fugiman)
 
 # Release 0.11.1 (2016-07-21)

--- a/action/install.go
+++ b/action/install.go
@@ -42,14 +42,6 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 		msg.Warn("Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'")
 	}
 
-	// Delete unused packages
-	if installer.DeleteUnused {
-		// It's unclear whether this should operate off of the lock, or off
-		// of the glide.yaml file. I'd think that doing this based on the
-		// lock would be much more reliable.
-		dependency.DeleteUnused(conf)
-	}
-
 	// Install
 	newConf, err := installer.Install(lock, conf)
 	if err != nil {
@@ -61,6 +53,13 @@ func Install(installer *repo.Installer, strip, stripVendor bool) {
 	// Set reference
 	if err := repo.SetReference(newConf, installer.ResolveTest); err != nil {
 		msg.Err("Failed to set references: %s (Skip to cleanup)", err)
+	}
+
+	// Delete unused packages
+	if installer.DeleteUnused {
+		// newConf is calculated based on the lock file so it should be
+		// accurate to the project list.
+		dependency.DeleteUnused(newConf)
 	}
 
 	// VendoredCleanup. This should ONLY be run if UpdateVendored was specified.

--- a/action/update.go
+++ b/action/update.go
@@ -24,11 +24,6 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 	EnsureVendorDir()
 	conf := EnsureConfig()
 
-	// Delete unused packages
-	if installer.DeleteUnused {
-		dependency.DeleteUnused(conf)
-	}
-
 	// Try to check out the initial dependencies.
 	if err := installer.Checkout(conf); err != nil {
 		msg.Die("Failed to do initial checkout of config: %s", err)
@@ -59,6 +54,12 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 			msg.Err("Failed to set references: %s (Skip to cleanup)", err)
 		}
 	}
+
+	// Delete unused packages
+	if installer.DeleteUnused {
+		dependency.DeleteUnused(confcopy)
+	}
+
 	// Vendored cleanup
 	// VendoredCleanup. This should ONLY be run if UpdateVendored was specified.
 	// When stripping VCS happens this will happen as well. No need for double

--- a/dependency/delete.go
+++ b/dependency/delete.go
@@ -28,6 +28,9 @@ func DeleteUnused(conf *cfg.Config) error {
 	for _, dep := range conf.Imports {
 		pkgList = append(pkgList, dep.Name)
 	}
+	for _, dep := range conf.DevImports {
+		pkgList = append(pkgList, dep.Name)
+	}
 
 	var searchPath string
 	var markForDelete []string


### PR DESCRIPTION
Note, there was also a mishandling of testImport that was fixed