### PR TITLE
Fix CustomRemoveAll() to handle spaces in paths, and also file not found.

### DIFF
--- a/path/path_test.go
+++ b/path/path_test.go
@@ -86,3 +86,28 @@ func TestGlide(t *testing.T) {
 	}
 	os.Chdir(wd)
 }
+
+func TestCustomRemoveAll(t *testing.T) {
+	td, err := filepath.Abs(testdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// test that deleting a non-existent directory does not throw an error
+	err = CustomRemoveAll(filepath.Join(td, "directory/doesnt/exist"))
+	if err != nil {
+		t.Errorf("Failed when removing non-existent directory %s", err)
+	}
+	// test that deleting a path with spaces does not throw an error
+	spaceyPath := filepath.Join(td, "10942384 12341234 12343214 324134132323")
+	err = os.MkdirAll(spaceyPath, 0777)
+	if err != nil {
+		t.Fatal("Failed to make test directory %s", err)
+	}
+	err = CustomRemoveAll(spaceyPath)
+	if err != nil {
+		t.Errorf("Errored incorrectly when deleting a path with spaces %s", err)
+	}
+	if _, err = os.Stat(spaceyPath); !os.IsNotExist(err) {
+		t.Errorf("Failed to successfully delete a path with spaces")
+	}
+}

--- a/path/winbug.go
+++ b/path/winbug.go
@@ -5,12 +5,31 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"syscall"
 
 	"bytes"
 	"io/ioutil"
 
 	"github.com/Masterminds/glide/msg"
 )
+
+// extract the exit code from an os.exec error
+func getExitCode(err error) int {
+        if err != nil {
+                if exitError, ok := err.(*exec.ExitError); ok {
+                        waitStatus := exitError.Sys().(syscall.WaitStatus)
+                        return waitStatus.ExitStatus()
+                }
+        }
+        return 0
+}
+
+
+// Hard to track down these codes - they are from windows.h and documented here: 
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+const WIN_ERROR_FILE_NOT_FOUND = 2
+const WIN_ERROR_PATH_NOT_FOUND = 3
+
 
 // This file and its contents are to handle a Windows bug where large sets of
 // files fail when using the `os` package. This has been seen in Windows 10
@@ -25,11 +44,15 @@ func CustomRemoveAll(p string) error {
 	// Handle the windows case first
 	if runtime.GOOS == "windows" {
 		msg.Debug("Detected Windows. Removing files using windows command")
-		cmd := exec.Command("cmd.exe", "/c", fmt.Sprintf("rd /s /q %s", p))
+                cmd := exec.Command("cmd.exe", "/c", "rd", "/s", "/q", p)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Error removing files: %s. output: %s", err, output)
+			exitCode := getExitCode(err)
+			if exitCode != WIN_ERROR_FILE_NOT_FOUND && exitCode != WIN_ERROR_PATH_NOT_FOUND {
+				return fmt.Errorf("Error removing files: %s. output: %s", err, output)
+			}
 		}
+		return nil
 	} else if detectWsl() {
 		cmd := exec.Command("rm", "-rf", p)
 		output, err2 := cmd.CombinedOutput()
@@ -37,6 +60,7 @@ func CustomRemoveAll(p string) error {
 		if err2 != nil {
 			return fmt.Errorf("Error removing files: %s. output: %s", err2, output)
 		}
+		return nil
 	}
 	return os.RemoveAll(p)
 }


### PR DESCRIPTION
Fixes to problem mentioned in https://github.com/Masterminds/glide/issues/905

This deals with two related implementation details in winbug.go -

1) the function was not working successfully, because it was not enquoting the path with spaces correctly. 

2) the exit code from Windows RD command (remove directory) should be be handled - "directory not found" should not really be an error.  By analogy, `rm -rf` returns no error code for a non-existent file.

I've tested this several times manually, but nice to get other checks on it.
