### PR TITLE
Fix glide home directory

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -46,7 +46,7 @@ func Home() string {
 		return homeDir
 	}
 
-	if h, err := homedir.Dir(); err != nil {
+	if h, err := homedir.Dir(); err == nil {
 		homeDir = filepath.Join(h, ".glide")
 	} else {
 		cwd, err := os.Getwd()


### PR DESCRIPTION
`path.Home()` does not return user's home directory even if it exists.
I think this is because incorrect `err` checking.