### PR TITLE
Allow import of dependencies from govendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install: build
 	install -m 755 ./glide ${DESTDIR}/usr/local/bin/glide
 
 test:
-	${GLIDE_GO_EXECUTABLE} test . ./gb ./path ./action ./tree ./util ./godep ./godep/strip ./gpm ./cfg ./dependency ./importer ./msg ./repo ./mirrors
+	${GLIDE_GO_EXECUTABLE} test . ./gb ./path ./action ./tree ./util ./godep ./godep/strip ./govendor ./gpm ./cfg ./dependency ./importer ./msg ./repo ./mirrors
 
 integration-test:
 	${GLIDE_GO_EXECUTABLE} build

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When a dependent package is encountered its imports are scanned to determine
 dependencies of dependencies (transitive dependencies). If the dependent project
 contains a `glide.yaml` file that information is used to help determine the
 dependency rules when fetching from a location or version to use. Configuration
-from Godep, GB, GOM, and GPM is also imported.
+from Godep, GB, GOM, GPM and govendor is also imported.
 
 The dependencies are exported to the `vendor/` directory where the `go` tools
 can find and use them. A `glide.lock` file is generated containing all the
@@ -200,7 +200,7 @@ $ glide get github.com/Masterminds/cookoo
 ```
 
 When `glide get` is used it will introspect the listed package to resolve its
-dependencies including using Godep, GPM, Gom, and GB config files.
+dependencies including using Godep, GPM, Gom, GB and govendor config files.
 
 ### glide update (aliased to up)
 
@@ -213,7 +213,7 @@ $ glide up
 ```
 
 This will recurse over the packages looking for other projects managed by Glide,
-Godep, gb, gom, and GPM. When one is found those packages will be installed as needed.
+Godep, gb, gom, GPM and govendor. When one is found those packages will be installed as needed.
 
 A `glide.lock` file will be created or updated with the dependencies pinned to
 specific versions. For example, if in the `glide.yaml` file a version was
