### PR TITLE
fixed the indirect dependencies issue

### DIFF
--- a/repo/installer.go
+++ b/repo/installer.go
@@ -723,6 +723,10 @@ func (d *VersionHandler) Process(pkg string) (e error) {
 	if d.Imported[root] == false {
 		d.Imported[root] = true
 		p := d.pkgPath(root)
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			dep := cfg.Dependency{Name: root}
+			VcsGet(&dep)
+		}
 		f, deps, err := importer.Import(p)
 		if f && err == nil {
 			for _, dep := range deps {


### PR DESCRIPTION
There's an issue that cannot get the specific version when use indirect dependencies.
It can repeat this issue through the following steps.
1) Import a package(considering as A package) but not declare in the current project glide.yaml
2) The glide.yaml(note: this glide.yaml is in the package directory) of the importing package(A) has a specific version of another package(considering as B package)
3) Execute the commands in the root project:
     a.  glide cc
     b.  glide up
4) You will find that the version of package B in the glide.lock is not the specific version in glide.yaml

So I fixed this issue. Please help review.
Thanks!