### PR TITLE
Use msg.Debug instead of fmt.Println in the case of hash mismatch.

### DIFF
--- a/action/install.go
+++ b/action/install.go
@@ -1,7 +1,6 @@
 package action
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/Masterminds/glide/cache"
@@ -37,9 +36,9 @@ func Install(installer *repo.Installer, stripVendor bool) {
 	if err != nil {
 		msg.Die("Could not load lockfile.")
 	} else if hash != lock.Hash {
-		fmt.Println(hash, lock.Hash)
+		msg.Debug(hash, lock.Hash)
 		foo, _ := conf.Marshal()
-		fmt.Println(string(foo))
+		msg.Debug(string(foo))
 		msg.Warn("Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'")
 	}
 


### PR DESCRIPTION
I was seeing the entire __glide.yaml__ file printed out on our CI server and it was distracting. This output is really verbose and should probably only be displayed if the `--debug` flag was provided. Are you okay with changing this to `msg.Debug`?