### PR TITLE
Fixes panic while running tree command

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -45,6 +45,10 @@ func Display(b *util.BuildCtxt, basedir, myName string, level int, core bool, l 
 func walkDeps(b *util.BuildCtxt, base, myName string) []string {
 	externalDeps := []string{}
 	filepath.Walk(base, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if !dependency.IsSrcDir(fi) {
 			if fi.IsDir() {
 				return filepath.SkipDir


### PR DESCRIPTION
Checks for error while walking directories and propagates them up to prevent panic. Fixes issue #440.