### PR TITLE
Fixed #517 failed to install testImport from lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   This skips unnecessary network requests (thanks @hori-ryota)
 
 ## Fixed
+- #517: Fixed failure to install testImport from lock when no imports present
+  or when same dependency on both import and testImport
 - #440: Fixed panic in `glide tree` when walking the filesystem (thanks @abhin4v)
 - #529: --delete flag deleted and re-downloaded transitive dependencies
 - #535: Resolve vendor directory symlinks (thanks @Fugiman)

--- a/action/get.go
+++ b/action/get.go
@@ -115,7 +115,10 @@ func writeLock(conf, confcopy *cfg.Config, base string) {
 	if err != nil {
 		msg.Die("Failed to generate config hash. Unable to generate lock file.")
 	}
-	lock := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
+	lock, err := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
+	if err != nil {
+		msg.Die("Failed to generate lock file: %s", err)
+	}
 	if err := lock.WriteFile(filepath.Join(base, gpath.LockFile)); err != nil {
 		msg.Die("Failed to write glide lock file: %s", err)
 	}

--- a/action/update.go
+++ b/action/update.go
@@ -87,7 +87,10 @@ func Update(installer *repo.Installer, skipRecursive, strip, stripVendor bool) {
 		if err != nil {
 			msg.Die("Failed to generate config hash. Unable to generate lock file.")
 		}
-		lock := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
+		lock, err := cfg.NewLockfile(confcopy.Imports, confcopy.DevImports, hash)
+		if err != nil {
+			msg.Die("Failed to generate lock file: %s", err)
+		}
 		wl := true
 		if gpath.HasLock(base) {
 			yml, err := ioutil.ReadFile(filepath.Join(base, gpath.LockFile))

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -104,8 +104,8 @@ func (i *Installer) Install(lock *cfg.Lockfile, conf *cfg.Config) (*cfg.Config, 
 
 	newConf.DeDupe()
 
-	if len(newConf.Imports) == 0 {
-		msg.Info("No dependencies found. Nothing installed.\n")
+	if len(newConf.Imports) == 0 && len(newConf.DevImports) == 0 {
+		msg.Info("No dependencies found. Nothing installed.")
 		return newConf, nil
 	}
 

--- a/repo/set_reference.go
+++ b/repo/set_reference.go
@@ -3,9 +3,11 @@ package repo
 import (
 	"sync"
 
+	"github.com/Masterminds/glide/cache"
 	"github.com/Masterminds/glide/cfg"
 	"github.com/Masterminds/glide/msg"
 	gpath "github.com/Masterminds/glide/path"
+	"github.com/codegangsta/cli"
 )
 
 // SetReference is a command to set the VCS reference (commit id, tag, etc) for
@@ -25,15 +27,39 @@ func SetReference(conf *cfg.Config, resolveTest bool) error {
 	done := make(chan struct{}, concurrentWorkers)
 	in := make(chan *cfg.Dependency, concurrentWorkers)
 	var wg sync.WaitGroup
+	var lock sync.Mutex
+	var returnErr error
 
 	for i := 0; i < concurrentWorkers; i++ {
 		go func(ch <-chan *cfg.Dependency) {
 			for {
 				select {
 				case dep := <-ch:
+					var loc string
+					if dep.Repository != "" {
+						loc = dep.Repository
+					} else {
+						loc = "https://" + dep.Name
+					}
+					key, err := cache.Key(loc)
+					if err != nil {
+						msg.Die(err.Error())
+					}
+					cache.Lock(key)
 					if err := VcsVersion(dep, cwd); err != nil {
 						msg.Err("Failed to set version on %s to %s: %s\n", dep.Name, dep.Reference, err)
+
+						// Capture the error while making sure the concurrent
+						// operations don't step on each other.
+						lock.Lock()
+						if returnErr == nil {
+							returnErr = err
+						} else {
+							returnErr = cli.NewMultiError(returnErr, err)
+						}
+						lock.Unlock()
 					}
+					cache.Unlock(key)
 					wg.Done()
 				case <-done:
 					return
@@ -66,5 +92,5 @@ func SetReference(conf *cfg.Config, resolveTest bool) error {
 	// close(done)
 	// close(in)
 
-	return nil
+	return returnErr
 }


### PR DESCRIPTION
There were two reasons for this
1. The case there import was empty but testImport was not
2. When the same dependency appeared in both import and testImport
thre was a race condition that could cause failure