@@ -417,16 +417,16 @@ That's up to you. It's not necessary, but it may also cause you extra
 work and lots of extra space in your VCS. There may also be unforeseen errors
 ([see an example](https://github.com/mattfarina/golang-broken-vendor)).
 
-#### Q: How do I import settings from GPM, Godep, gom or gb?
+#### Q: How do I import settings from GPM, Godep, gom, gb or govendor?
 
 There are two parts to importing.
 
-1. If a package you import has configuration for GPM, Godep, gom or gb Glide will
-   recursively install the dependencies automatically.
-2. If you would like to import configuration from GPM, Godep, gom or gb to Glide see
-   the `glide import` command. For example, you can run `glide import godep` for
-   Glide to detect the projects Godep configuration and generate a `glide.yaml`
-   file for you.
+1. If a package you import has configuration for GPM, Godep, gom, gb or govendor
+   Glide will recursively install the dependencies automatically.
+2. If you would like to import configuration from GPM, Godep, gom, gb or govendor
+   to Glide see the `glide import` command. For example, you can run
+   `glide import godep` for Glide to detect the projects Godep configuration
+   and generate a `glide.yaml` file for you.
 
 Each of these will merge your existing `glide.yaml` file with the
 dependencies it finds for those managers, and then emit the file as

--- a/action/create.go
+++ b/action/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/glide/dependency"
 	"github.com/Masterminds/glide/gb"
 	"github.com/Masterminds/glide/godep"
+	"github.com/Masterminds/glide/govendor"
 	"github.com/Masterminds/glide/gpm"
 	"github.com/Masterminds/glide/msg"
 	gpath "github.com/Masterminds/glide/path"
@@ -204,6 +205,9 @@ func guessImportDeps(base string, config *cfg.Config) {
 	} else if d, ok := guessImportGB(absBase); ok {
 		msg.Info("Importing GB configuration")
 		deps = d
+	} else if d, ok := guessImportGovendor(absBase); ok {
+		msg.Info("Importing govendor configuration")
+		deps = d
 	}
 
 	for _, i := range deps {
@@ -237,6 +241,15 @@ func guessImportGPM(dir string) ([]*cfg.Dependency, bool) {
 
 func guessImportGB(dir string) ([]*cfg.Dependency, bool) {
 	d, err := gb.Parse(dir)
+	if err != nil || len(d) == 0 {
+		return []*cfg.Dependency{}, false
+	}
+
+	return d, true
+}
+
+func guessImportGovendor(dir string) ([]*cfg.Dependency, bool) {
+	d, err := govendor.Parse(dir)
 	if err != nil || len(d) == 0 {
 		return []*cfg.Dependency{}, false
 	}

--- a/action/import_govendor.go
+++ b/action/import_govendor.go
@@ -1,0 +1,21 @@
+package action
+
+import (
+	"github.com/Masterminds/glide/govendor"
+	"github.com/Masterminds/glide/msg"
+)
+
+// ImportGovendor imports govendor dependencies into the present glide config
+func ImportGovendor(dest string) {
+	base := "."
+	config := EnsureConfig()
+	if !govendor.Has(base) {
+		msg.Die("There is no govendor file to import.")
+	}
+	deps, err := govendor.Parse(base)
+	if err != nil {
+		msg.Die("Failed to extract govendor file: %s", err)
+	}
+	appendImports(deps, config)
+	writeConfigToFileOrStdout(config, dest)
+}

--- a/glide.go
+++ b/glide.go
@@ -166,9 +166,10 @@ func commands() []cli.Command {
    the subpackage 'web'.
 
    If a fetched dependency has a glide.yaml file, configuration from Godep,
-   GPM, GOM, or GB Glide that configuration will be used to find the dependencies
-   and versions to fetch. If those are not available the dependent packages will
-   be fetched as either a version specified elsewhere or the latest version.
+   GB, GOM, GPM, govendor or Glide that configuration will be used to find
+   the dependencies and versions to fetch. If those are not available
+   the dependent packages will be fetched as either a version specified
+   elsewhere or the latest version.
 
    When adding a new dependency Glide will perform an update to work out
    the versions for the dependencies of this dependency (transitive ones). This
@@ -374,6 +375,20 @@ func commands() []cli.Command {
 						return nil
 					},
 				},
+				{
+					Name:  "govendor",
+					Usage: "Import govendor vendorfile and display the would-be yaml file",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "file, f",
+							Usage: "Save all of the discovered dependencies to a Glide YAML file.",
+						},
+					},
+					Action: func(c *cli.Context) error {
+						action.ImportGovendor(c.String("file"))
+						return nil
+					},
+				},
 			},
 		},
 		{
@@ -527,9 +542,9 @@ Example:
    '--no-recursive'. When this behavior is skipped a glide.lock file is not
    generated because the full dependency tree cannot be known.
 
-   Glide will also import Godep, GB, GOM, and GPM files as it finds them in dependencies.
-   It will create a glide.yaml file from the Godeps data, and then update. This
-   has no effect if '--no-recursive' is set.
+   Glide will also import Godep, GB, GOM, GPM and govendor files as it
+   finds them in dependencies. It will create a glide.yaml file from the Godeps
+   data, and then update. This has no effect if '--no-recursive' is set.
 
    The '--strip-vendor' flag will remove any nested 'vendor' folders and
    'Godeps/_workspace' folders after an update (along with undoing any Godep

--- a/govendor/file.go
+++ b/govendor/file.go
@@ -1,0 +1,347 @@
+// Package govendor provides compatibility with govendor vendorfiles.
+
+// This is 1-to-1 copy of govendor's `vendorfile/file.go` file.
+// govendor is governed by a BSD-style
+// license that can be found in the LICENSE file of govendor project
+
+package govendor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sort"
+)
+
+// Name of the vendor file.
+const Name = "vendor.json"
+
+// File is the structure of the vendor file.
+type File struct {
+	RootPath string // Import path of vendor folder
+
+	Comment string
+
+	Ignore string
+
+	Package []*Package
+
+	// all preserves unknown values.
+	all map[string]interface{}
+}
+
+// Package represents each package.
+type Package struct {
+	field map[string]interface{}
+
+	// If delete is set to true the package will not be written to the vendor file.
+	Remove bool
+
+	// If new is set to true the package will be treated as a new package to the file.
+	Add bool
+
+	// See the vendor spec for definitions.
+	Origin       string
+	Path         string
+	Tree         bool
+	Revision     string
+	RevisionTime string
+	Version      string
+	VersionExact string
+	ChecksumSHA1 string
+	Comment      string
+}
+
+func (pkg *Package) PathOrigin() string {
+	if len(pkg.Origin) > 0 {
+		return pkg.Origin
+	}
+	return pkg.Path
+}
+
+// The following stringer functions are useful for debugging.
+
+type packageList []*Package
+
+func (list packageList) String() string {
+	buf := &bytes.Buffer{}
+	for _, item := range list {
+		buf.WriteString("\t")
+		buf.WriteString(fmt.Sprintf("(%v) ", item.field))
+		if item.Remove {
+			buf.WriteString(" X ")
+		}
+		buf.WriteString(item.Path)
+		buf.WriteRune('\n')
+	}
+	buf.WriteRune('\n')
+	return buf.String()
+}
+
+func allString(all map[string]interface{}) string {
+	obj, _ := all["package"]
+	buf := &bytes.Buffer{}
+	for _, itemObj := range obj.([]interface{}) {
+		item := itemObj.(map[string]interface{})
+		buf.WriteString("\t")
+		buf.WriteString(item["path"].(string))
+		buf.WriteRune('\n')
+	}
+	buf.WriteRune('\n')
+	return buf.String()
+}
+
+var (
+	rootPathNames     = []string{"rootPath"}
+	packageNames      = []string{"package", "Package"}
+	ignoreNames       = []string{"ignore"}
+	originNames       = []string{"origin"}
+	pathNames         = []string{"path", "canonical", "Canonical", "vendor", "Vendor"}
+	treeNames         = []string{"tree"}
+	revisionNames     = []string{"revision", "Revision", "version", "Version"}
+	revisionTimeNames = []string{"revisionTime", "RevisionTime", "versionTime", "VersionTime"}
+	versionNames      = []string{"version"}
+	versionExactNames = []string{"versionExact"}
+	checksumSHA1Names = []string{"checksumSHA1"}
+	commentNames      = []string{"comment", "Comment"}
+)
+
+type vendorPackageSort []interface{}
+
+func (vp vendorPackageSort) Len() int      { return len(vp) }
+func (vp vendorPackageSort) Swap(i, j int) { vp[i], vp[j] = vp[j], vp[i] }
+func (vp vendorPackageSort) Less(i, j int) bool {
+	a := vp[i].(map[string]interface{})
+	b := vp[j].(map[string]interface{})
+	aPath, _ := a[pathNames[0]].(string)
+	bPath, _ := b[pathNames[0]].(string)
+
+	if aPath == bPath {
+		aOrigin, _ := a[originNames[0]].(string)
+		bOrigin, _ := b[originNames[0]].(string)
+		return len(aOrigin) > len(bOrigin)
+	}
+	return aPath < bPath
+}
+
+func setField(fieldObj interface{}, object map[string]interface{}, names []string) {
+loop:
+	for _, name := range names {
+		raw, found := object[name]
+		if !found {
+			continue
+		}
+		switch field := fieldObj.(type) {
+		default:
+			panic("unknown type")
+		case *string:
+			value, is := raw.(string)
+			if !is {
+				continue loop
+			}
+			*field = value
+			if len(value) != 0 {
+				break loop
+			}
+		case *bool:
+			value, is := raw.(bool)
+			if !is {
+				continue loop
+			}
+			*field = value
+			if value == true {
+				break loop
+			}
+		}
+	}
+}
+
+func setObject(fieldObj interface{}, object map[string]interface{}, names []string, hideEmpty bool) {
+	switch field := fieldObj.(type) {
+	default:
+		panic("unknown type")
+	case string:
+		for i, name := range names {
+			if i != 0 || (hideEmpty && len(field) == 0) {
+				delete(object, name)
+				continue
+			}
+			object[name] = field
+		}
+	case bool:
+		for i, name := range names {
+			if i != 0 || (hideEmpty && field == false) {
+				delete(object, name)
+				continue
+			}
+			object[name] = field
+		}
+	}
+}
+
+// getRawPackageList gets the array of items from all object.
+func (vf *File) getRawPackageList() []interface{} {
+	var rawPackageList []interface{}
+	for index, name := range packageNames {
+		rawPackageListObject, found := vf.all[name]
+		if !found {
+			continue
+		}
+		if index != 0 {
+			vf.all[packageNames[0]] = rawPackageListObject
+			delete(vf.all, name)
+		}
+		var is bool
+		rawPackageList, is = rawPackageListObject.([]interface{})
+		if is {
+			break
+		}
+	}
+	return rawPackageList
+}
+
+// toFields moves values from "all" to the field values.
+func (vf *File) toFields() {
+	setField(&vf.RootPath, vf.all, rootPathNames)
+	setField(&vf.Comment, vf.all, commentNames)
+	setField(&vf.Ignore, vf.all, ignoreNames)
+
+	rawPackageList := vf.getRawPackageList()
+
+	vf.Package = make([]*Package, len(rawPackageList))
+
+	for index, rawPackage := range rawPackageList {
+		object, is := rawPackage.(map[string]interface{})
+		if !is {
+			continue
+		}
+		pkg := &Package{}
+		vf.Package[index] = pkg
+		pkg.field = object
+		setField(&pkg.Origin, object, originNames)
+		setField(&pkg.Path, object, pathNames)
+		setField(&pkg.Tree, object, treeNames)
+		setField(&pkg.Revision, object, revisionNames)
+		setField(&pkg.RevisionTime, object, revisionTimeNames)
+		setField(&pkg.Version, object, versionNames)
+		setField(&pkg.VersionExact, object, versionExactNames)
+		setField(&pkg.ChecksumSHA1, object, checksumSHA1Names)
+		setField(&pkg.Comment, object, commentNames)
+	}
+}
+
+// toAll moves values from field values to "all".
+func (vf *File) toAll() {
+	delete(vf.all, "Tool")
+
+	setObject(vf.RootPath, vf.all, rootPathNames, true)
+	setObject(vf.Comment, vf.all, commentNames, false)
+	setObject(vf.Ignore, vf.all, ignoreNames, false)
+
+	rawPackageList := vf.getRawPackageList()
+
+	setPkgFields := func(pkg *Package) {
+		if pkg.Origin == pkg.Path {
+			pkg.Origin = ""
+		}
+		if pkg.field == nil {
+			pkg.field = make(map[string]interface{}, 10)
+		}
+		setObject(pkg.Origin, pkg.field, originNames, true)
+		setObject(pkg.Path, pkg.field, pathNames, false)
+		setObject(pkg.Tree, pkg.field, treeNames, true)
+		setObject(pkg.Revision, pkg.field, revisionNames, false)
+		setObject(pkg.RevisionTime, pkg.field, revisionTimeNames, true)
+		setObject(pkg.Version, pkg.field, versionNames, true)
+		setObject(pkg.VersionExact, pkg.field, versionExactNames, true)
+		setObject(pkg.ChecksumSHA1, pkg.field, checksumSHA1Names, true)
+		setObject(pkg.Comment, pkg.field, commentNames, true)
+	}
+
+	for i := len(vf.Package) - 1; i >= 0; i-- {
+		pkg := vf.Package[i]
+		switch {
+		case pkg.Remove:
+			for index, rawObj := range rawPackageList {
+				raw, is := rawObj.(map[string]interface{})
+				if !is {
+					continue
+				}
+				same := true
+				for key, value := range pkg.field {
+					if raw[key] != value {
+						same = false
+						break
+					}
+				}
+				if same {
+					rawPackageList[index] = nil
+				}
+			}
+		case pkg.Add:
+			setPkgFields(pkg)
+			rawPackageList = append(rawPackageList, pkg.field)
+		default:
+			if pkg.field == nil {
+				pkg.field = make(map[string]interface{}, 10)
+			}
+
+			delete(pkg.field, "local")
+			delete(pkg.field, "Local")
+			setPkgFields(pkg)
+		}
+	}
+	nextRawPackageList := make([]interface{}, 0, len(rawPackageList))
+	for _, raw := range rawPackageList {
+		if raw == nil {
+			continue
+		}
+		nextRawPackageList = append(nextRawPackageList, raw)
+	}
+	vf.all[packageNames[0]] = nextRawPackageList
+}
+
+// Marshal the vendor file to the specified writer.
+// Retains read fields.
+func (vf *File) Marshal(w io.Writer) error {
+	if vf.all == nil {
+		vf.all = map[string]interface{}{}
+	}
+	vf.toAll()
+
+	rawList := vf.getRawPackageList()
+	sort.Sort(vendorPackageSort(rawList))
+
+	jb, err := json.Marshal(vf.all)
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	err = json.Indent(buf, jb, "", "\t")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, buf)
+	return err
+}
+
+// Unmarshal the vendor file from the specified reader.
+// Stores internally all fields.
+func (vf *File) Unmarshal(r io.Reader) error {
+	bb, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	if vf.all == nil {
+		vf.all = make(map[string]interface{}, 3)
+	}
+	err = json.Unmarshal(bb, &vf.all)
+	if err != nil {
+		return err
+	}
+	vf.toFields()
+	return nil
+}

--- a/govendor/govendor.go
+++ b/govendor/govendor.go
@@ -1,0 +1,100 @@
+package govendor
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/glide/cfg"
+	"github.com/Masterminds/glide/msg"
+	gpath "github.com/Masterminds/glide/path"
+	"github.com/Masterminds/glide/util"
+)
+
+// Has returns true if this dir has a govendor-flavored vendorfile.
+func Has(dir string) bool {
+	path := filepath.Join(dir, "vendor/"+Name)
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func Parse(dir string) ([]*cfg.Dependency, error) {
+	path := filepath.Join(dir, "vendor/"+Name)
+	if fi, err := os.Stat(path); err != nil || fi.IsDir() {
+		return []*cfg.Dependency{}, nil
+	}
+
+	msg.Info("Found govendor vendor.json file in %s", gpath.StripBasepath(dir))
+	msg.Info("--> Parsing govendor metadata...")
+	buf := []*cfg.Dependency{}
+	file, err := os.Open(path)
+	if err != nil {
+		return buf, err
+	}
+	defer file.Close()
+
+	f := File{}
+
+	if err := f.Unmarshal(file); err != nil {
+		return buf, err
+	}
+
+	seen := map[string]bool{}
+	for _, p := range f.Package {
+		pkg, sub := util.NormalizeName(p.PathOrigin())
+		msg.Debug("Parsing %s -> %s", pkg, sub)
+		processPackage(&seen, &buf, p, pkg, sub)
+	}
+	return buf, nil
+}
+
+func processPackage(seen *map[string]bool, buf *[]*cfg.Dependency, p *Package, pkg, sub string) {
+	m := *seen
+	if _, ok := m[pkg]; ok {
+		if len(sub) == 0 {
+			return
+		}
+
+		for _, dep := range *buf {
+			if dep.Name == pkg {
+				subRef := getReferenceFromPackage(p)
+				if dep.Reference != subRef {
+					// Add conflicting subpackage as 1st class package
+					// and let the user resolve it.
+					// First `glide update` will report these.
+					processPackage(seen, buf, p, p.PathOrigin(), "")
+					return
+				}
+				dep.Subpackages = append(dep.Subpackages, sub)
+			}
+		}
+	} else {
+		m[pkg] = true
+		seen = &m
+
+		dep := &cfg.Dependency{
+			Name:      pkg,
+			Reference: getReferenceFromPackage(p),
+		}
+
+		msg.Info("Parsed %s (%s)", pkg, dep.Reference)
+
+		if len(sub) > 0 {
+			dep.Subpackages = []string{sub}
+		}
+		*buf = append(*buf, dep)
+	}
+	return
+}
+
+func getReferenceFromPackage(pkg *Package) string {
+	// TODO: Prefer Version over VersionExact?
+	if pkg.VersionExact != "" {
+		return pkg.VersionExact
+	}
+
+	if pkg.Version != "" {
+		return pkg.Version
+	}
+
+	return pkg.Revision
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -1,4 +1,4 @@
-// Package importer imports dependency configuration from Glide, Godep, GPM, GB and gom
+// Package importer imports dependency configuration from Glide, Godep, GPM, GB, gom and govendor
 package importer
 
 import (
@@ -10,12 +10,13 @@ import (
 	"github.com/Masterminds/glide/gb"
 	"github.com/Masterminds/glide/godep"
 	"github.com/Masterminds/glide/gom"
+	"github.com/Masterminds/glide/govendor"
 	"github.com/Masterminds/glide/gpm"
 )
 
 var i = &DefaultImporter{}
 
-// Import uses the DefaultImporter to import from Glide, Godep, GPM, GB and gom.
+// Import uses the DefaultImporter to import from Glide, Godep, GPM, GB, gom and govendor.
 func Import(path string) (bool, []*cfg.Dependency, error) {
 	return i.Import(path)
 }
@@ -30,10 +31,10 @@ type Importer interface {
 	Import(path string) (bool, []*cfg.Dependency, error)
 }
 
-// DefaultImporter imports from Glide, Godep, GPM, GB and gom.
+// DefaultImporter imports from Glide, Godep, GPM, GB, gom and govendor.
 type DefaultImporter struct{}
 
-// Import tries to import configuration from Glide, Godep, GPM, GB and gom.
+// Import tries to import configuration from Glide, Godep, GPM, GB, gom and govendor.
 func (d *DefaultImporter) Import(path string) (bool, []*cfg.Dependency, error) {
 
 	// Try importing from Glide first.
@@ -81,6 +82,15 @@ func (d *DefaultImporter) Import(path string) (bool, []*cfg.Dependency, error) {
 	// Try importing from gom
 	if gom.Has(path) {
 		deps, err := gom.Parse(path)
+		if err != nil {
+			return false, []*cfg.Dependency{}, err
+		}
+		return true, deps, nil
+	}
+
+	// Try importing from govendor
+	if govendor.Has(path) {
+		deps, err := govendor.Parse(path)
 		if err != nil {
 			return false, []*cfg.Dependency{}, err
 		}


### PR DESCRIPTION
This will allow import of existing dependencies tracked via [govendor](https://github.com/kardianos/govendor).

### Transitive dependencies

One caveat I bumped into while testing this out with [`hashicorp/terraform`](https://github.com/hashicorp/terraform) is that govendor (as opposed to glide) allows transitive dependencies to be pinned to different versions to what the original 1st level dependency requires.

I couldn't find any real benefit of that feature - in fact I think it's better if this treated as a conflict - like it is in Glide.

To solve this in most graceful way I decided to generate initial `glide.yaml` file which may not be error-less for the first time, but will include *all* dependencies and 1st `glide update` will report any conflicts and let the user resolve these, e.g.

```
[ERROR]	Failed to parse /Users/radek/gopath/src/github.com/hashicorp/terraform/glide.yaml: Import github.com/fsouza/go-dockerclient repeated with different versions 'bf97c77db7c945cbcdbf09d56c6f87a66f54537b' and 'b21e1152923f46354476a3befa5b7aab0f441b4c'
```

### `Version` vs `VersionExact`

There are 2 main fields that may define the pinned version. `Version` is typically more loose (`v1` which will match latest `v1.*.*` tag or branch) and `VersionExact` is exact match (typically resolved `Version`). I decided to give priority to `VersionExact` as I came to the conclusion that user is more likely to benefit from dependency versions that are as close to previous versions as possible.
