### PR TITLE
add default timeout for resolving root from go get

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/vcs"
 )
@@ -21,6 +22,9 @@ import (
 // This is not concurrently safe which is ok for the current application. If
 // other needs arise it may need to be re-written.
 var ResolveCurrent = false
+var goGetCli *http.Client = &http.Client{
+	Timeout: 5 * time.Second,
+}
 
 func init() {
 	// Precompile the regular expressions used to check VCS locations.
@@ -84,7 +88,7 @@ func getRootFromGoGet(pkg string) string {
 		u.RawQuery = u.RawQuery + "&go-get=1"
 	}
 	checkURL := u.String()
-	resp, err := http.Get(checkURL)
+	resp, err := goGetCli.Get(checkURL)
 	if err != nil {
 		addToRemotePackageCache(pkg, pkg)
 		return pkg


### PR DESCRIPTION
In function ```getRootFromGoGet```, glide fire http get to resolve root from go get. This will be hanged for long time with some import path without "https" service or be banned by GreetFireWall in china. Suggest to add timeout into http request.