### PR TITLE
Clean non source and non dependent packages

### DIFF
--- a/action/install.go
+++ b/action/install.go
@@ -63,5 +63,10 @@ func Install(installer *repo.Installer, stripVendor bool) {
 		if err != nil {
 			msg.Err("Unable to strip vendor directories: %s", err)
 		}
+		msg.Info("Cleaning test and unnecessary files from vendor directories...")
+		err = CleanVendor(newConf)
+		if err != nil {
+			msg.Err("Unable to clean vendor directories: %s", err)
+		}
 	}
 }

--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -383,7 +383,7 @@ func (r *Resolver) ResolveLocal(deep bool) ([]string, []string, error) {
 		if err != nil {
 			return []string{}, []string{}, err
 		}
-		tre, err := r.resolveImports(tl, true, true)
+		tre, err := r.resolveImports(tl, false, false)
 		return re, tre, err
 	}
 


### PR DESCRIPTION
This PR implements a WIP fix for #652 and #422 and is to gauge interest in this feature with the maintainers of glide. I understand new work is proceeding on [golang/dep](https://github.com/golang/dep) so work on glide may not be a priority . However, If there is interest I will continue work on this PR and make any necessary changes including adding tests, config and or cli flag options so this can be useful to the wider community 

## Purpose
To clean the vendor directory of unnecessary files and packages included in the VCS repo. Cleaning the vendor can reduce the size of a `vendor/` directory significantly. This is especially useful for projects that commit the `vendor/` directory into VCS. 

## Implementation
* When glide is provided the `--strip-vendor` flag the following is preformed
  * Remove any directory not explicit in the path of one of the declared or discovered dependencies
  * Remove any file that is not of `.go` or `.s`
  * Remove any file that has the suffix `test.go`

## Additional Work
* Add a glide.yaml config option or flag to enable cleaning `_test.go` files
* Add a glide.yaml config option or flag to enable cleaning non source files
* Add a glide.yaml config option or flag to enable cleaning all test,non source and embedded `vendor/` directories from 
* Add a glide.yaml config option to exclude a list of files and paths from cleaning
* Add tests
* During `glide init` questionnaire, ask if these options should be enabled
* Add a glide.yaml config option or flag to exclude license and legal files from cleaning
* Add a glide.yaml config option of flag to enable cleaning of files that are part of `package main` this will allow `go install ./...` to work properly with a `vendor/` directory. This is mostly useful for projects still using 1.8 or earlier as 1.9 is rumored to have this fixed. https://github.com/lparth/go/commit/eafa5c7f9b87503e63cafa64d0685e782e8f516e)
