### PR TITLE
Fix NPE: Check errors for WalkFunc

### DIFF
--- a/godep/strip/strip.go
+++ b/godep/strip/strip.go
@@ -54,6 +54,10 @@ func GodepWorkspace(v string) error {
 }
 
 func stripGodepWorkspaceHandler(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
 	// Skip the base vendor directory
 	if path == vPath {
 		return nil
@@ -81,6 +85,10 @@ func stripGodepWorkspaceHandler(path string, info os.FileInfo, err error) error 
 }
 
 func rewriteGodepfilesHandler(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
 	name := info.Name()
 
 	if info.IsDir() {


### PR DESCRIPTION
From https://github.com/golang/go/blob/go1.9/src/path/filepath/path.go#L336

```
// If there was a problem walking to the file or directory named by path, the
// incoming error will describe the problem and the function can decide how
// to handle that error (and Walk will not descend into that directory).
```