### PR TITLE
Add glide-pin plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,6 +10,7 @@ Some plugins exist today for Glide including:
 * [glide-brew](https://github.com/heewa/glide-brew) - Convert Go deps managed by glide to Homebrew resources to help you make brew formulas for you Go programs.
 * [glide-hash](https://github.com/mattfarina/glide-hash) - Generates a hash of the `glide.yaml` file compatible with Glides internal hash.
 * [glide-cleanup](https://github.com/ngdinhtoan/glide-cleanup) - Removing unused packages from the `glide.yaml` file.
+* [glide-pin](https://github.com/multiplay/glide-pin) - Take all dependencies from the `glide.lock` and pin them explicitly in the `glide.yaml` file.
 
 _Note, to add plugins to this list please create a pull request._
 


### PR DESCRIPTION
Adds a link to the glide-pin plugin for pinning all discovered dependencies in the `glide.lock` file explicitly in the `glide.yaml` file. Respects version ranges, but will replace them if the `--exact` flag is used.