### PR TITLE
Remove verbose flag

### DIFF
--- a/action/debug.go
+++ b/action/debug.go
@@ -7,15 +7,6 @@ import (
 // Debug sets the debugging flags across components.
 func Debug(on bool) {
 	msg.Default.IsDebugging = on
-
-	if on == true {
-		msg.Default.IsVerbose = on
-	}
-}
-
-// Verbose sets the verbose flags across components.
-func Verbose(on bool) {
-	msg.Default.IsVerbose = on
 }
 
 // Quiet sets the quiet flags across components.

--- a/glide.go
+++ b/glide.go
@@ -72,11 +72,6 @@ func main() {
 			Usage: "Quiet (no info or debug messages)",
 		},
 		cli.BoolFlag{
-			Name:   "verbose",
-			Usage:  "Print detailed informational messages",
-			Hidden: true,
-		},
-		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "Print debug verbose informational messages",
 		},
@@ -833,7 +828,6 @@ Example:
 // so it can be used by any Glide command.
 func startup(c *cli.Context) error {
 	action.Debug(c.Bool("debug"))
-	action.Verbose(c.Bool("verbose"))
 	action.NoColor(c.Bool("no-color"))
 	action.Quiet(c.Bool("quiet"))
 	action.Init(c.String("yaml"), c.String("home"))

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -22,9 +22,6 @@ type Messenger struct {
 	// IsDebugging, if true, shows Debug.
 	IsDebugging bool
 
-	// IsVerbose, if true, shows detailed informational messages.
-	IsVerbose bool
-
 	// NoColor, if true, will not use color in the output.
 	NoColor bool
 
@@ -52,7 +49,6 @@ func NewMessenger() *Messenger {
 	m := &Messenger{
 		Quiet:       false,
 		IsDebugging: false,
-		IsVerbose:   false,
 		NoColor:     false,
 		Stdout:      os.Stdout,
 		Stderr:      os.Stderr,
@@ -93,19 +89,6 @@ func (m *Messenger) Debug(msg string, args ...interface{}) {
 // Debug logs debug information using the Default Messenger
 func Debug(msg string, args ...interface{}) {
 	Default.Debug(msg, args...)
-}
-
-// Verbose logs detailed information
-func (m *Messenger) Verbose(msg string, args ...interface{}) {
-	if m.Quiet || !m.IsVerbose {
-		return
-	}
-	m.Info(msg, args...)
-}
-
-// Verbose detailed information using the Default Messenger
-func Verbose(msg string, args ...interface{}) {
-	Default.Verbose(msg, args...)
 }
 
 // Warn logs a warning


### PR DESCRIPTION
The verbose logging in the messenger isn't used anywhere, so this removes the command line
flag as well as cleaning up additional unused functions and fields. This is intended to address issue #568.