### PR TITLE
Make ending dots in prints more consistent

### DIFF
--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -26,12 +26,12 @@ func VcsUpdate(dep *cfg.Dependency, force bool, updated *UpdateTracker) error {
 	// If the dependency has already been pinned we can skip it. This is a
 	// faster path so we don't need to resolve it again.
 	if dep.Pin != "" {
-		msg.Debug("Dependency %s has already been pinned. Fetching updates skipped.", dep.Name)
+		msg.Debug("Dependency %s has already been pinned. Fetching updates skipped", dep.Name)
 		return nil
 	}
 
 	if updated.Check(dep.Name) {
-		msg.Debug("%s was already updated, skipping.", dep.Name)
+		msg.Debug("%s was already updated, skipping", dep.Name)
 		return nil
 	}
 	updated.Add(dep.Name)
@@ -50,14 +50,14 @@ func VcsUpdate(dep *cfg.Dependency, force bool, updated *UpdateTracker) error {
 
 	// If destination doesn't exist we need to perform an initial checkout.
 	if _, err := os.Stat(dest); os.IsNotExist(err) {
-		msg.Info("--> Fetching %s.", dep.Name)
+		msg.Info("--> Fetching %s", dep.Name)
 		if err = VcsGet(dep); err != nil {
 			msg.Warn("Unable to checkout %s\n", dep.Name)
 			return err
 		}
 	} else {
 		// At this point we have a directory for the package.
-		msg.Info("--> Fetching updates for %s.", dep.Name)
+		msg.Info("--> Fetching updates for %s", dep.Name)
 
 		// When the directory is not empty and has no VCS directory it's
 		// a vendored files situation.
@@ -67,7 +67,7 @@ func VcsUpdate(dep *cfg.Dependency, force bool, updated *UpdateTracker) error {
 		}
 		_, err = v.DetectVcsFromFS(dest)
 		if empty == true && err == v.ErrCannotDetectVCS {
-			msg.Warn("Cached version of %s is an empty directory. Fetching a new copy of the dependency.", dep.Name)
+			msg.Warn("Cached version of %s is an empty directory. Fetching a new copy of the dependency", dep.Name)
 			msg.Debug("Removing empty directory %s", dest)
 			err := os.RemoveAll(dest)
 			if err != nil {
@@ -130,7 +130,7 @@ func VcsUpdate(dep *cfg.Dependency, force bool, updated *UpdateTracker) error {
 				// branch it's a tag or commit id so we can skip
 				// performing an update.
 				if version == ver && !ib {
-					msg.Debug("%s is already set to version %s. Skipping update.", dep.Name, dep.Reference)
+					msg.Debug("%s is already set to version %s. Skipping update", dep.Name, dep.Reference)
 					return nil
 				}
 			}
@@ -151,7 +151,7 @@ func VcsVersion(dep *cfg.Dependency) error {
 	// If the dependency has already been pinned we can skip it. This is a
 	// faster path so we don't need to resolve it again.
 	if dep.Pin != "" {
-		msg.Debug("Dependency %s has already been pinned. Setting version skipped.", dep.Name)
+		msg.Debug("Dependency %s has already been pinned. Setting version skipped", dep.Name)
 		return nil
 	}
 
@@ -232,7 +232,7 @@ func VcsVersion(dep *cfg.Dependency) error {
 			}
 		}
 		if found {
-			msg.Info("--> Detected semantic version. Setting version for %s to %s.", dep.Name, ver)
+			msg.Info("--> Detected semantic version. Setting version for %s to %s", dep.Name, ver)
 		} else {
 			msg.Warn("--> Unable to find semantic version for constraint %s %s", dep.Name, ver)
 		}


### PR DESCRIPTION
It seems that mostly sentences that indicate an action ("Xing something") do not end in a dot. But some did. So it's either all of them or none: I changed it to none, dots at the end of these messages look strange.