### PR TITLE
reduce install dependencies to just Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,7 @@ to see this philosophy in action.*
 
 ## Install
 
-The easiest way to install the latest release on Mac or Linux is with the following script:
-
-```
-curl https://glide.sh/get | sh
-```
+The easiest way to install the latest release on Mac or Linux is with `go get github.com/Masterminds/glide`, with [Go](https://golang.org/dl/) 1.5 or later.
 
 On Mac OS X you can also install the latest release via [Homebrew](https://github.com/Homebrew/homebrew):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Glide provides the following functionality:
 
 There are a few ways to install Glide.
 
-1. Use the shell script to try an automatically install it. `curl https://glide.sh/get | sh`
+1. Use the command `go get github.com/Masterminds/glide` to try an automatically install it with [Go](https://golang.org/dl/) 1.5 or later.
 2. Download a [versioned release](https://github.com/Masterminds/glide/releases). Glide releases are semantically versioned.
 3. Use a system package manager to install Glide. For example, using `brew install glide` can be used if you're using [Homebrew](http://brew.sh) on Mac.
 4. The latest development snapshot can be installed with `go get`. For example, `go get -u github.com/Masterminds/glide`. This is not a release version.


### PR DESCRIPTION
Remove the need for curl and similar coreutil tools when installing Glide