### PR TITLE
check GOROOT before GOPATH during package resoving

### DIFF
--- a/dependency/resolver.go
+++ b/dependency/resolver.go
@@ -1032,23 +1032,23 @@ func (r *Resolver) FindPkg(name string) *PkgInfo {
 	//}
 	//}
 
-	// Check $GOPATH
-	for _, rr := range filepath.SplitList(r.BuildContext.GOPATH) {
-		p = filepath.Join(rr, "src", filepath.FromSlash(name))
-		if pkgExists(p) {
-			info.Path = p
-			info.Loc = LocGopath
-			r.findCache[name] = info
-			return info
-		}
-	}
-
 	// Check $GOROOT
 	for _, rr := range filepath.SplitList(r.BuildContext.GOROOT) {
 		p = filepath.Join(rr, "src", filepath.FromSlash(name))
 		if pkgExists(p) {
 			info.Path = p
 			info.Loc = LocGoroot
+			r.findCache[name] = info
+			return info
+		}
+	}
+
+	// Check $GOPATH
+	for _, rr := range filepath.SplitList(r.BuildContext.GOPATH) {
+		p = filepath.Join(rr, "src", filepath.FromSlash(name))
+		if pkgExists(p) {
+			info.Path = p
+			info.Loc = LocGopath
 			r.findCache[name] = info
 			return info
 		}

--- a/dependency/resolver_test.go
+++ b/dependency/resolver_test.go
@@ -42,6 +42,19 @@ func TestResolveLocalShallow(t *testing.T) {
 }
 
 func TestResolveLocalDeep(t *testing.T) {
+	// create package of same name with sys package
+	err := os.MkdirAll(filepath.Join(os.Getenv("GOPATH"), "src/strings"), os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create package of test case: %s", err)
+	}
+	// remove package of same name with sys package
+	defer func() {
+		err = os.Remove(filepath.Join(os.Getenv("GOPATH"), "src/strings"))
+		if err != nil {
+			t.Fatalf("Failed to remove package of test case: %s", err)
+		}
+	}()
+
 	r, err := NewResolver("../")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
If some package (which has the same name with official package) in GOPATH/src, such like GOPATH/src/fmt or GOPATH/src/strings, glide  package resolving GOPATH before GOROOT will cause unexpected error.
This pr will fix it.