### PR TITLE
Build: use VERSION if provided or fallback to git tag --describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLIDE_GO_EXECUTABLE ?= go
 DIST_DIRS := find * -type d -exec
-VERSION := $(shell git describe --tags)
+VERSION ?= $(shell git describe --tags)
 VERSION_INCODE = $(shell perl -ne '/^var version.*"([^"]+)".*$$/ && print "v$$1\n"' glide.go)
 VERSION_INCHANGELOG = $(shell perl -ne '/^\# Release (\d+(\.\d+)+) / && print "$$1\n"' CHANGELOG.md | head -n1)
 


### PR DESCRIPTION
Hi,

I'm packaging this software for a source based distribution [(Exherbo)](https://exherbo.org/). During the compilation, we are not in a git repository (I use Github tarball). Because of that, the `$(shell git tag --describe`) will emit an error even if I pass the `VERSION` to `make` like: `make build VERSION=0.12.3`

The error is harmless and the build still succeed but it can make the user think that the compilation will fail :-)