### PR TITLE
Check GOROOT before vendor + GOPATH

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -975,6 +975,17 @@ func (r *Resolver) FindPkg(name string) *PkgInfo {
 		return info
 	}
 
+	// Check $GOROOT
+	for _, rr := range filepath.SplitList(r.BuildContext.GOROOT) {
+		p = filepath.Join(rr, "src", filepath.FromSlash(name))
+		if pkgExists(p) {
+			info.Path = p
+			info.Loc = LocGoroot
+			r.findCache[name] = info
+			return info
+		}
+	}
+
 	// Check _only_ if this dep is in the current vendor directory.
 	p = filepath.Join(r.VendorDir, filepath.FromSlash(name))
 	if pkgExists(p) {
@@ -1003,17 +1014,6 @@ func (r *Resolver) FindPkg(name string) *PkgInfo {
 		if pkgExists(p) {
 			info.Path = p
 			info.Loc = LocGopath
-			r.findCache[name] = info
-			return info
-		}
-	}
-
-	// Check $GOROOT
-	for _, rr := range filepath.SplitList(r.BuildContext.GOROOT) {
-		p = filepath.Join(rr, "src", filepath.FromSlash(name))
-		if pkgExists(p) {
-			info.Path = p
-			info.Loc = LocGoroot
 			r.findCache[name] = info
 			return info
 		}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -112,6 +112,16 @@ func findPkg(b *util.BuildCtxt, name, cwd string) *dependency.PkgInfo {
 		return info
 	}
 
+	// Check $GOROOT
+	for _, r := range strings.Split(b.GOROOT, ":") {
+		p = filepath.Join(r, "src", name)
+		if fi, err = os.Stat(p); err == nil && (fi.IsDir() || gpath.IsLink(fi)) {
+			info.Path = p
+			info.Loc = dependency.LocGoroot
+			return info
+		}
+	}
+
 	// Recurse backward to scan other vendor/ directories
 	// If the cwd isn't an absolute path walking upwards looking for vendor/
 	// folders can get into an infinate loop.
@@ -151,16 +161,6 @@ func findPkg(b *util.BuildCtxt, name, cwd string) *dependency.PkgInfo {
 		if fi, err = os.Stat(p); err == nil && (fi.IsDir() || gpath.IsLink(fi)) {
 			info.Path = p
 			info.Loc = dependency.LocGopath
-			return info
-		}
-	}
-
-	// Check $GOROOT
-	for _, r := range strings.Split(b.GOROOT, ":") {
-		p = filepath.Join(r, "src", name)
-		if fi, err = os.Stat(p); err == nil && (fi.IsDir() || gpath.IsLink(fi)) {
-			info.Path = p
-			info.Loc = dependency.LocGoroot
 			return info
 		}
 	}


### PR DESCRIPTION
Fixes #577 

Glide was trying to fetch "testing", but failing. I realized that I had a directory in my GOPATH called "testing". Glide was looking at my GOPATH and vendor directories before looking at GOROOT.

This PR will check if an import is in the GOROOT before anything else. As far as I know, this is correct behaviour.
