### PR TITLE
Add recursive submodule setting for Git repositories

### DIFF
--- a/cfg/lock.go
+++ b/cfg/lock.go
@@ -162,6 +162,7 @@ type Lock struct {
 	Subpackages []string `yaml:"subpackages,omitempty"`
 	Arch        []string `yaml:"arch,omitempty"`
 	Os          []string `yaml:"os,omitempty"`
+	Recursive   bool     `yaml:"recursive:omitempty"`
 }
 
 // Clone creates a clone of a Lock.
@@ -174,6 +175,7 @@ func (l *Lock) Clone() *Lock {
 		Subpackages: l.Subpackages,
 		Arch:        l.Arch,
 		Os:          l.Os,
+		Recursive:   l.Recursive,
 	}
 }
 
@@ -187,6 +189,7 @@ func LockFromDependency(dep *Dependency) *Lock {
 		Subpackages: dep.Subpackages,
 		Arch:        dep.Arch,
 		Os:          dep.Os,
+		Recursive:   dep.Recursive,
 	}
 }
 


### PR DESCRIPTION
This PR requires a change to the `vcs` project PR I have submitted here:
https://github.com/Masterminds/vcs/pull/82/files

This is to include a new option for dependencies called `recursive` which is a boolean setting that determines if using the `--recursive` flag when working with git submodules is used or not.  Here is an example configuration file.

```yaml
package: github.com/my/package
import:
- package: gopkg.in/libgit2/git2go.v26
  recursive: false
```

I have run into a problem specifically with the `git2go` project where one of the tests has a purposefully broken `.gitmodules` file.  When the `--recursive` option is passed as the `vcs` project always does the checkout will fail and there is no way to recover.  Adding the `recursive` option allows telling Git not to deal with recursive submodules.  This is probably helpful in other scenarios as well where you are not interested in cloning recursive submodules.
