### PR TITLE
Force analysis of named paths in glide get

### DIFF
--- a/action/get.go
+++ b/action/get.go
@@ -59,7 +59,7 @@ func Get(names []string, installer *repo.Installer, insecure, skipRecursive, str
 		// to be between 1.0 and 2.0. But changing that dependency may then result
 		// in that dependency's dependencies changing... so we sorta do the whole
 		// thing to be safe.
-		err = installer.Update(confcopy)
+		err = installer.Update(confcopy, names...)
 		if err != nil {
 			msg.Die("Could not update packages: %s", err)
 		}

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -130,7 +130,7 @@ func (i *Installer) Checkout(conf *cfg.Config) error {
 // listed, but the version reconciliation has not been done.
 //
 // In other words, all versions in the Lockfile will be empty.
-func (i *Installer) Update(conf *cfg.Config) error {
+func (i *Installer) Update(conf *cfg.Config, req ...string) error {
 	base := "."
 
 	ic := newImportCache()
@@ -168,7 +168,7 @@ func (i *Installer) Update(conf *cfg.Config) error {
 	}
 	var deps cfg.Dependencies
 	var tdeps cfg.Dependencies
-	for _, v := range imps {
+	for _, v := range append(imps, req...) {
 		n := res.Stripv(v)
 		if conf.HasIgnore(n) {
 			continue


### PR DESCRIPTION
This addresses the issue where `glide get` fails to incorporate transitive dependencies of deps named on the command line and not already imported in the project.

Fixes #690 I think; related to #468 