### PR TITLE
Fixed #599: In some cases not importing dependencies config

### DIFF
--- a/repo/installer.go
+++ b/repo/installer.go
@@ -691,7 +691,7 @@ func (d *VersionHandler) Process(pkg string) (e error) {
 	// Should we look in places other than the root of the project?
 	if d.Imported[root] == false {
 		d.Imported[root] = true
-		p := d.pkgPath(pkg)
+		p := d.pkgPath(root)
 		f, deps, err := importer.Import(p)
 		if f && err == nil {
 			for _, dep := range deps {


### PR DESCRIPTION
This was happening when a sub-package imported before the top level
or if the top level for the project not imported at all.