### PR TITLE
update to master if we are detached WIP

### DIFF
--- a/vendor/github.com/Masterminds/vcs/git.go
+++ b/vendor/github.com/Masterminds/vcs/git.go
@@ -145,7 +145,10 @@ func (s *GitRepo) Update() error {
 	}
 
 	if detached {
-		return nil
+		err := s.UpdateVersion("master")
+		if err != nil {
+			return NewLocalError("Cannot set detached to master", err, "")
+		}
 	}
 
 	out, err = s.RunFromDir("git", "pull")


### PR DESCRIPTION
I have a problem 

* If the specific commit is checked out in glide, then git is in "detached head" mode, therefore pull is not working.
* Git is in state mode when we check out by tag

And because of all that the command 
```
glide up
```
is not working. We can make it work trying to checkout master