### PR TITLE
Use cache directory as defined by XDG Base Directory Specification

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,10 +1,8 @@
 // Package cache provides an interface for interfacing with the Glide local cache
 //
 // Glide has a local cache of metadata and repositories similar to the GOPATH.
-// To store the cache Glide creates a .glide directory with a cache subdirectory.
-// This is usually in the users home directory unless there is no accessible
-// home directory in which case the .glide directory is in the root of the
-// repository.
+// To store the cache Glide creates a $XDG_CACHE_HOME/glide directory with a
+// cache subdirectory. This is usually in the ~/.cache/glide directory.
 //
 // To get the cache location use the `cache.Location()` function. This will
 // return the proper base location in your environment.
@@ -40,7 +38,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/glide/msg"
-	gpath "github.com/Masterminds/glide/path"
 )
 
 // Enabled sets if the cache is globally enabled. Defaults to true.
@@ -63,13 +60,13 @@ func Setup() {
 	}
 	msg.Debug("Setting up the cache directory")
 	pths := []string{
-		"cache",
-		filepath.Join("cache", "src"),
-		filepath.Join("cache", "info"),
+		"src",
+		"info",
 	}
 
+	cachedir := filepath.Join(xdgCacheDir(), "glide")
 	for _, l := range pths {
-		err := os.MkdirAll(filepath.Join(gpath.Home(), l), 0755)
+		err := os.MkdirAll(filepath.Join(cachedir, l), 0755)
 		if err != nil {
 			msg.Die("Cache directory unavailable: %s", err)
 		}
@@ -86,7 +83,7 @@ func SetupReset() {
 
 // Location returns the location of the cache.
 func Location() string {
-	p := filepath.Join(gpath.Home(), "cache")
+	p := filepath.Join(xdgCacheDir(), "glide")
 	Setup()
 
 	return p

--- a/cache/xdg.go
+++ b/cache/xdg.go
@@ -1,0 +1,35 @@
+// Borrowed from golang.org/x/build/cmd/fetchlogs/xdg.go
+//
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license.
+
+package cache
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+)
+
+// xdgCacheDir returns the XDG Base Directory Specification cache
+// directory.
+func xdgCacheDir() string {
+	cache := os.Getenv("XDG_CACHE_HOME")
+	if cache == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			u, err := user.Current()
+			if err != nil {
+				home = u.HomeDir
+			}
+		}
+		// Not XDG but standard for OS X.
+		if runtime.GOOS == "darwin" {
+			return filepath.Join(home, "Library/Caches")
+		}
+		cache = filepath.Join(home, ".cache")
+	}
+	return cache
+}


### PR DESCRIPTION
From the specification:

https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html

There is a single base directory relative to which user-specific
non-essential (cached) data should be written. This directory is defined
by the environment variable $XDG_CACHE_HOME.

$XDG_CACHE_HOME defines the base directory relative to which user specific
non-essential data files should be stored. If $XDG_CACHE_HOME is either
not set or empty, a default equal to $HOME/.cache should be used.