### PR TITLE
Add an integration test setup on test runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 # in the vendor directory. We don't need to test all dependent packages.
 # Only testing this project.
 script:
-  - GO15VENDOREXPERIMENT=1 make test
+  - GO15VENDOREXPERIMENT=1 make test integration-test
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ install: build
 test:
 	${GLIDE_GO_EXECUTABLE} test . ./gb ./path ./action ./tree ./util ./godep ./godep/strip ./gpm ./cfg ./dependency ./importer ./msg ./repo ./mirrors
 
+integration-test:
+	${GLIDE_GO_EXECUTABLE} build
+	./glide up
+	./glide install
+
 clean:
 	rm -f ./glide.test
 	rm -f ./glide
@@ -36,4 +41,4 @@ dist: build-all
 	cd ..
 
 
-.PHONY: build test install clean bootstrap-dist build-all dist
+.PHONY: build test install clean bootstrap-dist build-all dist integration-test


### PR DESCRIPTION
This is quick and dirty but will catch some errors not otherwise
caught.