### PR TITLE
fix issue #577

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -146,11 +146,15 @@ func findPkg(b *util.BuildCtxt, name, cwd string) *dependency.PkgInfo {
 		}
 	}
 	// Check $GOPATH
-	for _, r := range strings.Split(b.GOPATH, ":") {
+	for i, r := range strings.Split(b.GOPATH, ":") {
 		p = filepath.Join(r, "src", name)
 		if fi, err = os.Stat(p); err == nil && (fi.IsDir() || gpath.IsLink(fi)) {
 			info.Path = p
-			info.Loc = dependency.LocGopath
+			if i == 0 {
+				info.Loc = dependency.LocGopathFirst
+			} else {
+				info.Loc = dependency.LocGopathOther
+			}
 			return info
 		}
 	}


### PR DESCRIPTION
1. check GOROOT before GOPATH in dependence.FindPkg (related to issue #577 )
   If there is "testing" project in GOPATH, pkg "testing" will be found in GOPATH success, "testing" and will be inserted into fetching list. 
2. only deal with first path on GOPATH, skip others
   If GOPATH has more than one paths, "GOPATH=/opt/gopkg:/home/someone/goprj" for example, trying to fetch own private project in goprj is strange. We should only fetch and vendor pkgs in first path of GOPATH.
