### PR TITLE
Fixed #615: There was a way Glide could get stuck in a resolver loop

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -460,7 +460,7 @@ func (r *Resolver) resolveImports(queue *list.List, testDeps, addTest bool) ([]s
 		return []string{}, nil
 	}
 
-	alreadySeen := map[string]bool{}
+	alreadySeen := make(map[string]bool, queue.Len())
 
 	for e := queue.Front(); e != nil; e = e.Next() {
 		vdep := e.Value.(string)


### PR DESCRIPTION
The resolver loop caused Kubernetes imports to fail.