### PR TITLE
`ResolveLocal(true)` now correctly reports dependencies of tests

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -383,7 +383,7 @@ func (r *Resolver) ResolveLocal(deep bool) ([]string, []string, error) {
 		if err != nil {
 			return []string{}, []string{}, err
 		}
-		tre, err := r.resolveImports(tl, true, true)
+		tre, err := r.resolveImports(tl, false, false)
 		return re, tre, err
 	}
 


### PR DESCRIPTION
This currently does not affect any code paths, as the only usage of `ResolveLocal(true)` is `glide list` and it doesn't list test dependencies. This bug was discovered while working on #869 
