### PR TITLE
fix issue :https://github.com/Masterminds/glide/issues/960.

### DIFF
--- a/path/winbug.go
+++ b/path/winbug.go
@@ -72,10 +72,19 @@ func CustomRename(o, n string) error {
 	// Handking windows cases first
 	if runtime.GOOS == "windows" {
 		msg.Debug("Detected Windows. Moving files using windows command")
-		cmd := exec.Command("cmd.exe", "/c", "move", o, n)
+
+		// fix issue: https://github.com/Masterminds/glide/issues/960.
+		// using XCOPY and RMDIR two commands to replace MOVE
+		cmd := exec.Command("cmd.exe", "/Y /T /E /I", "XCOPY", o, n)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Error moving files: %s. output: %s", err, output)
+			return fmt.Errorf("Error copying files: %s. output: %s", err, output)
+		}
+
+		cmd = exec.Command("cmd.exe", "/S /Q","RMDIR", o)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Error removing files: %s. output: %s", err, output)
 		}
 
 		return nil


### PR DESCRIPTION
using XCOPY and RMDIR   to replace MOVE on windows , to solve the install problem on Windows 10 amd64.

```
> glide install
Unable to export dependencies to vendor directory 3: Error moving files: exit status 1
```