### PR TITLE
Improve semver message

### DIFF
--- a/action/config_wizard.go
+++ b/action/config_wizard.go
@@ -203,11 +203,14 @@ func wizardRemember() bool {
 func wizardAskRange(ver *semver.Version, d *cfg.Dependency) string {
 	vstr := ver.String()
 	msg.Info("The package %s appears to use semantic versions (http://semver.org).", d.Name)
-	msg.Info("Would you like to track the latest minor or patch releases (major.minor.patch)?")
-	msg.Info("Tracking minor version releases would use '>= %s, < %d.0.0' ('^%s'). Tracking patch version", vstr, ver.Major()+1, vstr)
-	msg.Info("releases would use '>= %s, < %d.%d.0' ('~%s'). For more information on Glide versions", vstr, ver.Major(), ver.Minor()+1, vstr)
-	msg.Info("and ranges see https://glide.sh/docs/versions")
+	msg.Info("Would you like to track the latest minor or patch releases (major.minor.patch) ?")
+	msg.Info("The choices are:")
+	msg.Info(" - tracking minor version releases would use '>= %s, < %d.0.0' ('^%s').", vstr, ver.Major()+1, vstr)
+	msg.Info(" - tracking patch version releases would use '>= %s, < %d.%d.0' ('~%s').", vstr, ver.Major(), ver.Minor()+1, vstr)
+	msg.Info(" - skip ranges\n")
+	msg.Info("For more information on Glide versions and ranges see https://glide.sh/docs/versions")
 	msg.Info("Minor (M), Patch (P), or Skip Ranges (S)?")
+
 	res, err := msg.PromptUntil([]string{"minor", "m", "patch", "p", "skip ranges", "s"})
 	if err != nil {
 		msg.Die("Error processing response: %s", err)


### PR DESCRIPTION
When running a `glide get <package>` the message displayed for the semver isn't easy to read & understand.

This PR aim to improve the formatting of this message, to ease the developer choice.
A simple list seems enough to do the job IMO.

Thanks !
