### PR TITLE
Version info in lock file and export log

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -369,14 +369,29 @@ func (d Dependencies) DeDupe() (Dependencies, error) {
 
 // Dependency describes a package that the present package depends upon.
 type Dependency struct {
-	Name        string   `yaml:"package"`
-	Reference   string   `yaml:"version,omitempty"`
-	Pin         string   `yaml:"-"`
-	Repository  string   `yaml:"repo,omitempty"`
-	VcsType     string   `yaml:"vcs,omitempty"`
-	Subpackages []string `yaml:"subpackages,omitempty"`
-	Arch        []string `yaml:"arch,omitempty"`
-	Os          []string `yaml:"os,omitempty"`
+	Name        string          `yaml:"package"`
+	Reference   string          `yaml:"version,omitempty"`
+	Pin         string          `yaml:"-"`
+	Original    string          `yaml:"-"`
+	CommitInfo  *vcs.CommitInfo `yaml:"-"`
+	Repository  string          `yaml:"repo,omitempty"`
+	VcsType     string          `yaml:"vcs,omitempty"`
+	Subpackages []string        `yaml:"subpackages,omitempty"`
+	Arch        []string        `yaml:"arch,omitempty"`
+	Os          []string        `yaml:"os,omitempty"`
+}
+
+func (dep *Dependency) RefString() string {
+	refString := dep.Reference
+	if refString == dep.Pin {
+		refString = refString[0:7]
+	}
+	if refString != "" && refString != dep.Original {
+		refString = " (" + refString + ")"
+	} else {
+		refString = ""
+	}
+	return refString
 }
 
 // A transitive representation of a dependency for importing and exploting to yaml.
@@ -532,6 +547,8 @@ func (d *Dependency) Clone() *Dependency {
 	return &Dependency{
 		Name:        d.Name,
 		Reference:   d.Reference,
+		Original:    d.Original,
+		CommitInfo:  d.CommitInfo,
 		Pin:         d.Pin,
 		Repository:  d.Repository,
 		VcsType:     d.VcsType,

--- a/repo/installer.go
+++ b/repo/installer.go
@@ -284,7 +284,15 @@ func (i *Installer) Export(conf *cfg.Config) error {
 					if err != nil {
 						msg.Die(err.Error())
 					}
-					msg.Info("--> Exporting %s", dep.Name)
+
+					commitInfo := " "
+					if dep.CommitInfo != nil {
+						commitInfo = " " +
+							util.Date(dep.CommitInfo.Date) + " " +
+							dep.CommitInfo.Author
+					}
+
+					msg.Info("--> Exporting %s %s@%s%s%s", dep.Name, dep.Original, dep.Pin[0:7], dep.RefString(), commitInfo)
 					if err := repo.ExportDir(filepath.Join(vp, filepath.ToSlash(dep.Name))); err != nil {
 						msg.Err("Export failed for %s: %s\n", dep.Name, err)
 						// Capture the error while making sure the concurrent

--- a/repo/vcs.go
+++ b/repo/vcs.go
@@ -164,6 +164,7 @@ func VcsVersion(dep *cfg.Dependency) error {
 
 	// If there is no reference configured there is nothing to set.
 	if dep.Reference == "" {
+		dep.Original = "master"
 		// Before exiting update the pinned version
 		repo, err := dep.GetRepo(cwd)
 		if err != nil {
@@ -173,6 +174,11 @@ func VcsVersion(dep *cfg.Dependency) error {
 		if err != nil {
 			return err
 		}
+		dep.CommitInfo, err = repo.CommitInfo(dep.Pin)
+		if err != nil {
+			dep.CommitInfo = nil
+		}
+
 		return nil
 	}
 
@@ -240,9 +246,17 @@ func VcsVersion(dep *cfg.Dependency) error {
 	if err := repo.UpdateVersion(ver); err != nil {
 		return err
 	}
+	dep.Original = ver
 	dep.Pin, err = repo.Version()
+	if dep.Pin == dep.Original {
+		dep.Original = dep.Original[0:7]
+	}
 	if err != nil {
 		return err
+	}
+	dep.CommitInfo, err = repo.CommitInfo(dep.Pin)
+	if err != nil {
+		dep.CommitInfo = nil
 	}
 
 	return nil

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/vcs"
 )
@@ -334,4 +335,9 @@ func NormalizeName(name string) (string, string) {
 	}
 
 	return root, extra
+}
+
+// Date formats short date string in UTC
+func Date(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
 }


### PR DESCRIPTION
This pull request aims to improve deps info redability in export log by adding commit info (including tag name if available)
```
[INFO]  Exporting resolved dependencies...
[INFO]  --> Exporting github.com/Masterminds/vcs v1.12.0@6f1c6d1 (^1.12.0) 2017-09-11 Matt Farina <matt@mattfarina.com>
[INFO]  --> Exporting github.com/codegangsta/cli v1.20.0@cfb3883 (^1.16.0) 2017-08-11 Jesse Szwedko <jesse.szwedko@gmail.com>
[INFO]  --> Exporting github.com/Masterminds/semver v1.3.1@517734c (^1.3.0) 2017-07-10 Matt Farina <matt@mattfarina.com>
```
Also in `glide.lock` file by adding brief commit info as yaml comment
```
hash: 9678e016890de949db9cfcae386b5ae1a4c2149ccd602aad33ac90d7c19d117e
updated: 2017-09-22T16:50:29.351652493+07:00
imports:
- name: github.com/codegangsta/cli
  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1 # v1.20.0, 2017-08-11
- name: github.com/Masterminds/semver
  version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd # v1.3.1, 2017-07-10
- name: github.com/Masterminds/vcs
  version: 6f1c6d150500e452704e9863f68c2559f58616bf # v1.12.0, 2017-09-11
- name: github.com/mitchellh/go-homedir
```