### PR TITLE
Preserve .git file correctly

### DIFF
--- a/repo/installer.go
+++ b/repo/installer.go
@@ -359,16 +359,23 @@ func (i *Installer) Export(conf *cfg.Config) error {
 	// move it over to the newly-generated vendor dir - the user is probably
 	// submoduling, and it's easy enough not to break their setup.
 	ivg := filepath.Join(i.VendorPath(), ".git")
-	_, err = os.Stat(ivg)
+	gitInfo, err := os.Stat(ivg)
 	if err == nil {
-		msg.Info("Preserving existing vendor/.git directory")
+		msg.Info("Preserving existing vendor/.git")
 		vpg := filepath.Join(vp, ".git")
 		err = os.Rename(ivg, vpg)
 
 		if terr, ok := err.(*os.LinkError); ok {
-			err = fixcle(ivg, vpg, terr)
+			if gitInfo.IsDir() {
+				err = fixcle(ivg, vpg, terr)
+			} else {
+				// When this is a submodule, .git is just a file. Don't try to copy
+				// it as a directory in this case (see #828).
+				err = gpath.CopyFile(ivg, vpg)
+			}
+
 			if err != nil {
-				msg.Warn("Failed to preserve existing vendor/.git directory")
+				msg.Warn("Failed to preserve existing vendor/.git")
 			}
 		}
 	}


### PR DESCRIPTION
When vendor is a submodule, .git is a file (not a directory). When /tmp is on a
different filesystem, we try to copy it as a directory which leaves an empty
.git directory instead of the file. This change fixes this by copying it as a
file in this case.

Fixes #828.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masterminds/glide/829)
<!-- Reviewable:end -->
