### PR TITLE
add --ignore to list

### DIFF
--- a/action/list.go
+++ b/action/list.go
@@ -15,7 +15,7 @@ import (
 //  - dir (string): basedir
 //  - deep (bool): whether to do a deep scan or a shallow scan
 //  - format (string): The format to output (text, json, json-pretty)
-func List(basedir string, deep bool, format string) {
+func List(basedir string, deep bool, format string, ignore []string) {
 	basedir, err := filepath.Abs(basedir)
 	if err != nil {
 		msg.Die("Could not read directory: %s", err)
@@ -27,6 +27,10 @@ func List(basedir string, deep bool, format string) {
 	}
 	h := &dependency.DefaultMissingPackageHandler{Missing: []string{}, Gopath: []string{}, Prefix: "vendor"}
 	r.Handler = h
+
+	if len(ignore) > 0 {
+		r.Config.Ignore = ignore
+	}
 
 	localPkgs, _, err := r.ResolveLocal(deep)
 	if err != nil {

--- a/action/list.go
+++ b/action/list.go
@@ -15,6 +15,7 @@ import (
 //  - dir (string): basedir
 //  - deep (bool): whether to do a deep scan or a shallow scan
 //  - format (string): The format to output (text, json, json-pretty)
+//  - ignore ([]string): packages to ignore, i.e. they may miss without triggering an error
 func List(basedir string, deep bool, format string, ignore []string) {
 	basedir, err := filepath.Abs(basedir)
 	if err != nil {

--- a/action/list_test.go
+++ b/action/list_test.go
@@ -47,4 +47,17 @@ func TestList(t *testing.T) {
 	if len(o2.Installed) == 0 {
 		t.Error("No packages found on json-pretty list")
 	}
+
+	var buf4 bytes.Buffer
+	msg.Default.Stdout = &buf4
+	List("../", false, "json", []string{"nonexisting/package"})
+	j = buf3.Bytes()
+	var o3 PackageList
+	err = json.Unmarshal(j, &o3)
+	if err != nil {
+		t.Errorf("Error unmarshaling json list w/ ignore: %s", err)
+	}
+	if len(o3.Installed) == 0 {
+		t.Error("No packages found on json list w/ ignore")
+	}
 }

--- a/action/list_test.go
+++ b/action/list_test.go
@@ -17,14 +17,14 @@ func TestList(t *testing.T) {
 
 	var buf bytes.Buffer
 	msg.Default.Stdout = &buf
-	List("../", false, "text")
+	List("../", false, "text", []string{})
 	if buf.Len() < 5 {
 		t.Error("Expected some data to be found.")
 	}
 
 	var buf2 bytes.Buffer
 	msg.Default.Stdout = &buf2
-	List("../", false, "json")
+	List("../", false, "json", []string{})
 	j := buf2.Bytes()
 	var o PackageList
 	err := json.Unmarshal(j, &o)
@@ -37,7 +37,7 @@ func TestList(t *testing.T) {
 
 	var buf3 bytes.Buffer
 	msg.Default.Stdout = &buf3
-	List("../", false, "json-pretty")
+	List("../", false, "json-pretty", []string{})
 	j = buf3.Bytes()
 	var o2 PackageList
 	err = json.Unmarshal(j, &o2)

--- a/glide.go
+++ b/glide.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/glide/action"
 	"github.com/Masterminds/glide/cache"
@@ -664,7 +665,7 @@ Example:
    Directories that begin with . or _ are ignored, as are testdata directories. Packages in
    vendor are only included if they are used by the project.`,
 			Action: func(c *cli.Context) error {
-				action.List(".", true, c.String("output"))
+				action.List(".", true, c.String("output"), strings.Split(c.String("ignore"), ","))
 				return nil
 			},
 			Flags: []cli.Flag{
@@ -672,6 +673,11 @@ Example:
 					Name:  "output, o",
 					Usage: "Output format. One of: json|json-pretty|text",
 					Value: "text",
+				},
+				cli.StringFlag{
+					Name:  "ignore,i",
+					Usage: "Ignore given packages as dependency (comma separated list)",
+					Value: "",
 				},
 			},
 		},


### PR DESCRIPTION
We need a package to be in GOPATH to build loadable modules outside the main repo.

A default `glide list` fails because this dependency is not in the `vendor/` tree.