### PR TITLE
Fix segfault with Glide 0.13.2 when stripping Godep workspace

### DIFF
--- a/godep/strip/strip.go
+++ b/godep/strip/strip.go
@@ -70,7 +70,10 @@ func stripGodepWorkspaceHandler(path string, info os.FileInfo, err error) error 
 				godepMark[pp] = true
 
 				msg.Info("Removing: %s", path)
-				return os.RemoveAll(path)
+				if err := os.RemoveAll(path); err != nil {
+					return err
+				}
+				return filepath.SkipDir
 			}
 
 			msg.Debug("%s is not a directory. Skipping removal", path)


### PR DESCRIPTION
Fixes #975

When deleting 'Godeps/_workspace' folders the `Walk` function may be called for already deleted entries (e.g.  Godeps/_workspace/.gitignore) afterwards.

To reproduce the segfault try this glide.yaml:
```
package: github.com/databus23/glide-sigfault
import:
  - package: github.com/yudai/golcs
    version: 3aebbac3964febd3fa3189f5d9db214cc6e940a6
```

```
$> glide install -v
[INFO]	Lock file (glide.lock) does not exist. Performing update.
[INFO]	Downloading dependencies. Please wait...
[INFO]	--> Fetching updates for github.com/yudai/golcs
[INFO]	--> Setting version for github.com/yudai/golcs to 3aebbac3964febd3fa3189f5d9db214cc6e940a6.
[INFO]	Resolving imports
[INFO]	Downloading dependencies. Please wait...
[INFO]	Setting references for remaining imports
[INFO]	Exporting resolved dependencies...
[INFO]	--> Exporting github.com/yudai/golcs
[INFO]	Replacing existing vendor dependencies
[INFO]	Project relies on 1 dependencies.
[INFO]	Removing nested vendor and Godeps/_workspace directories...
[INFO]	Removing: /Users/d062284/Development/go/src/github.com/databus23/glide-sigfault/vendor/github.com/yudai/golcs/Godeps/_workspace
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x131c41f]

goroutine 1 [running]:
github.com/Masterminds/glide/godep/strip.stripGodepWorkspaceHandler(0xc0000f8480, 0x80, 0x0, 0x0, 0x1540480, 0xc0002da9f0, 0x0, 0x0)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/godep/strip/strip.go:62 +0x4f
path/filepath.walk(0xc00037ed80, 0x75, 0x1547760, 0xc000450b60, 0x14e0308, 0x0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:378 +0x21f
path/filepath.walk(0xc000092700, 0x6a, 0x1547760, 0xc0004508f0, 0x14e0308, 0x0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:382 +0x2fe
path/filepath.walk(0xc0000925b0, 0x63, 0x1547760, 0xc000450820, 0x14e0308, 0x0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:382 +0x2fe
path/filepath.walk(0xc00002c600, 0x5d, 0x1547760, 0xc000450750, 0x14e0308, 0x0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:382 +0x2fe
path/filepath.walk(0xc00002c4e0, 0x57, 0x1547760, 0xc000450680, 0x14e0308, 0x0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:382 +0x2fe
path/filepath.walk(0xc000026910, 0x4c, 0x1547760, 0xc0004505b0, 0x14e0308, 0x0, 0x1547760)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:382 +0x2fe
path/filepath.Walk(0xc000026910, 0x4c, 0x14e0308, 0xc0004504e0, 0x0)
	/usr/local/Cellar/go/1.11/libexec/src/path/filepath/path.go:404 +0x105
github.com/Masterminds/glide/godep/strip.GodepWorkspace(0xc000026910, 0x4c, 0xc00000c200, 0x0)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/godep/strip/strip.go:39 +0x117
github.com/Masterminds/glide/path.StripVendor(0x14d5ebf, 0x3b)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/path/strip.go:52 +0x13a
github.com/Masterminds/glide/action.Update(0xc0001e8540, 0x100)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/action/update.go:108 +0x2b4
github.com/Masterminds/glide/action.Install(0xc0001e8540, 0x14c1601)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/action/install.go:26 +0x47c
main.commands.func12(0xc00011b340, 0x0, 0xc00011b340)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/glide.go:510 +0x2b5
github.com/Masterminds/glide/vendor/github.com/codegangsta/cli.HandleAction(0x1438080, 0x14e04d8, 0xc00011b340, 0xc0000bb700, 0x0)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/vendor/github.com/codegangsta/cli/app.go:490 +0xc8
github.com/Masterminds/glide/vendor/github.com/codegangsta/cli.Command.Run(0x14bf922, 0x7, 0x14bdf4b, 0x1, 0x0, 0x0, 0x0, 0x14cb22f, 0x20, 0x0, ...)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/vendor/github.com/codegangsta/cli/command.go:210 +0x990
github.com/Masterminds/glide/vendor/github.com/codegangsta/cli.(*App).Run(0xc0000af040, 0xc0000a4090, 0x3, 0x3, 0x0, 0x0)
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/vendor/github.com/codegangsta/cli/app.go:255 +0x687
main.main()
	/private/tmp/glide-20180926-90535-1ihtivo/glide-0.13.2/src/github.com/Masterminds/glide/glide.go:104 +0x556
```