### PR TITLE
fix: git submodule foreach command accept one argument.

### DIFF
--- a/vendor/github.com/Masterminds/vcs/git.go
+++ b/vendor/github.com/Masterminds/vcs/git.go
@@ -181,7 +181,7 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git clean -x -d -f -f")
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}


### PR DESCRIPTION
`glide` `update` failed on my project after upgrade git to `2.22.0`.


glide debug output:

    error: unknown switch `x'
    usage: git submodule--helper foreach [--quiet] [--recursive] [--] <command>

        -q, --quiet           Suppress output of entering each submodule command
        --recursive           Recurse into nested submodules

    fatal: run_command returned non-zero status while recursing in the nested submodules of proto


`git` `submodule` `foreach` `--recursive` command accept one argument now.

See similar merge request https://github.com/golang/dep/pull/2168/files for more information.